### PR TITLE
fix: remove unused BuyerApproved and SellerDelivered storage keys (#2…

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -24,8 +24,6 @@ pub enum DataKey {
     Amount,
     Deadline,
     State,
-    BuyerApproved,
-    SellerDelivered,
 }
 
 #[contracttype]
@@ -80,8 +78,6 @@ impl EscrowContract {
         env.storage().instance().set(&DataKey::Amount, &amount);
         env.storage().instance().set(&DataKey::Deadline, &deadline_ledger);
         env.storage().instance().set(&DataKey::State, &EscrowState::Created);
-        env.storage().instance().set(&DataKey::BuyerApproved, &false);
-        env.storage().instance().set(&DataKey::SellerDelivered, &false);
 
         // Emit event
         env.events().publish(
@@ -135,7 +131,6 @@ impl EscrowContract {
         seller.require_auth();
 
         // Mark as delivered
-        env.storage().instance().set(&DataKey::SellerDelivered, &true);
         env.storage().instance().set(&DataKey::State, &EscrowState::Delivered);
 
         // Emit event


### PR DESCRIPTION
DataKey::BuyerApproved and DataKey::SellerDelivered were written to instance storage but 
  never read. Delivery and approval state is already fully encoded in EscrowState —        
  Delivered implies the seller marked delivery, Completed implies the buyer approved. The  
  redundant keys waste storage and create a misleading contract surface.                   
                                                                                           
  Changes (contracts/escrow/src/lib.rs)                                                    
                                                                                           
  - Remove BuyerApproved and SellerDelivered from DataKey                                  
  - Remove set(&DataKey::BuyerApproved, &false) and set(&DataKey::SellerDelivered, &false) 
   from initialize()                                                                       
  - Remove set(&DataKey::SellerDelivered, &true) from mark_delivered()                     
                                                                                           
  No behaviour changes — state transitions are unchanged.                                  
  
  closes #212 