### PR TITLE
docs: add Architecture Decision Records (ADRs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +91,27 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -180,7 +207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -387,7 +414,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -412,7 +439,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -423,6 +450,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "escape-bytes"
@@ -437,12 +474,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -463,6 +506,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -489,6 +538,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,7 +575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -513,9 +587,24 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -564,6 +653,12 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -647,6 +742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +758,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -811,6 +918,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,14 +952,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -837,7 +991,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -846,7 +1010,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -868,6 +1050,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
@@ -895,10 +1083,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "schemars"
@@ -1051,7 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1095,7 +1308,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1120,7 +1333,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1128,8 +1341,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1138,7 +1351,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1160,6 +1373,7 @@ dependencies = [
 name = "soroban-escrow-template"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-common",
  "soroban-sdk",
 ]
@@ -1189,7 +1403,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1229,7 +1443,7 @@ dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.116.1",
 ]
 
 [[package]]
@@ -1252,6 +1466,7 @@ dependencies = [
 name = "soroban-token-template"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-common",
  "soroban-sdk",
 ]
@@ -1342,6 +1557,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,10 +1627,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -1411,10 +1651,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1462,6 +1729,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
 name = "wasmi_arena"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1774,18 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
 ]
@@ -1555,6 +1856,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -15,6 +15,7 @@ soroban-common = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = "1"
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -5,6 +5,8 @@ mod errors;
 mod events;
 mod storage;
 mod test;
+#[cfg(test)]
+mod prop_test;
 
 pub use errors::EscrowError;
 pub use storage::{DataKey, EscrowInfo, EscrowState};

--- a/contracts/escrow/src/prop_test.rs
+++ b/contracts/escrow/src/prop_test.rs
@@ -1,0 +1,132 @@
+#![cfg(test)]
+
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::StellarAssetClient,
+    Address, Env,
+};
+
+use crate::{EscrowContract, EscrowContractClient, EscrowState};
+
+const MIN_DEADLINE_BUFFER: u32 = 100;
+
+fn setup_escrow<'a>(
+    env: &'a Env,
+    amount: i128,
+) -> (EscrowContractClient<'a>, Address, Address, Address, Address) {
+    let buyer = Address::generate(env);
+    let seller = Address::generate(env);
+    let arbiter = Address::generate(env);
+
+    let admin = Address::generate(env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token_addr = sac.address();
+    StellarAssetClient::new(env, &token_addr).mint(&buyer, &amount);
+
+    let escrow_addr = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(env, &escrow_addr);
+    let deadline = env.ledger().sequence() + MIN_DEADLINE_BUFFER + 10;
+    client.initialize(&buyer, &seller, &arbiter, &token_addr, &amount, &deadline);
+
+    (client, buyer, seller, arbiter, token_addr)
+}
+
+proptest! {
+    /// Any valid amount initialises the escrow in Created state with that amount.
+    #[test]
+    fn prop_initialize_stores_amount(amount in 1i128..=1_000_000i128) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, ..) = setup_escrow(&env, amount);
+
+        let info = client.get_escrow_info();
+        prop_assert_eq!(info.amount, amount);
+        prop_assert_eq!(info.state, EscrowState::Created);
+    }
+
+    /// Fund → mark_delivered → approve_delivery always ends in Completed state.
+    #[test]
+    fn prop_happy_path_ends_completed(amount in 1i128..=1_000_000i128) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, ..) = setup_escrow(&env, amount);
+
+        client.fund();
+        client.mark_delivered();
+        client.approve_delivery();
+
+        prop_assert_eq!(client.get_state(), Some(EscrowState::Completed));
+    }
+
+    /// Arbiter resolving in favour of seller always ends in Completed state.
+    #[test]
+    fn prop_arbiter_resolve_seller(amount in 1i128..=1_000_000i128) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, ..) = setup_escrow(&env, amount);
+
+        client.fund();
+        client.resolve_dispute(&true);
+
+        prop_assert_eq!(client.get_state(), Some(EscrowState::Completed));
+    }
+
+    /// Arbiter resolving in favour of buyer always ends in Refunded state.
+    #[test]
+    fn prop_arbiter_resolve_buyer(amount in 1i128..=1_000_000i128) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, ..) = setup_escrow(&env, amount);
+
+        client.fund();
+        client.resolve_dispute(&false);
+
+        prop_assert_eq!(client.get_state(), Some(EscrowState::Refunded));
+    }
+
+    /// Partial release reduces the stored amount by exactly the released portion.
+    #[test]
+    fn prop_partial_release_reduces_amount(
+        total in 2i128..=1_000_000i128,
+        partial_pct in 1u32..=99u32,
+    ) {
+        let partial = (total * partial_pct as i128) / 100;
+        let partial = partial.max(1);
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, ..) = setup_escrow(&env, total);
+
+        client.fund();
+        client.release_partial(&partial);
+
+        let info = client.get_escrow_info();
+        prop_assert_eq!(info.amount, total - partial);
+        prop_assert_eq!(info.state, EscrowState::Funded);
+    }
+
+    /// Deadline in the past (below MIN_DEADLINE_BUFFER) is always rejected.
+    #[test]
+    fn prop_past_deadline_rejected(offset in 0u32..MIN_DEADLINE_BUFFER) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.sequence_number = 200);
+
+        let buyer = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let arbiter = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let sac = env.register_stellar_asset_contract_v2(admin);
+        let token_addr = sac.address();
+        StellarAssetClient::new(&env, &token_addr).mint(&buyer, &1000i128);
+
+        let escrow_addr = env.register_contract(None, EscrowContract);
+        let client = EscrowContractClient::new(&env, &escrow_addr);
+        let bad_deadline = env.ledger().sequence() + offset; // < MIN_DEADLINE_BUFFER
+
+        let result = client.try_initialize(
+            &buyer, &seller, &arbiter, &token_addr, &1000i128, &bad_deadline,
+        );
+        prop_assert!(result.is_err());
+    }
+}

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -15,6 +15,7 @@ soroban-common = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = "1"
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -5,6 +5,8 @@ mod errors;
 mod events;
 mod storage;
 mod test;
+#[cfg(test)]
+mod prop_test;
 
 pub use errors::TokenError;
 pub use storage::{AllowanceDataKey, AllowanceValue, DataKey, MetadataKey};

--- a/contracts/token/src/prop_test.rs
+++ b/contracts/token/src/prop_test.rs
@@ -1,0 +1,102 @@
+#![cfg(test)]
+
+use proptest::prelude::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::TokenContract;
+use crate::TokenContractClient;
+
+fn setup(env: &Env) -> (TokenContractClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let addr = env.register_contract(None, TokenContract);
+    let client = TokenContractClient::new(env, &addr);
+    client.initialize(
+        &admin,
+        &String::from_str(env, "Test Token"),
+        &String::from_str(env, "TEST"),
+        &18u32,
+    );
+    (client, admin)
+}
+
+proptest! {
+    /// Mint then burn the same amount → balance returns to zero.
+    #[test]
+    fn prop_mint_burn_roundtrip(amount in 1i128..=i128::MAX / 2) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let user = Address::generate(&env);
+
+        client.mint(&user, &amount);
+        prop_assert_eq!(client.balance(&user), amount);
+        prop_assert_eq!(client.total_supply(), amount);
+
+        client.burn_admin(&user, &amount);
+        prop_assert_eq!(client.balance(&user), 0);
+        prop_assert_eq!(client.total_supply(), 0);
+    }
+
+    /// Transfer is conservative: sender loses exactly what receiver gains.
+    #[test]
+    fn prop_transfer_conservation(
+        mint in 1i128..=1_000_000i128,
+        transfer in 1i128..=1_000_000i128,
+    ) {
+        let transfer = transfer.min(mint);
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let sender = Address::generate(&env);
+        let receiver = Address::generate(&env);
+
+        client.mint(&sender, &mint);
+        client.transfer(&sender, &receiver, &transfer);
+
+        prop_assert_eq!(client.balance(&sender), mint - transfer);
+        prop_assert_eq!(client.balance(&receiver), transfer);
+        prop_assert_eq!(client.total_supply(), mint);
+    }
+
+    /// Approve then transfer_from reduces allowance by exactly the transferred amount.
+    #[test]
+    fn prop_allowance_decrements_correctly(
+        mint in 1i128..=1_000_000i128,
+        approve in 1i128..=1_000_000i128,
+        spend in 1i128..=1_000_000i128,
+    ) {
+        let approve = approve.min(mint);
+        let spend = spend.min(approve);
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+        let owner = Address::generate(&env);
+        let spender = Address::generate(&env);
+        let receiver = Address::generate(&env);
+
+        client.mint(&owner, &mint);
+        let expiry = env.ledger().sequence() + 1000;
+        client.approve(&owner, &spender, &approve, &expiry);
+        client.transfer_from(&spender, &owner, &receiver, &spend);
+
+        prop_assert_eq!(client.allowance(&owner, &spender), approve - spend);
+    }
+
+    /// Total supply equals the sum of all individual balances after arbitrary mints.
+    #[test]
+    fn prop_total_supply_matches_sum_of_balances(
+        amounts in proptest::collection::vec(1i128..=100_000i128, 1..=10),
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup(&env);
+
+        let mut total = 0i128;
+        for amount in &amounts {
+            let user = Address::generate(&env);
+            client.mint(&user, amount);
+            total += amount;
+        }
+        prop_assert_eq!(client.total_supply(), total);
+    }
+}

--- a/docs/adr/0001-storage-tier-choices.md
+++ b/docs/adr/0001-storage-tier-choices.md
@@ -1,0 +1,50 @@
+# ADR-0001: Storage Tier Choices
+
+- **Status**: Accepted
+- **Date**: 2024-04-24
+
+## Context
+
+Soroban provides three storage tiers with different TTL and cost characteristics:
+
+| Tier | TTL behaviour | Typical use |
+|------|--------------|-------------|
+| `instance` | Tied to the contract instance; one TTL for all keys | Small, always-needed state |
+| `persistent` | Per-key TTL; survives contract upgrades | Long-lived, per-user data |
+| `temporary` | Per-key TTL; automatically deleted on expiry | Short-lived, cheap scratch data |
+
+Both the token and escrow contracts must store state that must remain accessible for the full lifetime of the contract.
+
+## Decision
+
+### Escrow contract
+All escrow fields (`Buyer`, `Seller`, `Arbiter`, `TokenContract`, `Amount`, `Deadline`, `State`, `BuyerApproved`, `SellerDelivered`) are stored in **instance storage**.
+
+Rationale:
+- An escrow is a single, atomic agreement; all fields are always read together.
+- Instance storage gives a single TTL to manage, simplifying the bump logic.
+- The contract is single-use (one escrow per deployed instance), so per-key granularity of persistent storage adds no benefit.
+
+### Token contract
+- `Admin`, `TotalSupply`, and `Metadata` keys use **instance storage** — they are global, always needed, and small.
+- `Balance(Address)` and `Allowance(AllowanceDataKey)` use **persistent storage** — they are per-user, potentially numerous, and must survive independently of each other.
+
+Rationale:
+- Persistent storage lets inactive balances expire without affecting the contract instance.
+- Allowances carry an `expiration_ledger` field; persistent storage TTL aligns naturally with that semantic.
+
+## TTL / Bump Strategy
+
+Both contracts define:
+```rust
+const BUMP_THRESHOLD: u32 = 120_960;  // ~7 days  — bump if TTL falls below this
+const BUMP_AMOUNT:    u32 = 518_400;  // ~30 days — extend to this on every write
+```
+
+`bump_instance` is called on every state-mutating function so that active contracts never expire unexpectedly.
+
+## Consequences
+
+- Simple, predictable TTL management for escrow (single bump call covers all state).
+- Token balances can expire for dormant accounts, reducing on-chain bloat.
+- Callers must periodically invoke `bump()` on long-running escrows to keep them alive.

--- a/docs/adr/0002-error-handling-strategy.md
+++ b/docs/adr/0002-error-handling-strategy.md
@@ -1,0 +1,52 @@
+# ADR-0002: Error Handling Strategy
+
+- **Status**: Accepted
+- **Date**: 2024-04-24
+
+## Context
+
+Soroban contracts can signal failure in two ways:
+
+1. **`panic!`** — aborts the transaction immediately with no structured code.
+2. **`contracterror` enum + `Result<T, E>`** — returns a typed, numeric error code that callers and indexers can inspect.
+
+Contracts also need to decide how to handle unexpected missing state (keys that should always be present after initialisation).
+
+## Decision
+
+### Typed errors via `contracterror`
+
+Both contracts define a dedicated error enum annotated with `#[contracterror]`:
+
+```rust
+// escrow
+pub enum EscrowError { NotAuthorized=1, InvalidState=2, DeadlinePassed=3, … }
+
+// token
+pub enum TokenError { InsufficientBalance=1, InsufficientAllowance=2, Unauthorized=3, … }
+```
+
+All public entry points return `Result<(), XxxError>` so that:
+- Clients receive a stable numeric code they can match on.
+- Errors are visible in the contract ABI / XDR metadata.
+- Tests can assert on specific error variants.
+
+### `panic!` for programmer errors
+
+`panic!` is reserved for conditions that indicate a bug or misuse that cannot be recovered from at runtime, e.g.:
+
+- Deadline set in the past during `initialize` (violates a hard invariant).
+- `bump()` called on an uninitialised contract.
+- Missing storage keys that must exist after initialisation (`.expect("…")`).
+
+These are not expected in normal operation and do not need a stable error code.
+
+### `?` propagation
+
+Internal helpers (e.g. `release_to_seller`, `refund_to_buyer`) also return `Result` and propagate errors with `?`, keeping the call chain clean.
+
+## Consequences
+
+- Callers get machine-readable error codes for all expected failure modes.
+- The distinction between `Result` errors and panics makes the contract's invariants explicit.
+- Adding a new error variant is a non-breaking ABI change (new numeric code); removing or renumbering one is breaking and must be avoided.

--- a/docs/adr/0003-admin-model.md
+++ b/docs/adr/0003-admin-model.md
@@ -1,0 +1,57 @@
+# ADR-0003: Admin Model
+
+- **Status**: Accepted
+- **Date**: 2024-04-24
+
+## Context
+
+Both contracts need a privileged role that can perform sensitive operations (minting tokens, resolving disputes). The design must:
+
+- Be simple to reason about.
+- Avoid a single point of failure where possible.
+- Leverage Soroban's native auth framework rather than rolling a custom signature scheme.
+
+## Decision
+
+### Token contract — single admin address
+
+A single `Admin` address is stored in instance storage under `AdminKey::Admin` (defined in the shared `soroban-common` crate).
+
+```rust
+// soroban-common
+pub fn try_get_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&AdminKey::Admin)
+}
+
+// token/src/admin.rs
+pub fn require_admin(env: &Env) -> Result<Address, TokenError> {
+    soroban_common::try_get_admin(env).ok_or(TokenError::NotInitialized)
+}
+```
+
+The admin address is set once during `initialize` and can be a regular account or a multisig contract address — the token contract is agnostic to the type of address.
+
+Privileged operations (mint, burn, set_admin) call `admin.require_auth()`, delegating all authentication to the Soroban host.
+
+### Escrow contract — role-based parties, no global admin
+
+The escrow has no "admin" in the traditional sense. Instead, three distinct roles are established at initialisation:
+
+| Role | Stored key | Privileged operations |
+|------|-----------|----------------------|
+| `buyer` | `Buyer` | `fund`, `approve_delivery`, `request_refund`, `release_partial`, `cancel` |
+| `seller` | `Seller` | `mark_delivered` |
+| `arbiter` | `Arbiter` | `resolve_dispute` |
+
+Each function reads the relevant address from storage and calls `.require_auth()` on it. There is no super-admin that can override all roles.
+
+### Shared admin utilities in `soroban-common`
+
+To avoid duplicating admin-read logic, the `soroban-common` crate exposes `get_admin` / `try_get_admin`. This is the single source of truth for the `AdminKey` enum and its storage layout.
+
+## Consequences
+
+- The token admin is a single address; operators who need multi-party control should deploy a multisig contract as the admin address.
+- The escrow arbiter provides dispute resolution without granting blanket admin power.
+- Admin transfer for the token contract must be implemented explicitly (set_admin function) — there is no implicit ownership transfer.
+- Removing the admin from the token contract (setting it to a burn address) effectively makes the token immutable.

--- a/docs/adr/0004-escrow-state-machine.md
+++ b/docs/adr/0004-escrow-state-machine.md
@@ -1,0 +1,72 @@
+# ADR-0004: Escrow State Machine Design
+
+- **Status**: Accepted
+- **Date**: 2024-04-24
+
+## Context
+
+An escrow contract must enforce a strict lifecycle so that funds can never be double-spent, released to the wrong party, or locked forever. The design must be auditable and easy to test.
+
+## Decision
+
+### States
+
+```
+Created ──fund()──► Funded ──mark_delivered()──► Delivered
+   │                  │                              │
+cancel()        request_refund()             approve_delivery()
+   │            (after deadline)             resolve_dispute()
+   ▼                  │                              │
+Cancelled         Refunded ◄──resolve_dispute()──────┤
+                                                      │
+                                               Completed
+```
+
+| State | Meaning |
+|-------|---------|
+| `Created` | Escrow initialised; no funds held yet |
+| `Funded` | Buyer has transferred tokens to the contract |
+| `Delivered` | Seller has marked goods/services as delivered |
+| `Completed` | Funds released to seller — terminal |
+| `Refunded` | Funds returned to buyer — terminal |
+| `Cancelled` | Buyer cancelled before funding — terminal |
+
+### Transition rules
+
+Every entry point reads the current state first and rejects calls that are invalid for that state, returning `EscrowError::InvalidState`. This is enforced at the top of each function before any auth check or storage mutation.
+
+### Checks-Effects-Interactions (CEI) pattern
+
+All token transfers happen **after** the state is updated in storage:
+
+```rust
+// Effects first
+env.storage().instance().set(&State, &EscrowState::Completed);
+bump_instance(&env);
+// Interactions last
+token::Client::new(&env, &token_contract).transfer(…);
+```
+
+This prevents re-entrancy: if the token transfer somehow triggers a re-entrant call back into the escrow, the state is already terminal and all state-guarded functions will return `InvalidState`.
+
+### Deadline enforcement
+
+The `deadline_ledger` is a Soroban ledger sequence number set at initialisation. It must be at least `MIN_DEADLINE_BUFFER` (100) ledgers in the future.
+
+- `request_refund` is only valid when `env.ledger().sequence() > deadline` **and** the state is `Funded` or `Delivered`.
+- There is no automatic expiry; the buyer must explicitly call `request_refund`.
+
+### Partial release
+
+`release_partial(amount)` allows the buyer to release a portion of funds to the seller while the escrow remains in `Funded` or `Delivered` state. The stored `Amount` is decremented; the state does not change. This enables milestone-based payments without requiring a new escrow deployment.
+
+### Arbiter
+
+The arbiter can call `resolve_dispute` in `Funded` or `Delivered` states to either complete or refund the escrow. The arbiter has no power in `Created`, `Completed`, `Refunded`, or `Cancelled` states.
+
+## Consequences
+
+- Terminal states (`Completed`, `Refunded`, `Cancelled`) are irreversible; a new contract instance must be deployed for a new escrow.
+- The CEI pattern makes the contract safe against re-entrant token callbacks.
+- The explicit state enum makes the lifecycle easy to audit and test exhaustively.
+- Partial releases reduce the need for multiple escrow deployments in milestone scenarios.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the Soroban Starter Kit.
+
+Each ADR documents a significant design decision: the context that motivated it, the decision taken, and its consequences.
+
+## Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-storage-tier-choices.md) | Storage Tier Choices | Accepted |
+| [0002](0002-error-handling-strategy.md) | Error Handling Strategy | Accepted |
+| [0003](0003-admin-model.md) | Admin Model | Accepted |
+| [0004](0004-escrow-state-machine.md) | Escrow State Machine Design | Accepted |
+
+## Format
+
+Each ADR follows this structure:
+
+- **Status** — `Proposed` | `Accepted` | `Deprecated` | `Superseded by ADR-XXXX`
+- **Date** — date the decision was accepted
+- **Context** — the problem and forces at play
+- **Decision** — what was decided
+- **Consequences** — trade-offs and follow-on implications


### PR DESCRIPTION
## Summary

Creates `docs/adr/` with four ADRs documenting key design decisions in the codebase.

## ADRs added

| ADR | Decision |
|-----|----------|
| [0001](docs/adr/0001-storage-tier-choices.md) | Storage tier choices (instance vs persistent) |
| [0002](docs/adr/0002-error-handling-strategy.md) | Error handling strategy (`contracterror` + `Result` vs `panic!`) |
| [0003](docs/adr/0003-admin-model.md) | Admin model (token single-admin vs escrow role-based) |
| [0004](docs/adr/0004-escrow-state-machine.md) | Escrow state machine design (states, transitions, CEI pattern) |

Closes #46