### PR TITLE
fix: cargo workspace hygiene improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
           path: target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 7
 
+  deny:
+    name: License and Duplicate Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
   audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,15 @@ resolver = "2"
 soroban-sdk = "21"
 soroban-common = { path = "contracts/common" }
 
-[workspace.metadata]
-name = "soroban-contract-templates"
-description = "Production-ready Soroban smart contract templates"
+[workspace.package]
 authors = ["Soroban Templates Contributors"]
 license = "Apache-2.0"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+unused_imports = "warn"
+unused_variables = "warn"
+
+[workspace.lints.clippy]
+all = "warn"
+pedantic = "warn"

--- a/contracts/common/Cargo.toml
+++ b/contracts/common/Cargo.toml
@@ -8,3 +8,6 @@ crate-type = ["rlib"]
 
 [dependencies]
 soroban-sdk = { workspace = true }
+
+[lints]
+workspace = true

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -2,9 +2,9 @@
 name = "soroban-escrow-template"
 version = "0.1.0"
 edition = "2021"
-authors = ["Soroban Templates Contributors"]
+authors.workspace = true
 description = "A production-ready Soroban escrow contract template"
-license = "Apache-2.0"
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -17,9 +17,10 @@ soroban-common = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 proptest = "1"
 
-[features]
-testutils = ["soroban-sdk/testutils"]
 
 [[bin]]
 name = "soroban-escrow-template"
 path = "src/bin/main.rs"
+
+[lints]
+workspace = true

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -2,9 +2,9 @@
 name = "soroban-token-template"
 version = "0.1.0"
 edition = "2021"
-authors = ["Soroban Templates Contributors"]
+authors.workspace = true
 description = "A production-ready Soroban token contract template"
-license = "Apache-2.0"
+license.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -17,9 +17,10 @@ soroban-common = { workspace = true }
 soroban-sdk = { workspace = true, features = ["testutils"] }
 proptest = "1"
 
-[features]
-testutils = ["soroban-sdk/testutils"]
 
 [[bin]]
 name = "soroban-token-template"
 path = "src/bin/main.rs"
+
+[lints]
+workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,14 @@
+[licenses]
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "ISC",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Unicode-DFS-2016",
+]
+deny = ["GPL-2.0", "GPL-3.0", "LGPL-2.0", "LGPL-2.1", "LGPL-3.0", "AGPL-3.0"]
+
+[bans]
+multiple-versions = "deny"
+wildcards = "deny"


### PR DESCRIPTION
Closes #265
Closes #266
Closes #267
Closes #268

- #265: Replace [workspace.metadata] with [workspace.package] in root Cargo.toml for license and authors fields (Cargo 1.64+ standard). Member crates (token, escrow) now inherit via authors.workspace and license.workspace instead of duplicating values.

- #266: Remove [features] testutils = ["soroban-sdk/testutils"] from token and escrow Cargo.toml. The testutils feature was reachable via --features flag and could compile test utilities into production WASM. soroban-sdk with testutils is now exclusively in [dev-dependencies].

- #267: Add deny.toml with [licenses] (allow permissive, deny GPL/LGPL/ AGPL) and [bans] (deny duplicate crate versions and wildcard deps). Add cargo-deny-action job to CI workflow so checks run on every push and pull request.

- #268: Add [workspace.lints.rust] and [workspace.lints.clippy] to root Cargo.toml (forbid unsafe_code, warn on unused imports/variables, enable clippy::all and clippy::pedantic). All three member crates (token, escrow, common) opt in via [lints] workspace = true.