### PR TITLE
fix: WASM size check in CI, multi-stage Dockerfile, contracts entrypo…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,27 @@ jobs:
             fi
           done
 
+      - name: Check WASM sizes
+        run: |
+          MAX=65536
+          FAILED=0
+          for wasm in target/wasm32-unknown-unknown/release/*.wasm; do
+            size=$(wc -c < "$wasm")
+            echo "$(basename $wasm): $size bytes"
+            if [ "$size" -gt "$MAX" ]; then
+              echo "ERROR: $(basename $wasm) exceeds $MAX bytes ($size)"
+              FAILED=1
+            fi
+          done
+          exit $FAILED
+
       - name: Upload WASM artifacts
         uses: actions/upload-artifact@v4
         with:
           name: wasm-contracts
           path: target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 7
+
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
 

--- a/docker/Dockerfile.contracts
+++ b/docker/Dockerfile.contracts
@@ -1,14 +1,21 @@
-# Rust contract builder
-FROM rust:1.78-slim AS contracts
+# Stage 1: build
+FROM rust:1.78-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config libssl-dev curl ca-certificates \
+    pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Soroban CLI
 RUN cargo install --locked stellar-cli --features opt
 
 WORKDIR /contracts
 COPY soroban-starter-kit/ .
 
-CMD ["stellar", "contract", "build"]
+RUN for dir in contracts/*/; do \
+      [ -f "$dir/Cargo.toml" ] && stellar contract build --manifest-path "$dir/Cargo.toml"; \
+    done
+
+# Stage 2: runtime — only .wasm artifacts
+FROM debian:bookworm-slim AS runtime
+
+WORKDIR /wasm
+COPY --from=builder /contracts/target/wasm32-unknown-unknown/release/*.wasm ./

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,10 +17,16 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.contracts
+      target: builder
+    command: >
+      sh -c "for dir in contracts/*/; do
+        [ -f \"$$dir/Cargo.toml\" ] && stellar contract build --manifest-path \"$$dir/Cargo.toml\";
+      done"
     volumes:
       - ../contracts:/contracts
       - cargo-cache:/usr/local/cargo/registry
     env_file: ../.env
+    restart: "no"
     depends_on:
       - stellar-node
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,16 +11,16 @@ CONTRACT="${2:-all}"
 
 case "$NETWORK" in
   testnet)
-    RPC_URL="https://soroban-testnet.stellar.org"
-    PASSPHRASE="Test SDF Network ; September 2015"
+    RPC_URL="${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
     ;;
   mainnet)
-    RPC_URL="https://soroban.stellar.org"
-    PASSPHRASE="Public Global Stellar Network ; September 2015"
+    RPC_URL="${STELLAR_RPC_URL:-https://soroban.stellar.org}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Public Global Stellar Network ; September 2015}"
     ;;
   local)
-    RPC_URL="http://localhost:${LOCAL_RPC_PORT:-8000}"
-    PASSPHRASE="Standalone Network ; February 2017"
+    RPC_URL="${STELLAR_RPC_URL:-http://localhost:${LOCAL_RPC_PORT:-8000}}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Standalone Network ; February 2017}"
     ;;
   *)
     echo "Unknown network: $NETWORK (use testnet|mainnet|local)" >&2


### PR DESCRIPTION
…int, deploy.sh env vars

- ci.yml: add WASM size check (65536 byte limit) after contract build (#239)
- Dockerfile.contracts: convert to multi-stage build; runtime stage copies only .wasm files (#247)
- docker-compose.yml: add explicit build command and restart:no to contracts service (#246)
- deploy.sh: read RPC_URL and passphrase from STELLAR_RPC_URL / STELLAR_NETWORK_PASSPHRASE env vars (#251)

Closes #239 
Closes #247 
Closes #246 
Closes #251 