### PR TITLE
Fix/min deadline buffer constant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "tests", "fuzz"]
 members = ["contracts/common", "contracts/token", "contracts/escrow", "tests"]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A curated collection of production-ready Soroban smart contract templates. These
 git clone https://github.com/your-username/soroban-contract-templates.git
 cd soroban-contract-templates
 
-# Build a contract (example: token)
-cd contracts/token
-stellar contract build
+# Build a contract from the repo root (example: token)
+stellar contract build --manifest-path contracts/token/Cargo.toml
+# Alternatively: cd contracts/token && stellar contract build
 
 # Deploy to testnet
 ./scripts/deploy.sh testnet

--- a/contracts/common/src/lib.rs
+++ b/contracts/common/src/lib.rs
@@ -2,6 +2,11 @@
 
 use soroban_sdk::{contracttype, Address, Env};
 
+/// Minimum number of ledgers the deadline must be ahead of the current ledger
+/// when initializing an escrow. Enforced by the contract; tests must respect
+/// this value to avoid generating deadlines the contract would reject.
+pub const MIN_DEADLINE_BUFFER: u32 = 10;
+
 /// Storage key for the contract administrator address.
 ///
 /// Used in instance storage to persist the admin [`Address`] across invocations.

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -11,6 +11,7 @@ pub use errors::EscrowError;
 pub use storage::{DataKey, EscrowInfo, EscrowState};
 
 use admin::require_admin;
+use soroban_common::MIN_DEADLINE_BUFFER;
 use storage::DataKey::*;
 
 /// Extend storage TTL when remaining ledgers fall below this threshold.
@@ -18,9 +19,6 @@ const LEDGER_LIFETIME_THRESHOLD: u32 = 120_960;
 
 /// Target TTL (in ledgers) after each extension.
 const LEDGER_BUMP_AMOUNT: u32 = 518_400;
-
-/// Minimum number of ledgers the deadline must be in the future.
-const MIN_DEADLINE_BUFFER: u32 = 10;
 
 fn bump_instance(env: &Env) {
     env.storage()

--- a/contracts/escrow/src/prop_test.rs
+++ b/contracts/escrow/src/prop_test.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{
 
 use crate::{EscrowContract, EscrowContractClient, EscrowState};
 
-const MIN_DEADLINE_BUFFER: u32 = 100;
+use soroban_common::MIN_DEADLINE_BUFFER;
 
 fn setup_escrow<'a>(
     env: &'a Env,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -4,17 +4,12 @@ version = "0.1.0"
 edition = "2021"
 authors.workspace = true
 license.workspace = true
-
-[dependencies]
-soroban-sdk = { workspace = true, features = ["testutils"] }
-soroban-escrow-template = { path = "../contracts/escrow" }
-soroban-token-template = { path = "../contracts/token" }
 publish = false
 
 [dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
-soroban-token-template = { path = "../contracts/token" }
 soroban-escrow-template = { path = "../contracts/escrow" }
+soroban-token-template = { path = "../contracts/token" }
 
 [[test]]
 name = "integration"


### PR DESCRIPTION
- Added `pub const MIN_DEADLINE_BUFFER: u32 = 10` to
  `contracts/common/src/lib.rs`
  - Removed local constant from `escrow/src/lib.rs`; now imports from
  `soroban_common`
  - Removed local constant from `escrow/src/prop_test.rs`; now imports from
  `soroban_common`
  - Fixed pre-existing duplicate keys in `Cargo.toml` and `tests/Cargo.toml`
  that blocked workspace builds
   
  Closes #477