### PR TITLE
fix: use relative TTL duration in extend_ttl (#214 #35)

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -213,7 +213,8 @@ impl token::Interface for TokenContract {
 
         env.storage().temporary().set(&key, &amount);
         if expiration_ledger > env.ledger().sequence() {
-            env.storage().temporary().extend_ttl(&key, expiration_ledger, expiration_ledger);
+            let ttl = expiration_ledger.saturating_sub(env.ledger().sequence());
+            env.storage().temporary().extend_ttl(&key, ttl, ttl);
         }
 
         env.events().publish(


### PR DESCRIPTION
extend_ttl(threshold, extend_to) expects durations in ledgers, not absolute ledger       
  numbers. The original code passed expiration_ledger directly as both arguments — at      
  ledger sequence 100 with an expiration of 150, this set the TTL to 150 ledgers instead of
  the intended 50, keeping allowances alive ~3× longer than approved.                      
                                                                                           
  Change (contracts/token/src/lib.rs)                                                      
                                                                                           
  // Before                                                                                
  env.storage().temporary().extend_ttl(&key, expiration_ledger, expiration_ledger);        
                                                                                           
  // After                                                                                 
  let ttl = expiration_ledger.saturating_sub(env.ledger().sequence());                     
  env.storage().temporary().extend_ttl(&key, ttl, ttl);                                    
                                                                                           
  saturating_sub is used defensively — the call is already guarded by if expiration_ledger 
  > env.ledger().sequence(), so underflow cannot occur in practice, but it prevents any    
  panic if the guard is ever relaxed. 
  
  closes  #214 