### PR TITLE
test(token): add comprehensive burn_from regression tests

### DIFF
--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -609,3 +609,64 @@ fn test_burn_more_than_total_supply_returns_overflow() {
     // We test admin_burn since it returns Result (burn panics).
     assert!(client.try_admin_burn(&user, &200i128).is_err());
 }
+
+#[test]
+fn test_burn_from() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let client = init_token(&env, &admin);
+    client.mint(&owner, &1000i128);
+    let expiration = env.ledger().sequence() + 100;
+    client.approve(&owner, &spender, &400i128, &expiration);
+
+    client.burn_from(&spender, &owner, &250i128);
+
+    assert_eq!(client.balance(&owner), 750i128);
+    assert_eq!(client.total_supply(), 750i128);
+    assert_eq!(client.allowance(&owner, &spender), 150i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_burn_from_insufficient_allowance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let client = init_token(&env, &admin);
+    client.mint(&owner, &1000i128);
+    let expiration = env.ledger().sequence() + 100;
+    client.approve(&owner, &spender, &100i128, &expiration);
+
+    client.burn_from(&spender, &owner, &101i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_burn_from_expired_allowance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let owner = Address::generate(&env);
+    let spender = Address::generate(&env);
+    let client = init_token(&env, &admin);
+    client.mint(&owner, &1000i128);
+    let expiration = env.ledger().sequence() + 10;
+    client.approve(&owner, &spender, &500i128, &expiration);
+    env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+        timestamp: 0,
+        protocol_version: 22,
+        sequence_number: expiration + 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 1,
+        min_persistent_entry_ttl: 1,
+        max_entry_ttl: 6_312_000,
+    });
+
+    client.burn_from(&spender, &owner, &100i128);
+}


### PR DESCRIPTION
Closes #429

---

Add three tests covering the burn_from implementation:

- test_burn_from: verifies a successful burn decreases owner balance, total supply, and spender allowance by the correct amounts
- test_burn_from_insufficient_allowance: asserts panic with Error(Contract, #2) when burn amount exceeds approved allowance
- test_burn_from_expired_allowance: advances ledger past expiration and asserts panic with Error(Contract, #2)

All tests use init_token helper, mock_all_auths, and the LedgerInfo advance pattern from test_expired_allowance. No production changes.