### PR TITLE
fix(#285 #106): add doc comments to all DataKey variants

### DIFF
--- a/contracts/escrow/src/storage.rs
+++ b/contracts/escrow/src/storage.rs
@@ -3,16 +3,27 @@ use soroban_sdk::{contracttype, Address};
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    /// Buyer's address. Type: `Address`. Storage: instance.
     Buyer,
+    /// Seller's address. Type: `Address`. Storage: instance.
     Seller,
+    /// Arbiter's address for dispute resolution. Type: `Address`. Storage: instance.
     Arbiter,
+    /// Address of the token contract holding escrowed funds. Type: `Address`. Storage: instance.
     TokenContract,
+    /// Escrowed token amount. Type: `i128`. Storage: instance.
     Amount,
+    /// Ledger sequence number after which refunds become claimable. Type: `u32`. Storage: instance.
     Deadline,
+    /// Current lifecycle state of the escrow. Type: `EscrowState`. Storage: instance.
     State,
+    /// Whether the buyer has approved delivery. Type: `bool`. Storage: instance.
     BuyerApproved,
+    /// Whether the seller has marked delivery complete. Type: `bool`. Storage: instance.
     SellerDelivered,
+    /// Whether the contract is paused. Type: `bool`. Storage: instance.
     Paused,
+    /// Contract version number. Type: `u32`. Storage: instance.
     Version,
 }
 

--- a/contracts/token/src/storage.rs
+++ b/contracts/token/src/storage.rs
@@ -3,14 +3,23 @@ use soroban_sdk::{contracttype, Address};
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
+    /// Current admin address. Type: `Address`. Storage: instance.
     Admin,
+    /// Pending admin address awaiting acceptance. Type: `Address`. Storage: instance.
     PendingAdmin,
+    /// Token balance for an account. Type: `i128`. Storage: persistent, keyed by `Address`.
     Balance(Address),
+    /// Approved spending allowance between two accounts. Type: `AllowanceValue`. Storage: persistent, keyed by `AllowanceDataKey`.
     Allowance(AllowanceDataKey),
+    /// Token metadata field (name, symbol, or decimals). Type: varies. Storage: instance, keyed by `MetadataKey`.
     Metadata(MetadataKey),
+    /// Aggregate minted supply. Type: `i128`. Storage: instance.
     TotalSupply,
+    /// Whether the contract is paused. Type: `bool`. Storage: instance.
     Paused,
+    /// Contract version number. Type: `u32`. Storage: instance.
     Version,
+    /// Maximum tokens that may ever be minted. Type: `i128`. Storage: instance.
     MaxSupply,
 }
 


### PR DESCRIPTION
Each variant now documents the data it stores, its type, and the storage tier (instance/persistent) used.

closes #285