### PR TITLE
fix(#284 #105): implement Display for TokenError and EscrowError

### DIFF
--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -13,3 +13,19 @@ pub enum EscrowError {
     InvalidAmount = 8,
     InvalidParties = 9,
 }
+
+impl core::fmt::Display for EscrowError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            EscrowError::NotAuthorized => write!(f, "not authorized"),
+            EscrowError::InvalidState => write!(f, "invalid state"),
+            EscrowError::DeadlinePassed => write!(f, "deadline passed"),
+            EscrowError::DeadlineNotReached => write!(f, "deadline not reached"),
+            EscrowError::AlreadyInitialized => write!(f, "already initialized"),
+            EscrowError::NotInitialized => write!(f, "not initialized"),
+            EscrowError::InsufficientFunds => write!(f, "insufficient funds"),
+            EscrowError::InvalidAmount => write!(f, "invalid amount"),
+            EscrowError::InvalidParties => write!(f, "invalid parties"),
+        }
+    }
+}

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -41,7 +41,7 @@ pub enum DataKey {
 }
 
 #[contracttype]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EscrowState {
     Created = 0,
     Funded = 1,

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -3,6 +3,18 @@
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, token, Address, Env, Symbol,
 };
+
+/// Extend storage TTL when remaining ledgers fall below this threshold.
+/// 120_960 ledgers ≈ 7 days (at ~5 s/ledger).
+const LEDGER_LIFETIME_THRESHOLD: u32 = 120_960;
+
+/// Target TTL (in ledgers) after each extension.
+/// 518_400 ledgers ≈ 30 days (at ~5 s/ledger).
+const LEDGER_BUMP_AMOUNT: u32 = 518_400;
+
+fn bump_instance(env: &Env) {
+    env.storage().instance().extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
 /// script
 /// Escrow contract for secure two-party transactions
 ///

--- a/contracts/escrow/src/storage.rs
+++ b/contracts/escrow/src/storage.rs
@@ -17,7 +17,7 @@ pub enum DataKey {
 }
 
 #[contracttype]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum EscrowState {
     Created = 0,
     Funded = 1,

--- a/contracts/token/src/errors.rs
+++ b/contracts/token/src/errors.rs
@@ -12,3 +12,18 @@ pub enum TokenError {
     Overflow = 7,
     ExceedsMaxSupply = 6,
 }
+
+impl core::fmt::Display for TokenError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TokenError::InsufficientBalance => write!(f, "insufficient balance"),
+            TokenError::InsufficientAllowance => write!(f, "insufficient allowance"),
+            TokenError::Unauthorized => write!(f, "unauthorized"),
+            TokenError::AlreadyInitialized => write!(f, "already initialized"),
+            TokenError::NotInitialized => write!(f, "not initialized"),
+            TokenError::InvalidAmount => write!(f, "invalid amount"),
+            TokenError::Overflow => write!(f, "arithmetic overflow"),
+            TokenError::ExceedsMaxSupply => write!(f, "exceeds max supply"),
+        }
+    }
+}

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -10,16 +10,21 @@ use admin::require_admin;
 use storage::DataKey::{Admin, Allowance, Balance, Metadata, TotalSupply};
 use storage::MetadataKey::{Decimals, Name, Symbol as SymbolKey};
 
-const BUMP_THRESHOLD: u32 = 120_960;
-const BUMP_AMOUNT: u32 = 518_400;
+/// Extend storage TTL when remaining ledgers fall below this threshold.
+/// 120_960 ledgers ≈ 7 days (at ~5 s/ledger).
+const LEDGER_LIFETIME_THRESHOLD: u32 = 120_960;
+
+/// Target TTL (in ledgers) after each extension.
+/// 518_400 ledgers ≈ 30 days (at ~5 s/ledger).
+const LEDGER_BUMP_AMOUNT: u32 = 518_400;
 const CONTRACT_VERSION: u32 = 1;
 
 fn bump_instance(env: &Env) {
-    env.storage().instance().extend_ttl(BUMP_THRESHOLD, BUMP_AMOUNT);
+    env.storage().instance().extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 }
 
 fn bump_persistent(env: &Env, key: &DataKey) {
-    env.storage().persistent().extend_ttl(key, BUMP_THRESHOLD, BUMP_AMOUNT);
+    env.storage().persistent().extend_ttl(key, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 }
 
 /// Token contract implementing the Soroban Token Interface


### PR DESCRIPTION
closes #284 

Adds core::fmt::Display to both error enums so log messages show human-readable strings instead of raw numeric codes.