### PR TITLE
fix: enforce allowance expiration in transfer_from (#182)

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -32,6 +32,13 @@ pub struct AllowanceDataKey {
 
 #[contracttype]
 #[derive(Clone)]
+pub struct AllowanceValue {
+    pub amount: i128,
+    pub expiration_ledger: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
 pub enum MetadataKey {
     Name,
     Symbol,
@@ -200,7 +207,14 @@ impl TokenContract {
 impl token::Interface for TokenContract {
     fn allowance(env: Env, from: Address, spender: Address) -> i128 {
         let key = DataKey::Allowance(AllowanceDataKey { from, spender });
-        env.storage().temporary().get(&key).unwrap_or(0)
+        let val: AllowanceValue = match env.storage().temporary().get(&key) {
+            Some(v) => v,
+            None => return 0,
+        };
+        if env.ledger().sequence() > val.expiration_ledger {
+            return 0;
+        }
+        val.amount
     }
 
     fn approve(env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32) {
@@ -211,7 +225,7 @@ impl token::Interface for TokenContract {
             spender: spender.clone(),
         });
 
-        env.storage().temporary().set(&key, &amount);
+        env.storage().temporary().set(&key, &AllowanceValue { amount, expiration_ledger });
         if expiration_ledger > env.ledger().sequence() {
             env.storage().temporary().extend_ttl(&key, expiration_ledger, expiration_ledger);
         }
@@ -234,18 +248,27 @@ impl token::Interface for TokenContract {
     fn transfer_from(env: Env, spender: Address, from: Address, to: Address, amount: i128) {
         spender.require_auth();
 
-        // Check allowance
-        let allowance = Self::allowance(env.clone(), from.clone(), spender.clone());
-        if allowance < amount {
-            panic!("Insufficient allowance");
-        }
-
-        // Update allowance
         let key = DataKey::Allowance(AllowanceDataKey {
             from: from.clone(),
             spender: spender.clone(),
         });
-        env.storage().temporary().set(&key, &(allowance - amount));
+
+        let val: AllowanceValue = env.storage().temporary()
+            .get(&key)
+            .unwrap_or(AllowanceValue { amount: 0, expiration_ledger: 0 });
+
+        if env.ledger().sequence() > val.expiration_ledger {
+            panic!("Allowance expired");
+        }
+        if val.amount < amount {
+            panic!("Insufficient allowance");
+        }
+
+        // Update allowance
+        env.storage().temporary().set(&key, &AllowanceValue {
+            amount: val.amount - amount,
+            expiration_ledger: val.expiration_ledger,
+        });
 
         // Perform transfer
         Self::transfer_impl(env, from, to, amount).unwrap();


### PR DESCRIPTION
Summary                                                                                  
                                                                                           
  approve stored expiration_ledger only as a TTL hint — it was never validated at spend    
  time. transfer_from checked only the stored amount, so an expired allowance could still  
  be used indefinitely.                                                                    
                                                                                           
  Changes                                                                                  
                                                                                           
  Added `AllowanceValue` struct to co-locate amount and expiration:                        
                                                                                           
  pub struct AllowanceValue {                                                              
      pub amount: i128,                                                                    
      pub expiration_ledger: u32,                                                          
  }                                                                                        
                                                                                           
  `approve` — stores AllowanceValue instead of a bare i128.                                
                                                                                           
  `allowance` — returns 0 if ledger.sequence() > expiration_ledger.                        
                                                                                           
  `transfer_from` — explicitly checks expiration before amount; panics with "Allowance     
  expired" if the ledger has passed.                                                       
                                                                                           
  Before / After                                                                           
                                                                                           
  // Before — expiration never checked                                                     
  let allowance = Self::allowance(...); // returned stored i128 regardless of expiry       
  if allowance < amount { panic!("Insufficient allowance"); }                              
                                                                                           
  // After — expiration checked first                                                      
  if env.ledger().sequence() > val.expiration_ledger { panic!("Allowance expired"); }      
  if val.amount < amount { panic!("Insufficient allowance"); }                             
                                                                                           
  References                                                                               
                                                                                           
  Closes #182                                                                              
                             