### PR TITLE
fix(escrow): return InvalidAmount error when amount <= 0 (#189)

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -49,6 +49,7 @@ pub enum EscrowError {
     AlreadyInitialized = 5,
     NotInitialized = 6,
     InsufficientFunds = 7,
+    InvalidAmount = 8,
 }
 
 #[contractimpl]
@@ -65,6 +66,10 @@ impl EscrowContract {
     ) -> Result<(), EscrowError> {
         if env.storage().instance().has(&DataKey::State) {
             return Err(EscrowError::AlreadyInitialized);
+        }
+
+        if amount <= 0 {
+            return Err(EscrowError::InvalidAmount);
         }
 
         // Verify deadline is in the future


### PR DESCRIPTION
Problem                                                                                  
                                                                                           
  initialize() accepted amount <= 0, allowing zero or negative escrows to be created. This 
  wastes storage and causes confusing downstream failures when the escrow is funded or     
  claimed.                                                                                 
                                                                                           
  Changes                                                                                  
                                                                                           
  - Add InvalidAmount = 8 to EscrowError                                                   
  - Return EscrowError::InvalidAmount early in initialize() if amount <= 0                 
                                                                                           
  Before / After                                                                           
                                                                                           
  // before — no amount validation                                                         
  if env.storage().instance().has(&DataKey::State) {                                       
      return Err(EscrowError::AlreadyInitialized);                                         
  }                                                                                        
                                                                                           
  // after                                                                                 
  if env.storage().instance().has(&DataKey::State) {                                       
      return Err(EscrowError::AlreadyInitialized);                                         
  }                                                                                        
  if amount <= 0 {                                                                         
      return Err(EscrowError::InvalidAmount);                                              
  }                                                                                        
                                                                                           
  Testing                                                                                  
                                                                                           
  Existing tests pass. No behaviour change for valid inputs.                               
                                                                                           
  Closes #189                                                                              
                                       