### PR TITLE
fix(escrow): validate distinct buyer, seller, arbiter addresses (#188)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -49,6 +49,7 @@ pub enum EscrowError {
     AlreadyInitialized = 5,
     NotInitialized = 6,
     InsufficientFunds = 7,
+    InvalidParties = 8,
 }
 
 #[contractimpl]
@@ -65,6 +66,10 @@ impl EscrowContract {
     ) -> Result<(), EscrowError> {
         if env.storage().instance().has(&DataKey::State) {
             return Err(EscrowError::AlreadyInitialized);
+        }
+
+        if buyer == seller || buyer == arbiter || seller == arbiter {
+            return Err(EscrowError::InvalidParties);
         }
 
         // Verify deadline is in the future


### PR DESCRIPTION
Problem                                                                                  
                                                                                           
  initialize() accepted any combination of addresses, including buyer == arbiter or seller 
  == arbiter. This gives one party unilateral dispute resolution power, breaking the       
  security model of the escrow.                                                            
                                                                                           
  Changes                                                                                  
                                                                                           
  - Add InvalidParties = 8 to EscrowError                                                  
  - Assert buyer != seller, buyer != arbiter, seller != arbiter at the start of            
  initialize(), returning EscrowError::InvalidParties on failure                           
                                                                                           
  Before / After                                                                           
                                                                                           
  // before — no address uniqueness check                                                  
  if env.storage().instance().has(&DataKey::State) {                                       
      return Err(EscrowError::AlreadyInitialized);                                         
  }                                                                                        
                                                                                           
  // after                                                                                 
  if env.storage().instance().has(&DataKey::State) {                                       
      return Err(EscrowError::AlreadyInitialized);                                         
  }                                                                                        
  if buyer == seller || buyer == arbiter || seller == arbiter {                            
      return Err(EscrowError::InvalidParties);                                             
  }                                                                                        
                                                                                           
  Testing                                                                                  
                                                                                           
  Existing tests pass. The fix is a pure guard — no behaviour change for valid inputs.     
                                                                                           
  Closes #188              