### PR TITLE
fix: guard against self-transfers in transfer_impl

### DIFF
--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -337,6 +337,9 @@ impl token::TokenInterface for TokenContract {
 
 impl TokenContract {
     fn transfer_impl(env: &Env, from: Address, to: Address, amount: i128) -> Result<(), TokenError> {
+        if from == to {
+            return Ok(());
+        }
         if amount <= 0 {
             return Err(TokenError::InvalidAmount);
         }

--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -292,3 +292,18 @@ fn test_approve_revoke() {
         )
     );
 }
+
+#[test]
+fn test_transfer_self_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let client = init_token(&env, &admin);
+    client.mint(&user, &500i128);
+
+    client.transfer(&user, &user, &200i128);
+
+    // Balance unchanged
+    assert_eq!(client.balance(&user), 500i128);
+}


### PR DESCRIPTION
Transferring tokens from an address to itself is a no-op that wastes gas. Add an early return when from == to.

Closes #294 