### PR TITLE
fix: return Result from get_escrow_info and Option from get_state to …

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -220,23 +220,21 @@ impl EscrowContract {
     }
 
     /// Get escrow details
-    pub fn get_escrow_info(env: Env) -> (Address, Address, Address, Address, i128, u32, EscrowState) {
-        let buyer: Address = env.storage().instance().get(&DataKey::Buyer).unwrap();
-        let seller: Address = env.storage().instance().get(&DataKey::Seller).unwrap();
-        let arbiter: Address = env.storage().instance().get(&DataKey::Arbiter).unwrap();
-        let token_contract: Address = env.storage().instance().get(&DataKey::TokenContract).unwrap();
-        let amount: i128 = env.storage().instance().get(&DataKey::Amount).unwrap();
-        let deadline: u32 = env.storage().instance().get(&DataKey::Deadline).unwrap();
-        let state: EscrowState = env.storage().instance().get(&DataKey::State).unwrap();
+    pub fn get_escrow_info(env: Env) -> Result<(Address, Address, Address, Address, i128, u32, EscrowState), EscrowError> {
+        let buyer: Address = env.storage().instance().get(&DataKey::Buyer).ok_or(EscrowError::NotInitialized)?;
+        let seller: Address = env.storage().instance().get(&DataKey::Seller).ok_or(EscrowError::NotInitialized)?;
+        let arbiter: Address = env.storage().instance().get(&DataKey::Arbiter).ok_or(EscrowError::NotInitialized)?;
+        let token_contract: Address = env.storage().instance().get(&DataKey::TokenContract).ok_or(EscrowError::NotInitialized)?;
+        let amount: i128 = env.storage().instance().get(&DataKey::Amount).ok_or(EscrowError::NotInitialized)?;
+        let deadline: u32 = env.storage().instance().get(&DataKey::Deadline).ok_or(EscrowError::NotInitialized)?;
+        let state: EscrowState = env.storage().instance().get(&DataKey::State).ok_or(EscrowError::NotInitialized)?;
 
-        (buyer, seller, arbiter, token_contract, amount, deadline, state)
+        Ok((buyer, seller, arbiter, token_contract, amount, deadline, state))
     }
 
     /// Get current state
-    pub fn get_state(env: Env) -> EscrowState {
-        env.storage().instance()
-            .get(&DataKey::State)
-            .unwrap_or(EscrowState::Created)
+    pub fn get_state(env: Env) -> Option<EscrowState> {
+        env.storage().instance().get(&DataKey::State)
     }
 
     /// Check if deadline has passed

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -100,7 +100,7 @@ fn test_mark_delivered() {
     client.mark_delivered();
 
     // Verify state change
-    assert_eq!(client.get_state(), EscrowState::Delivered);
+    assert_eq!(client.get_state(), Some(EscrowState::Delivered));
 }
 
 #[test]
@@ -124,7 +124,7 @@ fn test_approve_delivery() {
     client.approve_delivery();
 
     // Verify completion
-    assert_eq!(client.get_state(), EscrowState::Completed);
+    assert_eq!(client.get_state(), Some(EscrowState::Completed));
 }
 
 #[test]
@@ -176,7 +176,7 @@ fn test_arbiter_resolve_to_seller() {
     client.resolve_dispute(&true);
 
     // Verify completion
-    assert_eq!(client.get_state(), EscrowState::Completed);
+    assert_eq!(client.get_state(), Some(EscrowState::Completed));
 }
 
 #[test]
@@ -201,5 +201,5 @@ fn test_arbiter_resolve_to_buyer() {
     client.resolve_dispute(&false);
 
     // Verify refund
-    assert_eq!(client.get_state(), EscrowState::Refunded);
+    assert_eq!(client.get_state(), Some(EscrowState::Refunded));
 }


### PR DESCRIPTION

Here are PR descriptions for all three issues

PR 3 — fix/token-getter-not-initialized

fix: return Result from admin and metadata getters instead of panicking

admin(), name(), symbol(), and decimals() all called .unwrap() on storage reads. Calling any 
of them before initialization produced an opaque host panic with no actionable error for the 
caller.

Changes
- Changed all four getters to return Result<T, TokenError> using 
.ok_or(TokenError::NotInitialized) instead of .unwrap()

Closes #186 
