### PR TITLE
fix: resolve issues #231 #234 #238 #242

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,21 @@ jobs:
           name: wasm-contracts
           path: target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 7
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,0 +1,90 @@
+name: Infra
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'infra/**'
+      - '.github/workflows/infra.yml'
+  workflow_dispatch:
+
+env:
+  TF_VERSION: "1.8.0"
+  TF_WORKING_DIR: infra
+
+jobs:
+  plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      # Cache the .terraform directory so the apply job uses the exact same
+      # provider binaries — prevents "saved plan is stale" errors.
+      - name: Cache .terraform
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.TF_WORKING_DIR }}/.terraform
+          key: terraform-${{ runner.os }}-${{ hashFiles(format('{0}/.terraform.lock.hcl', env.TF_WORKING_DIR)) }}
+          restore-keys: |
+            terraform-${{ runner.os }}-
+
+      - name: Terraform Init
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform init -input=false
+
+      - name: Terraform Plan
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform plan -input=false -out=tfplan
+
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan
+          path: ${{ env.TF_WORKING_DIR }}/tfplan
+          retention-days: 1
+
+  apply:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+    needs: plan
+    # Only apply on pushes to main, not on PRs
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      # Restore the same .terraform directory from the plan job — no re-init needed.
+      - name: Restore .terraform cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.TF_WORKING_DIR }}/.terraform
+          key: terraform-${{ runner.os }}-${{ hashFiles(format('{0}/.terraform.lock.hcl', env.TF_WORKING_DIR)) }}
+          restore-keys: |
+            terraform-${{ runner.os }}-
+
+      - name: Download plan artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan
+          path: ${{ env.TF_WORKING_DIR }}
+
+      # Apply uses the downloaded plan directly — no terraform init re-run.
+      - name: Terraform Apply
+        working-directory: ${{ env.TF_WORKING_DIR }}
+        run: terraform apply -input=false tfplan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `cargo audit` security scanning job in CI workflow (#238)
+- Error Reference section in README documenting all `TokenError` and `EscrowError` codes (#234)
+- This CHANGELOG file (#231)
+- Terraform provider version pinning and `.terraform` directory caching between plan and apply jobs (#242)
+
+## [1.0.0] - 2026-04-24
+
+### Added
+- Token contract with mint, burn, transfer, approve, and admin controls
+- Escrow contract with buyer/seller/arbiter roles, deadline enforcement, and dispute resolution
+- Shared `common` crate for reusable types and utilities
+- Comprehensive unit tests for both contracts (8+ cases each)
+- Property-based tests via `proptest`
+- Test snapshots for deterministic ledger state verification
+- Deployment scripts for testnet and local network
+- Docker Compose setup for local Stellar node with Soroban RPC
+- Dev container configuration for reproducible development environments
+- Architecture Decision Records (ADRs) covering storage tiers, error handling, admin model, and escrow state machine
+- CI workflow with test, build, and WASM artifact upload jobs
+- Benchmark suite for escrow and token operations
+
+[Unreleased]: https://github.com/Fidelis900/soroban-starter-kit/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/Fidelis900/soroban-starter-kit/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -86,6 +86,34 @@ Start a local Stellar node with Soroban RPC:
 docker compose up stellar-node
 ```
 
+## ⚠️ Error Reference
+
+### Token Contract Errors (`TokenError`)
+
+| Code | Name | Description |
+|------|------|-------------|
+| 1 | `InsufficientBalance` | Caller's balance is too low to complete the transfer or burn |
+| 2 | `InsufficientAllowance` | Approved allowance is too low for the requested `transfer_from` amount |
+| 3 | `Unauthorized` | Caller is not the admin or does not have permission for this operation |
+| 4 | `AlreadyInitialized` | `initialize` was called on a contract that has already been set up |
+| 5 | `NotInitialized` | An operation was attempted before the contract was initialized |
+| 6 | `InvalidAmount` | Amount is zero, negative, or exceeds the configured max supply |
+| 7 | `Overflow` | Arithmetic overflow occurred during a balance or supply calculation |
+
+### Escrow Contract Errors (`EscrowError`)
+
+| Code | Name | Description |
+|------|------|-------------|
+| 1 | `NotAuthorized` | Caller is not permitted to invoke this function (wrong party or arbiter) |
+| 2 | `InvalidState` | The escrow is not in the required state for this operation |
+| 3 | `DeadlinePassed` | The escrow deadline has already elapsed; the operation is no longer valid |
+| 4 | `DeadlineNotReached` | The deadline has not yet passed; premature refund or timeout claim attempted |
+| 5 | `AlreadyInitialized` | `initialize` was called on an escrow that is already set up |
+| 6 | `NotInitialized` | An operation was attempted before the escrow was initialized |
+| 7 | `InsufficientFunds` | The escrow account does not hold enough tokens to complete the operation |
+| 8 | `InvalidAmount` | The specified amount is zero or otherwise invalid |
+| 9 | `InvalidParties` | Buyer, seller, or arbiter addresses are invalid or conflict with each other |
+
 ## 🤝 Contributing
 
 We welcome contributions! Please:


### PR DESCRIPTION
fix: resolve issues 

closes #238 
closes  #234 
closes  #231 
closes  #242

Summary
Addresses four open issues covering security scanning, documentation gaps, and CI/infra reliability.

Changes
#238 — Dependency Vulnerability Scanning Added a dedicated audit job to ci.yml that installs cargo-audit and scans all workspace dependencies for known CVEs. Runs independently of the test and build jobs so security failures are surfaced clearly.

#234 — Error Code Documentation Added an "Error Reference" section to README.md with full tables for both TokenError and EscrowError. Each entry includes the numeric value, variant name, and a plain-English description of when it's returned.

#231 — CHANGELOG Created CHANGELOG.md following the Keep a Changelog format with an [Unreleased] section and a [1.0.0] initial release entry documenting the existing feature set.

#242 — Terraform Plan/Apply Staleness Created 
infra.yml
 with:

Terraform version pinned via TF_VERSION: "1.8.0" and hashicorp/setup-terraform@v3
.terraform directory cached and keyed on .terraform.lock.hcl hash
Apply job restores the cache instead of re-running terraform init, eliminating the "saved plan is stale" error
Apply only runs on pushes to main, not on PRs
Testing
CI audit job can be verified by triggering the workflow — cargo audit will exit non-zero if any advisory matches
README error tables were cross-referenced directly against errors.rs in both contracts
Infra workflow is path-scoped to infra/** so it won't trigger on unrelated changes
Closes #231, #234, #238, #242