### PR TITLE
Fix/escrow deadline validation

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -8,6 +8,8 @@ use soroban_sdk::{
 const BUMP_THRESHOLD: u32 = 120_960;
 /// TTL extended to on every write (~30 days at 5s/ledger).
 const BUMP_AMOUNT: u32 = 518_400;
+/// Minimum ledgers from now a deadline must be set to (~8 minutes at 5s/ledger).
+const MIN_DEADLINE_BUFFER: u32 = 100;
 
 fn bump_instance(env: &Env) {
     env.storage().instance().extend_ttl(BUMP_THRESHOLD, BUMP_AMOUNT);
@@ -76,9 +78,9 @@ impl EscrowContract {
             return Err(EscrowError::AlreadyInitialized);
         }
 
-        // Verify deadline is in the future
-        if deadline_ledger <= env.ledger().sequence() {
-            panic!("Deadline must be in the future");
+        // Verify deadline is sufficiently in the future
+        if deadline_ledger < env.ledger().sequence() + MIN_DEADLINE_BUFFER {
+            panic!("Deadline must be at least MIN_DEADLINE_BUFFER ledgers in the future");
         }
 
         // Store escrow details

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -3,6 +3,15 @@
 use soroban_sdk::{
     contract, contractimpl, contracttype, token, Address, Env, Symbol,
 };
+
+/// Minimum TTL before a bump is needed (~7 days at 5s/ledger).
+const BUMP_THRESHOLD: u32 = 120_960;
+/// TTL extended to on every write (~30 days at 5s/ledger).
+const BUMP_AMOUNT: u32 = 518_400;
+
+fn bump_instance(env: &Env) {
+    env.storage().instance().extend_ttl(BUMP_THRESHOLD, BUMP_AMOUNT);
+}
  /// script
 /// Escrow contract for secure two-party transactions
 /// 
@@ -82,6 +91,7 @@ impl EscrowContract {
         env.storage().instance().set(&DataKey::State, &EscrowState::Created);
         env.storage().instance().set(&DataKey::BuyerApproved, &false);
         env.storage().instance().set(&DataKey::SellerDelivered, &false);
+        bump_instance(&env);
 
         // Emit event
         env.events().publish(
@@ -114,6 +124,7 @@ impl EscrowContract {
 
         // Update state
         env.storage().instance().set(&DataKey::State, &EscrowState::Funded);
+        bump_instance(&env);
 
         // Emit event
         env.events().publish((Symbol::new(&env, "escrow_funded"), buyer), amount);
@@ -137,6 +148,7 @@ impl EscrowContract {
         // Mark as delivered
         env.storage().instance().set(&DataKey::SellerDelivered, &true);
         env.storage().instance().set(&DataKey::State, &EscrowState::Delivered);
+        bump_instance(&env);
 
         // Emit event
         env.events().publish((Symbol::new(&env, "delivery_marked"), seller), ());
@@ -247,6 +259,14 @@ impl EscrowContract {
         env.ledger().sequence() > deadline
     }
 
+    /// Extend storage TTL for an active escrow. Anyone can call this.
+    pub fn bump(env: Env) {
+        if !env.storage().instance().has(&DataKey::State) {
+            panic!("Not initialized");
+        }
+        bump_instance(&env);
+    }
+
     // Internal helper functions
     fn release_to_seller(env: Env) -> Result<(), EscrowError> {
         let seller: Address = env.storage().instance().get(&DataKey::Seller).unwrap();
@@ -259,6 +279,7 @@ impl EscrowContract {
 
         // Update state
         env.storage().instance().set(&DataKey::State, &EscrowState::Completed);
+        bump_instance(&env);
 
         // Emit event
         env.events().publish((Symbol::new(&env, "funds_released"), seller), amount);
@@ -277,6 +298,7 @@ impl EscrowContract {
 
         // Update state
         env.storage().instance().set(&DataKey::State, &EscrowState::Refunded);
+        bump_instance(&env);
 
         // Emit event
         env.events().publish((Symbol::new(&env, "funds_refunded"), buyer), amount);

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -62,7 +62,7 @@ fn test_initialize_twice() {
 }
 
 #[test]
-#[should_panic(expected = "Deadline must be in the future")]
+#[should_panic(expected = "Deadline must be at least MIN_DEADLINE_BUFFER ledgers in the future")]
 fn test_initialize_past_deadline() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -4,6 +4,17 @@ use soroban_sdk::{
     contract, contractimpl, contracttype, token, Address, Env, String, Symbol,
 };
 
+const BUMP_THRESHOLD: u32 = 120_960;
+const BUMP_AMOUNT: u32 = 518_400;
+
+fn bump_instance(env: &Env) {
+    env.storage().instance().extend_ttl(BUMP_THRESHOLD, BUMP_AMOUNT);
+}
+
+fn bump_persistent(env: &Env, key: &DataKey) {
+    env.storage().persistent().extend_ttl(key, BUMP_THRESHOLD, BUMP_AMOUNT);
+}
+
 /// Token contract implementing the Soroban Token Interface
 /// 
 /// This contract provides a complete implementation of a fungible token with:
@@ -74,6 +85,7 @@ impl TokenContract {
         
         // Initialize total supply to 0
         env.storage().instance().set(&DataKey::TotalSupply, &0i128);
+        bump_instance(&env);
 
         // Emit initialization event
         env.events().publish((Symbol::new(&env, "initialize"), admin.clone()), (name, symbol, decimals));
@@ -97,12 +109,14 @@ impl TokenContract {
         let balance = Self::balance_of(env.clone(), to.clone());
         let new_balance = balance + amount;
         env.storage().persistent().set(&DataKey::Balance(to.clone()), &new_balance);
+        bump_persistent(&env, &DataKey::Balance(to.clone()));
 
         // Update total supply
         let total_supply: i128 = env.storage().instance()
             .get(&DataKey::TotalSupply)
             .unwrap_or(0);
         env.storage().instance().set(&DataKey::TotalSupply, &(total_supply + amount));
+        bump_instance(&env);
 
         // Emit event
         env.events().publish((Symbol::new(&env, "mint"), to), amount);
@@ -130,12 +144,14 @@ impl TokenContract {
         // Update balance
         let new_balance = balance - amount;
         env.storage().persistent().set(&DataKey::Balance(from.clone()), &new_balance);
+        bump_persistent(&env, &DataKey::Balance(from.clone()));
 
         // Update total supply
         let total_supply: i128 = env.storage().instance()
             .get(&DataKey::TotalSupply)
             .unwrap_or(0);
         env.storage().instance().set(&DataKey::TotalSupply, &(total_supply - amount));
+        bump_instance(&env);
 
         // Emit event
         env.events().publish((Symbol::new(&env, "burn"), from), amount);
@@ -152,6 +168,7 @@ impl TokenContract {
         admin.require_auth();
         
         env.storage().instance().set(&DataKey::Admin, &new_admin);
+        bump_instance(&env);
         
         // Emit event
         env.events().publish((Symbol::new(&env, "set_admin"),), new_admin);
@@ -271,9 +288,11 @@ impl TokenContract {
 
         // Update balances
         env.storage().persistent().set(&DataKey::Balance(from.clone()), &(from_balance - amount));
+        bump_persistent(&env, &DataKey::Balance(from.clone()));
         
         let to_balance = Self::balance_of(env.clone(), to.clone());
         env.storage().persistent().set(&DataKey::Balance(to.clone()), &(to_balance + amount));
+        bump_persistent(&env, &DataKey::Balance(to.clone()));
 
         // Emit event
         env.events().publish((Symbol::new(&env, "transfer"), from, to), amount);


### PR DESCRIPTION
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


PR 1 — fix/storage-ttl-extension

fix: extend storage TTL after every write to prevent mid-lifecycle expiry

Neither contract called extend_ttl after writing to storage. On Soroban, all storage entries 
have a finite TTL. A long-lived escrow could have its instance storage expire before the 
deadline, making funds permanently inaccessible with no recovery path.

Changes
- Added BUMP_THRESHOLD (120,960 ledgers ≈ 7 days) and BUMP_AMOUNT (518,400 ledgers ≈ 30 days) 
constants to both contracts
- Called extend_ttl on instance() storage after every state-mutating write in both contracts
- Called extend_ttl on persistent() storage after every Balance key write in the token 
contract
- Added a public bump(env) function to the escrow contract so any party or keeper can extend 
TTL during idle periods without triggering a state transition

Closes #185

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
