### PR TITLE
test(escrow): add initialize party uniqueness validation tests

### DIFF
--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -184,6 +184,45 @@ fn test_initialize_past_deadline() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_initialize_buyer_equals_seller_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let same = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token = create_mock_token(&env);
+    let deadline = env.ledger().sequence() + 100;
+    let (client, _) = create_escrow_contract(&env);
+    client.initialize(&same, &same, &arbiter, &token, &1_000, &deadline);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_initialize_buyer_equals_arbiter_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let same = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token = create_mock_token(&env);
+    let deadline = env.ledger().sequence() + 100;
+    let (client, _) = create_escrow_contract(&env);
+    client.initialize(&same, &seller, &same, &token, &1_000, &deadline);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_initialize_seller_equals_arbiter_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let buyer = Address::generate(&env);
+    let same = Address::generate(&env);
+    let token = create_mock_token(&env);
+    let deadline = env.ledger().sequence() + 100;
+    let (client, _) = create_escrow_contract(&env);
+    client.initialize(&buyer, &same, &same, &token, &1_000, &deadline);
+}
+
+#[test]
 fn test_initialize_escrow() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
Closes #437

---

Add three tests covering the InvalidParties (#9) guard in initialize(), which rejects escrows where any two of buyer/seller/arbiter are identical:

- test_initialize_buyer_equals_seller_fails: buyer == seller → #9
- test_initialize_buyer_equals_arbiter_fails: buyer == arbiter → #9
- test_initialize_seller_equals_arbiter_fails: seller == arbiter → #9

All tests reuse create_escrow_contract and create_mock_token helpers and follow the existing #[should_panic(expected = ...)] convention. No production code modified.