### PR TITLE
fix: return Result<T, TokenError::NotInitialized> from admin and meta…

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -160,31 +160,31 @@ impl TokenContract {
     }
 
     /// Get the current admin
-    pub fn admin(env: Env) -> Address {
+    pub fn admin(env: Env) -> Result<Address, TokenError> {
         env.storage().instance()
             .get(&DataKey::Admin)
-            .unwrap()
+            .ok_or(TokenError::NotInitialized)
     }
 
     /// Get token name
-    pub fn name(env: Env) -> String {
+    pub fn name(env: Env) -> Result<String, TokenError> {
         env.storage().instance()
             .get(&DataKey::Metadata(MetadataKey::Name))
-            .unwrap()
+            .ok_or(TokenError::NotInitialized)
     }
 
     /// Get token symbol
-    pub fn symbol(env: Env) -> String {
+    pub fn symbol(env: Env) -> Result<String, TokenError> {
         env.storage().instance()
             .get(&DataKey::Metadata(MetadataKey::Symbol))
-            .unwrap()
+            .ok_or(TokenError::NotInitialized)
     }
 
     /// Get token decimals
-    pub fn decimals(env: Env) -> u32 {
+    pub fn decimals(env: Env) -> Result<u32, TokenError> {
         env.storage().instance()
             .get(&DataKey::Metadata(MetadataKey::Decimals))
-            .unwrap()
+            .ok_or(TokenError::NotInitialized)
     }
 
     /// Get total supply


### PR DESCRIPTION
PR 2 — fix/escrow-deadline-validation

fix: enforce minimum deadline buffer to prevent same-block escrow expiry

deadline_ledger == env.ledger().sequence() was accepted, creating an escrow that expires in 
the same block it is created. The buyer would have no time to fund it before the deadline 
passed.

Changes
- Added MIN_DEADLINE_BUFFER = 100 constant (~8 minutes at 5s/ledger)
- Changed deadline check from <= sequence() to < sequence() + MIN_DEADLINE_BUFFER
- Updated the test panic message to match the new error text

Closes #185

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━