### PR TITLE
test(escrow): add initialize amount validation tests

### DIFF
--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -184,6 +184,38 @@ fn test_initialize_past_deadline() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_initialize_zero_amount_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token = create_mock_token(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    let (client, _) = create_escrow_contract(&env);
+    client.initialize(&buyer, &seller, &arbiter, &token, &0, &deadline);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_initialize_negative_amount_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token = create_mock_token(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    let (client, _) = create_escrow_contract(&env);
+    client.initialize(&buyer, &seller, &arbiter, &token, &-1, &deadline);
+}
+
+#[test]
 fn test_initialize_escrow() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #438

---

Add two tests covering the InvalidAmount (#8) guard in initialize():

- test_initialize_zero_amount_fails: passes amount=0, expects Error(Contract, #8) panic.
- test_initialize_negative_amount_fails: passes amount=-1, expects Error(Contract, #8) panic.

Both reuse existing helpers (create_escrow_contract, create_mock_token) and follow the #[should_panic(expected = ...)] convention. No production code modified.