### PR TITLE
fix: apply checks-effects-interactions in escrow to prevent reentranc…

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -253,12 +253,12 @@ impl EscrowContract {
         let token_contract: Address = env.storage().instance().get(&DataKey::TokenContract).unwrap();
         let amount: i128 = env.storage().instance().get(&DataKey::Amount).unwrap();
 
+        // Update state before transfer (checks-effects-interactions)
+        env.storage().instance().set(&DataKey::State, &EscrowState::Completed);
+
         // Transfer tokens to seller
         let token_client = token::Client::new(&env, &token_contract);
         token_client.transfer(&env.current_contract_address(), &seller, &amount);
-
-        // Update state
-        env.storage().instance().set(&DataKey::State, &EscrowState::Completed);
 
         // Emit event
         env.events().publish((Symbol::new(&env, "funds_released"), seller), amount);
@@ -271,12 +271,12 @@ impl EscrowContract {
         let token_contract: Address = env.storage().instance().get(&DataKey::TokenContract).unwrap();
         let amount: i128 = env.storage().instance().get(&DataKey::Amount).unwrap();
 
+        // Update state before transfer (checks-effects-interactions)
+        env.storage().instance().set(&DataKey::State, &EscrowState::Refunded);
+
         // Transfer tokens back to buyer
         let token_client = token::Client::new(&env, &token_contract);
         token_client.transfer(&env.current_contract_address(), &buyer, &amount);
-
-        // Update state
-        env.storage().instance().set(&DataKey::State, &EscrowState::Refunded);
 
         // Emit event
         env.events().publish((Symbol::new(&env, "funds_refunded"), buyer), amount);


### PR DESCRIPTION
 Summary                                                                                  
                                                                                           
  release_to_seller and refund_to_buyer were calling token_client.transfer() before        
  updating DataKey::State. A malicious token contract could re-enter the escrow while state
  was still Funded/Delivered, triggering a double-spend.                                   
                                                                                           
  Changes                                                                                  
                                                                                           
  Applied the checks-effects-interactions pattern in both internal helpers:                
                                                                                           
  - release_to_seller — state set to Completed before transfer()                           
  - refund_to_buyer — state set to Refunded before transfer()                              
                                                                                           
  Before:                                                                                  
                                                                                           
  token_client.transfer(...); // external call                                             
  env.storage().instance().set(&DataKey::State, &EscrowState::Completed); // state update  
  after                                                                                    
                                                                                           
  After:                                                                                   
                                                                                           
  env.storage().instance().set(&DataKey::State, &EscrowState::Completed); // state update  
  first                                                                                    
  token_client.transfer(...); // external call                                             
                                                                                           
  Any re-entrant call now hits the InvalidState guard and reverts, since the state is      
  already terminal before the external call is made.                                       
                                                                                           
  References                                                                               
                                                                                           
  Closes #181    