### PR TITLE
fix: reject approve with past expiration_ledger (#213 #34)

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -206,6 +206,10 @@ impl token::Interface for TokenContract {
     fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
         from.require_auth();
 
+        if expiration_ledger <= env.ledger().sequence() {
+            panic!("expiration_ledger must be in the future");
+        }
+
         let key = DataKey::Allowance(AllowanceDataKey {
             from: from.clone(),
             spender: spender.clone(),


### PR DESCRIPTION
The expiration_ledger guard in approve() only controlled whether extend_ttl was called — 
  it did not prevent the approval from being stored. Passing a past or current ledger      
  number would silently write the allowance to storage with only the default minimum TTL,  
  giving the spender a live allowance with no meaningful expiry.                           
                                                                                           
  Change (contracts/token/src/lib.rs)                                                      
                                                                                           
  fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger:   
  u32) {                                                                                   
      from.require_auth();                                                                 
                                                                                           
  +   if expiration_ledger <= env.ledger().sequence() {                                    
  +       panic!("expiration_ledger must be in the future");                               
  +   }                                                                                    
      // ...                                                                               
  }                                                                                        
                                                                                           
  The call now fails fast before touching storage, consistent with how the escrow contract 
  validates its deadline.               
  
closes #213 