### PR TITLE
Add patch.crates-io examples for local soroban-sdk development

### DIFF
--- a/contracts/common/Cargo.toml
+++ b/contracts/common/Cargo.toml
@@ -11,3 +11,8 @@ soroban-sdk = { workspace = true }
 
 [lints]
 workspace = true
+
+# Uncomment to use a local or forked version of soroban-sdk for development
+# [patch.crates-io]
+# soroban-sdk = { path = "/path/to/local/soroban-sdk" }
+# soroban-sdk = { git = "https://github.com/your-fork/soroban-sdk", branch = "your-branch" }

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -24,3 +24,8 @@ path = "src/bin/main.rs"
 
 [lints]
 workspace = true
+
+# Uncomment to use a local or forked version of soroban-sdk for development
+# [patch.crates-io]
+# soroban-sdk = { path = "/path/to/local/soroban-sdk" }
+# soroban-sdk = { git = "https://github.com/your-fork/soroban-sdk", branch = "your-branch" }

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -24,3 +24,8 @@ path = "src/bin/main.rs"
 
 [lints]
 workspace = true
+
+# Uncomment to use a local or forked version of soroban-sdk for development
+# [patch.crates-io]
+# soroban-sdk = { path = "/path/to/local/soroban-sdk" }
+# soroban-sdk = { git = "https://github.com/your-fork/soroban-sdk", branch = "your-branch" }


### PR DESCRIPTION
Closes #273
Closes #274

- Added commented-out [patch.crates-io] section to all contract Cargo.toml files
- Shows examples for both local path and git fork overrides
- Enables developers to easily use local or forked versions of soroban-sdk
- Version fields (0.1.0) already present in all contracts