### PR TITLE
fix: Add Dependabot config and standardize workspace metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,9 @@ overflow-checks = true
 lto = true
 codegen-units = 1
 
-[workspace.metadata]
+[workspace.package]
 name = "soroban-contract-templates"
 description = "Production-ready Soroban smart contract templates"
-[workspace.package]
 authors = ["Soroban Templates Contributors"]
 license = "Apache-2.0"
 


### PR DESCRIPTION
- Add .github/dependabot.yml for Cargo ecosystem with weekly updates
- Move workspace metadata to standard [workspace.package] section  
- Verify contract Cargo.toml files have correct cdylib/rlib crate-type

Closes #271
Closes #270
Closes #272