### PR TITLE
test(token): add regression test for unauthorized admin_burn

### DIFF
--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -609,3 +609,17 @@ fn test_burn_more_than_total_supply_returns_overflow() {
     // We test admin_burn since it returns Result (burn panics).
     assert!(client.try_admin_burn(&user, &200i128).is_err());
 }
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_unauthorized_admin_burn_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let client = init_token(&env, &admin);
+    client.mint(&user, &500i128);
+    // clear all auths so the next call has no authorization
+    env.set_auths(&[]);
+    client.admin_burn(&user, &100i128);
+}


### PR DESCRIPTION
Closes #428

---

 Summary
  
  Adds a regression test covering the Unauthorized (#3) error path for admin_burn — previously untested for unauthorized callers.
  
  Change
  
  test_unauthorized_admin_burn_fails in contracts/token/src/test.rs:
  
  1. Initializes the token contract via init_token
  2. Mints 500 tokens to user (requires auth — done before clearing)
  3. Clears all auths with env.set_auths(&[])
  4. Calls client.admin_burn(&user, &100i128) and asserts it panics with Error
  Conventions followed
  
  - Uses init_token helper and env.mock_all_auths() — same as all other tests
  - Uses env.set_auths(&[]) to revoke auth — mirrors test_unauthorized_set_admin_fails
  - Uses #[should_panic(expected = "Error)")]
  
  No production changes
  
  Tests only. No new imports, no formatting changes, no production logic touched.
  
  Files changed
  
  - contracts/token/src/test.rs — 14 lines added