### PR TITLE
chore: add secrets management hygiene and pre-commit hook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 HORIZON_URL=https://horizon-testnet.stellar.org
 NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 
+# ── Signing keys (NEVER commit real values) ───────────────────────────────────
+# Paste your Stellar secret key here for local use only.
+# Generate a throwaway testnet keypair: stellar keys generate --network testnet dev-key
+STELLAR_SECRET_KEY=your-stellar-secret-key-here
+
 # ── Local Stellar node (docker-compose.yml) ───────────────────────────────────
 LOCAL_RPC_PORT=8000
 LOCAL_HORIZON_PORT=8001

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit
+# Blocks commits that contain common secret patterns or stage a .env file.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks
+#   chmod +x .githooks/pre-commit
+
+set -euo pipefail
+
+STAGED=$(git diff --cached --name-only)
+
+# ── 1. Block staged .env files ────────────────────────────────────────────────
+for f in $STAGED; do
+  if [[ "$f" == ".env" || "$f" == *"/.env" ]]; then
+    echo "ERROR: Attempt to commit a .env file: $f" >&2
+    echo "       Remove it with: git reset HEAD $f" >&2
+    exit 1
+  fi
+done
+
+# ── 2. Scan staged content for secret patterns ────────────────────────────────
+PATTERNS=(
+  'S[A-Z2-7]{55}'                        # Stellar secret key (S + 55 base32 chars)
+  'PRIVATE[_\s-]?KEY'                    # generic private key label
+  '[a-z0-9]{24}\.[a-z0-9]{6}\.[a-z0-9_-]{27}'  # Discord bot token
+  'Bearer\s+[A-Za-z0-9\-._~+/]+=*'      # Bearer token
+  'sk-[A-Za-z0-9]{32,}'                  # OpenAI / Stripe secret key
+  'ghp_[A-Za-z0-9]{36}'                  # GitHub personal access token
+  'xox[baprs]-[A-Za-z0-9\-]+'           # Slack token
+  '\bmnemonic\b.*\b(word|phrase|seed)\b' # mnemonic seed phrase label
+)
+
+COMBINED=$(printf '%s|' "${PATTERNS[@]}")
+COMBINED="${COMBINED%|}"  # strip trailing pipe
+
+if git diff --cached -U0 | grep -qEi "$COMBINED"; then
+  echo "ERROR: Staged changes appear to contain a secret or private key." >&2
+  echo "       Review the diff with: git diff --cached" >&2
+  echo "       If this is a false positive, commit with: git commit --no-verify" >&2
+  exit 1
+fi
+
+exit 0

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -127,3 +127,36 @@ rustup target add wasm32-unknown-unknown
 **Freighter wallet not connecting**
 - Install the [Freighter extension](https://freighter.app)
 - Switch Freighter to the matching network (Testnet / Mainnet)
+
+---
+
+## Secrets Management
+
+### Golden rules
+
+- **Never commit `.env`** — it is listed in `.gitignore`. If you accidentally stage it, run `git reset HEAD .env`.
+- **Never commit real keys, mnemonics, or tokens** — not even in comments or test fixtures.
+- **`.env.example` is the source of truth** for which variables exist. It must contain only placeholder values (e.g. `SXXX…`, `your-api-key-here`).
+- **Rotate immediately** if a secret is ever pushed to a remote branch. Treat the key as permanently compromised regardless of whether the commit was later removed.
+
+### Local setup
+
+```bash
+cp .env.example .env   # create your local config from the template
+# edit .env and fill in real values — this file is gitignored
+```
+
+### Sharing configuration between developers
+
+Share the *shape* of config (variable names, descriptions) via `.env.example`. Share actual values through a secrets manager (e.g. AWS Secrets Manager, 1Password, Doppler) or an encrypted channel — never via chat, email, or a repository.
+
+### Pre-commit hook
+
+A sample hook lives at `.githooks/pre-commit`. Enable it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+chmod +x .githooks/pre-commit
+```
+
+The hook blocks commits that contain common secret patterns (Stellar secret keys, mnemonics, bearer tokens, API keys) or that stage a `.env` file directly.


### PR DESCRIPTION
Closes #427

---

Summary
  
  Three lightweight, documentation/configuration-only changes to improve secret hygiene and developer onboarding around environment variables.
  
  Changes
  
  .env.example
  
  - Added STELLAR_SECRET_KEY=your-stellar-secret-key-here with a prominent NEVER commit real values comment and a tip for generating a throwaway testnet keypair.
  - All other values were already safe public testnet defaults — no changes needed.
  
  docs/dev-environment.md — new "Secrets Management" section
  
  Covers:
  
  - Golden rules (never commit .env, never commit real keys, rotate immediately if leaked)
  - Local setup (cp .env.example .env)
  - How to share config between developers (secrets manager, not chat/email/repo)
  - How to enable the pre-commit hook
  
  .githooks/pre-commit (new, executable)
  
  Blocks commits that:
  
  1. Stage a .env file directly
  2. Contain content matching common secret patterns:
    - Stellar secret keys (S + 55 base32 chars)
    - Generic PRIVATE_KEY labels
    - Discord bot tokens
    - Bearer tokens
    - OpenAI / Stripe sk- keys
    - GitHub PATs (ghp_)
    - Slack tokens (xox*)
    - Mnemonic seed phrase labels
  
  Escape hatch for false positives: git commit --no-verify.
  
  Enable once per clone:
  
  git config core.hooksPath .githooks
  chmod +x .githooks/pre-commit
  
  No production or test changes
  
  Documentation and configuration only. Does not affect builds, tests, or CI.
  
  Files changed
  
  ┌─────────────────────────┬───────────────────────────────────────┐
  │ File                    │ Change                                │
  ├─────────────────────────┼───────────────────────────────────────┤
  │ .env.example            │ +5 lines (key placeholder + comments) │
  ├─────────────────────────┼───────────────────────────────────────┤
  │ docs/dev-environment.md │ +33 lines (new section)               │
  ├─────────────────────────┼───────────────────────────────────────┤
  │ .githooks/pre-commit    │ +44 lines (new file, executable)      │
  └─────────────────────────┴───────────────────────────────────────┘