### PR TITLE
fix(token): replace panic! with panic_with_error! in transfer_from (#…

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, token, Address, Env, String, Symbol,
+    contract, contractimpl, contracttype, contracterror, panic_with_error, token, Address, Env, String, Symbol,
 };
 
 /// Token contract implementing the Soroban Token Interface
@@ -39,7 +39,8 @@ pub enum MetadataKey {
 }
 
 /// Custom errors for the token contract
-#[contracttype]
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum TokenError {
     InsufficientBalance = 1,
     InsufficientAllowance = 2,
@@ -237,7 +238,7 @@ impl token::Interface for TokenContract {
         // Check allowance
         let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
         if allowance < amount {
-            panic!("Insufficient allowance");
+            panic_with_error!(&env, TokenError::InsufficientAllowance);
         }
 
         // Update allowance


### PR DESCRIPTION
Problem                                                                                  
                                                                                           
  transfer_from() used panic!("Insufficient allowance") when the allowance check failed,   
  discarding the existing TokenError::InsufficientAllowance variant. Callers receive an    
  opaque panic with no typed error context.                                                
                                                                                           
  Changes                                                                                  
                                                                                           
  - Replace panic!("Insufficient allowance") with panic_with_error!(&env,                  
  TokenError::InsufficientAllowance)                                                       
  - Change TokenError from #[contracttype] to #[contracterror] so it satisfies             
  Into<soroban_sdk::Error> as required by panic_with_error!                                
  - Add Copy, Clone, Debug, PartialEq derives to TokenError                                
  - Add contracterror and panic_with_error to the soroban_sdk import                       
                                                                                           
  Before / After                                                                           
                                                                                           
  // before                                                                                
  if allowance < amount {                                                                  
      panic!("Insufficient allowance");                                                    
  }                                                                                        
                                                                                           
  // after                                                                                 
  if allowance < amount {                                                                  
      panic_with_error!(&env, TokenError::InsufficientAllowance);                          
  }                                                                                        
                                                                                           
  Testing                                                                                  
                                                                                           
  Existing tests pass. No behaviour change for the success path.                           
                                                                                           
  Closes #190      