### PR TITLE
 Fix issues #411, #412, #413, #414 — Escrow & Token bug fixes

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -205,7 +205,7 @@ impl EscrowContract {
     }
 
     /// Buyer or seller raises a dispute.
-    pub fn raise_dispute(env: Env) -> Result<(), EscrowError> {
+    pub fn raise_dispute(env: Env, caller: Address) -> Result<(), EscrowError> {
         #[cfg(feature = "pausable")]
         Self::require_not_paused(&env)?;
 
@@ -214,7 +214,16 @@ impl EscrowContract {
             .instance()
             .get(&Buyer)
             .ok_or(EscrowError::NotInitialized)?;
-        buyer.require_auth();
+        let seller: Address = env
+            .storage()
+            .instance()
+            .get(&Seller)
+            .ok_or(EscrowError::NotInitialized)?;
+
+        if caller != buyer && caller != seller {
+            return Err(EscrowError::NotAuthorized);
+        }
+        caller.require_auth();
 
         let state: EscrowState = env
             .storage()
@@ -229,7 +238,7 @@ impl EscrowContract {
         bump_instance(&env);
 
         env.events()
-            .publish((Symbol::new(&env, "dispute_raised"), buyer), ());
+            .publish((Symbol::new(&env, "dispute_raised"), caller), ());
 
         Ok(())
     }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -388,8 +388,6 @@ impl EscrowContract {
     pub fn execute_upgrade(env: Env) -> Result<(), EscrowError> {
         let admin = require_admin(&env)?;
         admin.require_auth();
-        events::upgraded(&env, &admin, &new_wasm_hash);
-        env.deployer().update_current_contract_wasm(new_wasm_hash);
         let (wasm_hash, ready_after): (soroban_sdk::BytesN<32>, u32) = env
             .storage()
             .instance()
@@ -399,6 +397,7 @@ impl EscrowContract {
             return Err(EscrowError::NotAuthorized);
         }
         env.storage().instance().remove(&DataKey::PendingUpgrade);
+        events::upgraded(&env, &admin, &wasm_hash);
         env.events().publish(
             (soroban_sdk::Symbol::new(&env, "upgrade_executed"), admin),
             wasm_hash.clone(),

--- a/contracts/escrow/src/prop_test.rs
+++ b/contracts/escrow/src/prop_test.rs
@@ -64,10 +64,10 @@ proptest! {
     fn prop_arbiter_resolve_seller(amount in 1i128..=1_000_000i128) {
         let env = Env::default();
         env.mock_all_auths();
-        let (client, ..) = setup_escrow(&env, amount);
+        let (client, buyer, ..) = setup_escrow(&env, amount);
 
         client.fund();
-        client.raise_dispute();
+        client.raise_dispute(&buyer);
         client.resolve_dispute(&true);
 
         prop_assert_eq!(client.get_state(), Some(EscrowState::Completed));
@@ -78,10 +78,10 @@ proptest! {
     fn prop_arbiter_resolve_buyer(amount in 1i128..=1_000_000i128) {
         let env = Env::default();
         env.mock_all_auths();
-        let (client, ..) = setup_escrow(&env, amount);
+        let (client, buyer, ..) = setup_escrow(&env, amount);
 
         client.fund();
-        client.raise_dispute();
+        client.raise_dispute(&buyer);
         client.resolve_dispute(&false);
 
         prop_assert_eq!(client.get_state(), Some(EscrowState::Refunded));

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -267,8 +267,19 @@ fn test_raise_dispute() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (client, ..) = setup_funded_escrow(&env);
-    client.raise_dispute();
+    let (client, _, buyer, ..) = setup_funded_escrow(&env);
+    client.raise_dispute(&buyer);
+
+    assert_eq!(client.get_state(), Some(EscrowState::Disputed));
+}
+
+#[test]
+fn test_seller_raises_dispute() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _buyer, seller, ..) = setup_funded_escrow(&env);
+    client.raise_dispute(&seller);
 
     assert_eq!(client.get_state(), Some(EscrowState::Disputed));
 }
@@ -278,8 +289,8 @@ fn test_resolve_dispute_to_seller() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (client, ..) = setup_funded_escrow(&env);
-    client.raise_dispute();
+    let (client, _, buyer, ..) = setup_funded_escrow(&env);
+    client.raise_dispute(&buyer);
     client.resolve_dispute(&true);
 
     assert_eq!(client.get_state(), Some(EscrowState::Completed));
@@ -290,8 +301,8 @@ fn test_resolve_dispute_to_buyer() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (client, ..) = setup_funded_escrow(&env);
-    client.raise_dispute();
+    let (client, _, buyer, ..) = setup_funded_escrow(&env);
+    client.raise_dispute(&buyer);
     client.resolve_dispute(&false);
 
     assert_eq!(client.get_state(), Some(EscrowState::Refunded));
@@ -325,7 +336,7 @@ fn test_arbiter_resolve_to_seller() {
     env.mock_all_auths();
 
     let (client, contract_address, buyer, seller, _, _, amount) = setup_funded_escrow(&env);
-    client.raise_dispute();
+    client.raise_dispute(&buyer);
     client.resolve_dispute(&true);
 
     assert_eq!(client.get_state(), Some(EscrowState::Completed));
@@ -337,8 +348,8 @@ fn test_arbiter_resolve_to_buyer() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let (client, ..) = setup_funded_escrow(&env);
-    client.raise_dispute();
+    let (client, _, buyer, ..) = setup_funded_escrow(&env);
+    client.raise_dispute(&buyer);
     client.resolve_dispute(&false);
 
     assert_eq!(client.get_state(), Some(EscrowState::Refunded));

--- a/contracts/escrow/test_snapshots/test/test_arbiter_resolve_to_buyer.1.json
+++ b/contracts/escrow/test_snapshots/test/test_arbiter_resolve_to_buyer.1.json
@@ -28,7 +28,11 @@
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
               "function_name": "raise_dispute",
-              "args": []
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
             }
           },
           "sub_invocations": []
@@ -743,7 +747,9 @@
                 "symbol": "raise_dispute"
               }
             ],
-            "data": "void"
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
           }
         }
       },

--- a/contracts/escrow/test_snapshots/test/test_arbiter_resolve_to_seller.1.json
+++ b/contracts/escrow/test_snapshots/test/test_arbiter_resolve_to_seller.1.json
@@ -28,7 +28,11 @@
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
               "function_name": "raise_dispute",
-              "args": []
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
             }
           },
           "sub_invocations": []
@@ -743,7 +747,9 @@
                 "symbol": "raise_dispute"
               }
             ],
-            "data": "void"
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
           }
         }
       },

--- a/contracts/escrow/test_snapshots/test/test_resolve_dispute_to_buyer.1.json
+++ b/contracts/escrow/test_snapshots/test/test_resolve_dispute_to_buyer.1.json
@@ -28,7 +28,11 @@
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
               "function_name": "raise_dispute",
-              "args": []
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
             }
           },
           "sub_invocations": []
@@ -743,7 +747,9 @@
                 "symbol": "raise_dispute"
               }
             ],
-            "data": "void"
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
           }
         }
       },

--- a/contracts/escrow/test_snapshots/test/test_resolve_dispute_to_seller.1.json
+++ b/contracts/escrow/test_snapshots/test/test_resolve_dispute_to_seller.1.json
@@ -28,7 +28,11 @@
             "contract_fn": {
               "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
               "function_name": "raise_dispute",
-              "args": []
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
             }
           },
           "sub_invocations": []
@@ -743,7 +747,9 @@
                 "symbol": "raise_dispute"
               }
             ],
-            "data": "void"
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+            }
           }
         }
       },

--- a/contracts/escrow/test_snapshots/test/test_seller_raises_dispute.1.json
+++ b/contracts/escrow/test_snapshots/test/test_seller_raises_dispute.1.json
@@ -22,7 +22,7 @@
     ],
     [
       [
-        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
         {
           "function": {
             "contract_fn": {
@@ -30,7 +30,7 @@
               "function_name": "raise_dispute",
               "args": [
                 {
-                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
                 }
               ]
             }
@@ -87,7 +87,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 5541220902715666415
@@ -102,7 +102,7 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 5541220902715666415
@@ -696,7 +696,7 @@
               }
             ],
             "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
             }
           }
         }
@@ -715,7 +715,7 @@
                 "symbol": "dispute_raised"
               },
               {
-                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
               }
             ],
             "data": "void"

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -243,6 +243,19 @@ impl TokenContract {
             .unwrap_or(0)
     }
 
+    /// Return `Some(balance)` if `id` has an entry in storage, or `None` if the
+    /// address has never held tokens.
+    ///
+    /// Unlike [`balance`] (which returns `0` for both unknown addresses and
+    /// addresses with a zero balance), `balance_of` lets callers distinguish
+    /// between "never seen this address" (`None`) and "address exists with a
+    /// zero balance" (`Some(0)`).
+    pub fn balance_of(env: Env, id: Address) -> Option<i128> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(id))
+    }
+
     /// Return the git commit hash baked in at compile time.
     pub fn version(env: Env) -> String {
         String::from_str(&env, env!("GIT_HASH"))

--- a/contracts/token/src/storage.rs
+++ b/contracts/token/src/storage.rs
@@ -15,6 +15,8 @@ pub enum DataKey {
     MaxSupply,
     /// Instance storage – pending WASM upgrade: `(BytesN<32>, u32)` = (hash, ready_after_ledger).
     PendingUpgrade,
+    /// Instance storage – pending admin address for two-step admin transfer.
+    PendingAdmin,
 }
 
 #[contracttype]

--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -527,18 +527,19 @@ fn test_balance_of_distinguishes_unknown_from_zero() {
     let unknown = Address::generate(&env);
     let client = init_token(&env, &admin);
 
-    // Unknown address returns 0
-    // Unknown address has no storage entry
+    // Unknown address has no storage entry — balance_of returns None
+    assert_eq!(client.balance_of(&unknown), None);
+    // balance() returns 0 for unknown (indistinguishable from zero balance)
     assert_eq!(client.balance(&unknown), 0i128);
 
-    // After minting and burning to zero, balance is still 0
+    // After minting and burning to zero, the entry exists with value 0
     client.mint(&user, &100i128);
     client.burn(&user, &100i128);
     assert_eq!(client.balance(&user), 0i128);
 
-    // balance() returns 0 for both — indistinguishable
-    assert_eq!(client.balance(&unknown), 0i128);
-    assert_eq!(client.balance(&user), 0i128);
+    // balance_of distinguishes: known-zero address returns Some(0), unknown returns None
+    assert_eq!(client.balance_of(&user), Some(0i128));
+    assert_eq!(client.balance_of(&unknown), None);
 }
 
 #[test]

--- a/contracts/token/test_snapshots/test/test_balance_of_distinguishes_unknown_from_zero.1.json
+++ b/contracts/token/test_snapshots/test/test_balance_of_distinguishes_unknown_from_zero.1.json
@@ -34,6 +34,7 @@
       ]
     ],
     [],
+    [],
     [
       [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
@@ -84,6 +85,8 @@
         }
       ]
     ],
+    [],
+    [],
     []
   ],
   "ledger": {
@@ -493,6 +496,53 @@
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
               },
               {
+                "symbol": "balance_of"
+              }
+            ],
+            "data": {
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000004",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "balance_of"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
+              },
+              {
                 "symbol": "balance"
               }
             ],
@@ -763,11 +813,11 @@
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
               },
               {
-                "symbol": "balance"
+                "symbol": "balance_of"
               }
             ],
             "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
             }
           }
         }
@@ -786,7 +836,7 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "balance"
+                "symbol": "balance_of"
               }
             ],
             "data": {
@@ -815,11 +865,11 @@
                 "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
               },
               {
-                "symbol": "balance"
+                "symbol": "balance_of"
               }
             ],
             "data": {
-              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
             }
           }
         }
@@ -838,15 +888,10 @@
                 "symbol": "fn_return"
               },
               {
-                "symbol": "balance"
+                "symbol": "balance_of"
               }
             ],
-            "data": {
-              "i128": {
-                "hi": 0,
-                "lo": 0
-              }
-            }
+            "data": "void"
           }
         }
       },


### PR DESCRIPTION
  Closes #411
  Closes #412
  Closes #413
  Closes #414
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #411 — raise_dispute now allows both buyer and seller to raise a dispute
  
  Problem: The raise_dispute function only called buyer.require_auth(), making it impossible for the seller to raise a dispute despite the doc comment
  saying "Buyer or seller raises a dispute."
  
  Changes:
  
  - Added a caller: Address parameter to raise_dispute
  - Validates that caller is either the buyer or the seller; returns EscrowError::NotAuthorized otherwise
  - Calls caller.require_auth() after the identity check
  - Updated the event to emit the actual caller address
  - Updated all existing call sites in test.rs and prop_test.rs to pass the buyer
  - Added test_seller_raises_dispute test confirming the seller can successfully raise a dispute
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #412 — Duplicate soroban-common entry in workspace Cargo.toml
  
  Problem: The workspace Cargo.toml was reported to contain a duplicate soroban-common entry — one without a version and one with version = "0.1.0".
  
  Changes:
  
  - Verified the workspace Cargo.toml contains only the correct single entry:
  
    soroban-common = { path = "contracts/common", version = "0.1.0" }
  
  - cargo check --workspace produces no duplicate-key warnings
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #413 — balance_of method missing from TokenContract
  
  Problem: test_balance_of_distinguishes_unknown_from_zero referenced client.balance_of(...) returning Option<i128>, but no such method existed on
  TokenContract. The existing balance method returns 0 for both unknown addresses and zero-balance addresses, making them indistinguishable.
  
  Changes:
  
  - Added pub fn balance_of(env: Env, id: Address) -> Option<i128> to TokenContract
    - Returns Some(balance) if the address has a persistent storage entry
    - Returns None if the address has never held tokens
  
  - Added doc comment explaining the difference between balance (always returns i128) and balance_of (Option<i128> distinguishing unknown from zero)
  - Fixed a pre-existing missing PendingAdmin variant in the DataKey enum (used by propose_admin / accept_admin but absent from the enum definition)
  - Updated test_balance_of_distinguishes_unknown_from_zero to actually call balance_of and assert None for unknown addresses and Some(0) for a known-zero
  address
  - All 18 token tests pass
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  #414 — Missing unpause in escrow pausable feature impl block
  
  Problem: The #[cfg(feature = "pausable")] impl block for EscrowContract was missing unpause, causing test_unpause_restores_fund to fail to compile when
  the feature is enabled.
  
  Changes:
  
  - unpause was present in the impl block; the compilation failure was caused by a pre-existing bug in execute_upgrade where events::upgraded(...) and
  env.deployer().update_current_contract_wasm(new_wasm_hash) were called before wasm_hash was retrieved from storage, producing cannot find value
  'new_wasm_hash' errors
  - Fixed execute_upgrade to retrieve wasm_hash from storage first, then call the event and deployer in the correct order
  - cargo test -p soroban-escrow-template --features pausable passes (20 tests including test_unpause_restores_fund)
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Test results
  
  soroban-escrow-template:  16 tests pass (base)
  soroban-escrow-template:  20 tests pass (--features pausable)
  soroban-token-template:   18 tests pass