### PR TITLE
fix: replace panic! with TokenError::InvalidAmount for negative amoun…

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -46,6 +46,7 @@ pub enum TokenError {
     Unauthorized = 3,
     AlreadyInitialized = 4,
     NotInitialized = 5,
+    InvalidAmount = 6,
 }
 
 #[contractimpl]
@@ -90,7 +91,7 @@ impl TokenContract {
         admin.require_auth();
 
         if amount < 0 {
-            panic!("Amount must be non-negative");
+            return Err(TokenError::InvalidAmount);
         }
 
         // Update recipient balance
@@ -119,7 +120,7 @@ impl TokenContract {
         admin.require_auth();
 
         if amount < 0 {
-            panic!("Amount must be non-negative");
+            return Err(TokenError::InvalidAmount);
         }
 
         let balance = Self::balance_of(env.clone(), from.clone());
@@ -261,7 +262,7 @@ impl TokenContract {
 
     fn transfer_impl(env: Env, from: Address, to: Address, amount: i128) -> Result<(), TokenError> {
         if amount < 0 {
-            panic!("Amount must be non-negative");
+            return Err(TokenError::InvalidAmount);
         }
 
         let from_balance = Self::balance_of(env.clone(), from.clone());


### PR DESCRIPTION
Summary                                                                                  
                                                                                           
  Three locations in the token contract called panic!("Amount must be non-negative")       
  instead of returning a typed error. This made failures opaque — callers received an      
  unstructured abort with no way to programmatically distinguish the error, and            
  indexers/clients had no typed signal to act on.                                          
                                                                                           
  Changes                                                                                  
                                                                                           
  Added InvalidAmount = 6 to TokenError and replaced all three panics with return          
  Err(TokenError::InvalidAmount):                                                          
                                                                                           
  ┌──────────┬──────────┐                                                                  
  │ Location │ Function │                                                                  
  ├─────────────┼──────────┤                                                               
  │ `lib.rs:93`  │ `mint`   │                                                              
  │ `lib.rs:122` │ `burn`          │                                                       
  │ `lib.rs:264` │ `transfer_impl` │                                                       
  └──────────────┴─────────────────┘                                                       
                                                                                           
  Before / After                                                                           
                                                                                           
  // Before                                                                                
  if amount < 0 {                                                                          
      panic!("Amount must be non-negative");                                               
  }                                                                                        
                                                                                           
  // After                                                                                 
  if amount < 0 {                                                                          
      return Err(TokenError::InvalidAmount);                                               
  }                                                                                        
                                                                                           
  References                                                                               
                                                                                           
  Closes #183                