### PR TITLE
feat: add property-based tests for token and escrow contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,7 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -387,7 +393,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -412,7 +418,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -442,7 +448,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -489,6 +495,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,7 +519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -811,6 +829,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,14 +853,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -837,7 +886,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -846,7 +905,25 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -868,6 +945,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rfc6979"
@@ -1051,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1120,7 +1203,7 @@ dependencies = [
  "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
- "getrandom",
+ "getrandom 0.2.17",
  "hex-literal",
  "hmac",
  "k256",
@@ -1128,8 +1211,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "p256",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sec1",
  "sha2",
  "sha3",
@@ -1160,6 +1243,7 @@ dependencies = [
 name = "soroban-escrow-template"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-common",
  "soroban-sdk",
 ]
@@ -1189,7 +1273,7 @@ dependencies = [
  "ctor",
  "derive_arbitrary",
  "ed25519-dalek",
- "rand",
+ "rand 0.8.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -1252,6 +1336,7 @@ dependencies = [
 name = "soroban-token-template"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "soroban-common",
  "soroban-sdk",
 ]
@@ -1399,6 +1484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,6 +1506,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1556,6 +1656,12 @@ checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -15,6 +15,7 @@ soroban-common = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { version = "1.4", default-features = false, features = ["std"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -202,3 +202,61 @@ fn test_arbiter_resolve_to_buyer() {
 
     assert_eq!(client.get_state(), Some(EscrowState::Refunded));
 }
+
+// ── Property-based tests ──────────────────────────────────────────────────
+
+#[cfg(test)]
+mod prop_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// For any valid partial release amount, the remaining escrow amount decreases by exactly that amount.
+    #[test]
+    fn prop_partial_release_reduces_amount() {
+        proptest!(|(total in 2i128..=1_000_000i128, pct in 1u32..=99u32)| {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let buyer = Address::generate(&env);
+            let seller = Address::generate(&env);
+            let arbiter = Address::generate(&env);
+            let token_address = setup_token(&env, &buyer, total);
+            let deadline = env.ledger().sequence() + 200;
+
+            let (client, _) = create_escrow_contract(&env);
+            client.initialize(&buyer, &seller, &arbiter, &token_address, &total, &deadline);
+            client.fund();
+
+            let partial = (total * pct as i128) / 100;
+            if partial == 0 || partial >= total { return Ok(()); }
+
+            client.release_partial(&partial);
+
+            let info = client.get_escrow_info();
+            prop_assert_eq!(info.amount, total - partial);
+            prop_assert_eq!(info.state, EscrowState::Funded);
+        });
+    }
+
+    /// Escrow initialized with any valid positive amount always starts in Created state.
+    #[test]
+    fn prop_initialize_always_creates_state() {
+        proptest!(|(amount in 1i128..=1_000_000i128)| {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let buyer = Address::generate(&env);
+            let seller = Address::generate(&env);
+            let arbiter = Address::generate(&env);
+            let token_address = setup_token(&env, &buyer, amount);
+            let deadline = env.ledger().sequence() + 200;
+
+            let (client, _) = create_escrow_contract(&env);
+            client.initialize(&buyer, &seller, &arbiter, &token_address, &amount, &deadline);
+
+            let info = client.get_escrow_info();
+            prop_assert_eq!(info.state, EscrowState::Created);
+            prop_assert_eq!(info.amount, amount);
+        });
+    }
+}

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -15,6 +15,7 @@ soroban-common = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { version = "1.4", default-features = false, features = ["std"] }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -180,3 +180,76 @@ fn test_set_admin() {
 
     assert_eq!(client.admin(), new_admin);
 }
+
+// ── Property-based tests ──────────────────────────────────────────────────
+
+#[cfg(test)]
+mod prop_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// For any valid amount, mint then burn the same amount returns balance to zero.
+    #[test]
+    fn prop_mint_then_burn_restores_balance() {
+        proptest!(|(amount in 1i128..=i128::MAX / 2)| {
+            let env = Env::default();
+            env.mock_all_auths();
+            let admin = Address::generate(&env);
+            let user = Address::generate(&env);
+            let client = init_token(&env, &admin);
+
+            client.mint(&user, &amount);
+            let balance_after_mint = client.balance(&user);
+            client.burn_admin(&user, &amount);
+
+            prop_assert_eq!(balance_after_mint, amount);
+            prop_assert_eq!(client.balance(&user), 0);
+            prop_assert_eq!(client.total_supply(), 0);
+        });
+    }
+
+    /// total_supply always equals the sum of all individual balances after minting to multiple users.
+    #[test]
+    fn prop_total_supply_matches_sum_of_balances() {
+        proptest!(|(a in 1i128..=1_000_000i128, b in 1i128..=1_000_000i128, c in 1i128..=1_000_000i128)| {
+            let env = Env::default();
+            env.mock_all_auths();
+            let admin = Address::generate(&env);
+            let client = init_token(&env, &admin);
+
+            let u1 = Address::generate(&env);
+            let u2 = Address::generate(&env);
+            let u3 = Address::generate(&env);
+            client.mint(&u1, &a);
+            client.mint(&u2, &b);
+            client.mint(&u3, &c);
+
+            let expected = a + b + c;
+            prop_assert_eq!(client.total_supply(), expected);
+            prop_assert_eq!(client.balance(&u1) + client.balance(&u2) + client.balance(&u3), expected);
+        });
+    }
+
+    /// Transfer is conservative: sender loses exactly what receiver gains, total supply unchanged.
+    #[test]
+    fn prop_transfer_is_conservative() {
+        proptest!(|(mint in 1i128..=1_000_000i128, transfer_pct in 1u32..=100u32)| {
+            let env = Env::default();
+            env.mock_all_auths();
+            let admin = Address::generate(&env);
+            let sender = Address::generate(&env);
+            let receiver = Address::generate(&env);
+            let client = init_token(&env, &admin);
+
+            client.mint(&sender, &mint);
+            let transfer = (mint * transfer_pct as i128) / 100;
+            if transfer == 0 { return Ok(()); }
+
+            client.transfer(&sender, &receiver, &transfer);
+
+            prop_assert_eq!(client.balance(&sender), mint - transfer);
+            prop_assert_eq!(client.balance(&receiver), transfer);
+            prop_assert_eq!(client.total_supply(), mint);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Closes #223

All existing tests use hardcoded inputs. This PR adds property-based testing via `proptest` to both contracts, generating hundreds of random inputs per run to catch edge cases that manual tests miss.

## Changes

**`contracts/token/Cargo.toml` / `contracts/escrow/Cargo.toml`**
- Added `proptest = { version = "1.4", default-features = false, features = ["std"] }` as a dev-dependency

**`contracts/token/src/test.rs`** — 3 new properties:
- `prop_mint_then_burn_restores_balance` — for any valid amount, mint then burn returns balance and total supply to zero
- `prop_total_supply_matches_sum_of_balances` — total supply always equals the sum of all individual balances
- `prop_transfer_is_conservative` — sender loses exactly what receiver gains; total supply is unchanged

**`contracts/escrow/src/test.rs`** — 2 new properties:
- `prop_partial_release_reduces_amount` — partial release reduces stored amount by exactly the released value
- `prop_initialize_always_creates_state` — any valid positive amount always initializes to `Created` state

## Testing

```
cargo test --package soroban-token-template   # 11 passed
cargo test --package soroban-escrow-template  # 12 passed
```