### PR TITLE
test(token): add regression tests for transfer invalid amount validation

### DIFF
--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -197,6 +197,32 @@ fn test_mint_zero_amount() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_transfer_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let other = Address::generate(&env);
+    let client = init_token(&env, &admin);
+    client.mint(&user, &1000i128);
+    client.transfer(&user, &other, &0i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_transfer_negative_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let other = Address::generate(&env);
+    let client = init_token(&env, &admin);
+    client.mint(&user, &1000i128);
+    client.transfer(&user, &other, &-1i128);
+}
+
+#[test]
 fn test_set_admin() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #430

---

Summary
  
  Adds two regression tests to contracts/token/src/test.rs covering the InvalidAmount (#6) error path in transfer_impl for zero and negative amounts — a
  validation path that had no dedicated test coverage.
  
  Changes
  
  - test_transfer_zero_amount — mints 1000 tokens to user, calls client.transfer(&user, &other, &0i128), and asserts the transaction panics with Error.
  - test_transfer_negative_amount — same setup, calls client.transfer(&user, &other, &-1i128), asserts the same Errorpanic.
  
  Test approach
  
  Both tests follow the existing file conventions exactly:
  
  - Use the init_token helper for setup
  - Use env.mock_all_auths()
  - Use #[should_panic(expected = "Error)] matching the pattern of test_mint_zero_amount
  
  No production changes
  
  Zero modifications to production logic, no new imports, no formatting changes.
  