### PR TITLE
fix: resolve Cargo workspace issues #261 #262 #263 #264

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,12 @@ resolver = "2"
 soroban-sdk = "21"
 soroban-common = { path = "contracts/common" }
 
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+lto = true
+codegen-units = 1
+
 [workspace.metadata]
 name = "soroban-contract-templates"
 description = "Production-ready Soroban smart contract templates"


### PR DESCRIPTION
- #264: contracts already use workspace = true for soroban-sdk (no change needed)
- #262/#263: add [profile.release] with opt-level=z, lto=true, codegen-units=1, overflow-checks=true to workspace Cargo.toml
- #261: Cargo.lock was already tracked; .gitignore never excluded it (no change needed)

Closes #261

Closes #262

Closes #263

Closes #264
