### PR TITLE
docs: expand CONTRIBUTING.md and add full v0.1.0 CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This CHANGELOG file (#231)
 - Terraform provider version pinning and `.terraform` directory caching between plan and apply jobs (#242)
 
-## [1.0.0] - 2026-04-24
+## [0.1.0] - 2026-04-24
+
+Initial public release of the Soroban Starter Kit.
 
 ### Added
-- Token contract with mint, burn, transfer, approve, and admin controls
-- Escrow contract with buyer/seller/arbiter roles, deadline enforcement, and dispute resolution
-- Shared `common` crate for reusable types and utilities
-- Comprehensive unit tests for both contracts (8+ cases each)
-- Property-based tests via `proptest`
-- Test snapshots for deterministic ledger state verification
-- Deployment scripts for testnet and local network
-- Docker Compose setup for local Stellar node with Soroban RPC
-- Dev container configuration for reproducible development environments
-- Architecture Decision Records (ADRs) covering storage tiers, error handling, admin model, and escrow state machine
-- CI workflow with test, build, and WASM artifact upload jobs
-- Benchmark suite for escrow and token operations
 
-[Unreleased]: https://github.com/Fidelis900/soroban-starter-kit/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/Fidelis900/soroban-starter-kit/releases/tag/v1.0.0
+#### Token Contract (`contracts/token`)
+- `initialize` — sets admin, name, symbol, decimals, and optional supply cap; guards against double-initialization
+- `mint` — admin-only minting with overflow protection via `checked_add`
+- `burn` / `burn_from` — self-service and allowance-based token burning
+- `admin_burn` — admin-initiated burn from any address
+- `transfer` / `transfer_from` — SEP-41 / `TokenInterface`-compliant transfers with allowance enforcement
+- `approve` — time-bounded allowances stored in temporary storage; emits revocation event when amount is zero
+- `balance` / `balance_of` — `balance` returns `0` for unknown addresses; `balance_of` returns `Option<i128>` to distinguish unknown from zero-balance addresses
+- `total_supply` — returns current circulating supply
+- `propose_admin` / `accept_admin` / `cancel_admin_transfer` — two-step admin handover to prevent accidental loss of admin access
+- `set_admin` — single-step admin transfer kept for backwards compatibility (deprecated)
+- `version` — returns the git commit hash baked in at compile time via `build.rs`
+- `pausable` feature flag — adds `pause` / `unpause` entry points (admin only); blocks `mint`, `burn`, `transfer`, and `transfer_from` while paused
+- `upgradeable` feature flag — adds `propose_upgrade` / `execute_upgrade` with a ~24-hour timelock (17 280 ledgers) before a WASM upgrade can be applied
+- `capped-supply` feature flag — adds `max_supply` entry point and enforces a hard cap on `mint`
+- Automatic TTL extension for instance and persistent storage entries
+
+#### Escrow Contract (`contracts/escrow`)
+- `initialize` — sets buyer, seller, arbiter, token contract, amount, and deadline; validates token address by calling `decimals()`; enforces distinct party addresses and a minimum deadline buffer
+- `fund` — buyer transfers tokens to the contract, advancing state from `Created` to `Funded`
+- `mark_delivered` — seller signals delivery, advancing state to `Delivered`
+- `approve_delivery` — buyer releases escrowed funds to the seller
+- `request_refund` — buyer reclaims funds after the deadline has passed
+- `raise_dispute` — buyer or seller escalates to `Disputed` state
+- `resolve_dispute` — arbiter resolves a dispute, releasing funds to either party
+- `cancel` — buyer cancels an unfunded escrow (`Created` state only)
+- `bump` — public TTL extension so any party can keep an active escrow alive
+- `get_escrow_info` — returns full escrow details as an `EscrowInfo` struct
+- `get_state` — returns `Option<EscrowState>` (returns `None` before initialization)
+- `is_deadline_passed` — convenience predicate for deadline checks
+- State machine: `Created → Funded → Delivered → Completed`, with exits to `Refunded` and `Cancelled`
+- Checks-effects-interactions pattern enforced on all token transfer paths
+- `pausable` feature flag — adds `pause` / `unpause` (admin only); blocks `fund`, `mark_delivered`, `approve_delivery`, `request_refund`, and `raise_dispute` while paused
+- `upgradeable` feature flag — adds `propose_upgrade` / `execute_upgrade` with a ~24-hour timelock
+
+#### Shared `common` Crate (`contracts/common`)
+- `AdminKey` storage key enum for consistent admin address storage
+- `get_admin` / `try_get_admin` — panic and `Option`-returning admin accessors
+- `get_instance` — generic typed instance-storage getter
+- `extend_ttl_instance` / `extend_ttl_persistent` — reusable TTL extension helpers
+
+#### Testing
+- Unit test suites for both contracts (8+ cases each) covering happy paths, error conditions, and edge cases
+- Property-based tests via `proptest` for fuzz-style validation of token and escrow invariants
+- Test snapshots under `test_snapshots/` for deterministic ledger state verification
+- Integration test crate under `tests/`
+
+#### CI / Tooling
+- GitHub Actions workflow with test, build, and WASM artifact upload jobs
+- `cargo audit` security scanning
+- Benchmark suite (`benches/`) for escrow and token operations using `criterion`
+- `build.rs` in each contract crate to embed `GIT_HASH` at compile time
+- Docker Compose setup for a local Stellar node with Soroban RPC
+- Dev container configuration (`.devcontainer/`) for reproducible development environments
+- Deployment scripts (`scripts/deploy.sh`) for testnet and local network
+
+#### Documentation
+- Architecture Decision Records (ADRs) covering storage tiers, error handling, admin model, and escrow state machine
+- `README.md` with quick-start guide, contract template table, and error reference
+- `CONTRIBUTING.md` with dev setup, test instructions, code style, and PR process
+- `SECURITY.md` with vulnerability disclosure policy
+
+[Unreleased]: https://github.com/Fidelis900/soroban-starter-kit/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Fidelis900/soroban-starter-kit/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,65 +1,214 @@
 # Contributing to Soroban Starter Kit
 
+Thanks for taking the time to contribute. This guide covers everything you need to get set up, write good code, and get your changes merged.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Dev Environment Setup](#dev-environment-setup)
+- [Running Tests](#running-tests)
+- [Code Style](#code-style)
+- [Adding a New Contract Template](#adding-a-new-contract-template)
+- [PR Checklist](#pr-checklist)
+- [Issue Labelling Conventions](#issue-labelling-conventions)
+- [PR Review Process](#pr-review-process)
+
+---
+
 ## Prerequisites
 
-- [Rust](https://rustup.rs/) (latest stable) with `wasm32-unknown-unknown` target
-- [Stellar CLI](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli)
-- [Docker](https://www.docker.com/) (for local node)
+| Tool | Version | Install |
+|------|---------|---------|
+| Rust | latest stable | [rustup.rs](https://rustup.rs/) |
+| wasm32 target | — | `rustup target add wasm32-unknown-unknown` |
+| Stellar CLI | latest | [docs](https://developers.stellar.org/docs/tools/developer-tools/cli/stellar-cli) |
+| Docker | 24+ | [docker.com](https://www.docker.com/) |
 
 ```bash
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Add the WASM compilation target
 rustup target add wasm32-unknown-unknown
+
+# Install Stellar CLI
 cargo install stellar-cli
 ```
 
-## Dev Setup
+---
+
+## Dev Environment Setup
+
+### Option A — Local
 
 ```bash
 git clone https://github.com/Fidelis900/soroban-starter-kit.git
 cd soroban-starter-kit
-```
 
-Start a local Stellar node:
-
-```bash
+# Start a local Stellar node with Soroban RPC
 docker compose up stellar-node
 ```
 
-## Test Commands
+### Option B — Dev Container
 
-Run tests for a specific contract:
+Open the repo in VS Code and select **Reopen in Container** when prompted. The `.devcontainer/devcontainer.json` configuration installs all prerequisites automatically.
+
+### Environment Variables
+
+Copy the example env file and fill in any values you need for local deployment:
+
+```bash
+cp .env.example .env
+```
+
+---
+
+## Running Tests
+
+### Unit tests for a single contract
 
 ```bash
 cd contracts/token   # or contracts/escrow
 cargo test
 ```
 
-Run all contract tests from the repo root:
+### All workspace tests
 
 ```bash
 cargo test --workspace
 ```
 
-## Code Style
+### Tests with a specific feature flag
 
-- Follow standard Rust conventions (`rustfmt`, `clippy`)
-- Run before committing:
+Both contracts support optional Cargo features (`pausable`, `upgradeable`, `capped-supply` for token). To test with a feature enabled:
 
 ```bash
+cargo test -p soroban-token-template --features pausable
+cargo test -p soroban-escrow-template --features pausable,upgradeable
+```
+
+### Property-based tests
+
+Property tests live in `prop_test.rs` inside each contract and run as part of the normal `cargo test` suite. They use the `proptest` crate and run a configurable number of random cases.
+
+### Benchmarks
+
+```bash
+cargo bench -p benches
+```
+
+### Build WASM artifacts
+
+```bash
+cargo build --target wasm32-unknown-unknown --release -p soroban-token-template
+cargo build --target wasm32-unknown-unknown --release -p soroban-escrow-template
+```
+
+---
+
+## Code Style
+
+Follow standard Rust conventions. Run these before every commit:
+
+```bash
+# Format
 cargo fmt --all
+
+# Lint (warnings are treated as errors in CI)
 cargo clippy --all-targets -- -D warnings
 ```
 
-## PR Process
+Additional conventions:
 
-1. Fork the repo and create a branch: `git checkout -b feat/your-feature`
-2. Make your changes with tests covering new functionality
-3. Ensure `cargo fmt`, `cargo clippy`, and `cargo test` all pass
-4. Open a pull request against `main` with a clear description of the change
-5. Address any review feedback before merge
+- `unsafe` code is forbidden workspace-wide (`unsafe_code = "forbid"`).
+- Public functions must have doc comments explaining parameters, errors, and preconditions.
+- Use `Result<T, ContractError>` for all fallible contract entry points — never `unwrap` in production paths.
+- Keep storage key enums in `storage.rs`; keep event helpers in `events.rs`.
+- Prefer `checked_add` / `checked_sub` over raw arithmetic to avoid silent overflow.
+
+---
 
 ## Adding a New Contract Template
 
-- Place the contract under `contracts/<name>/`
-- Include a `scripts/deploy.sh` using the `stellar` CLI
-- Add at least 8 test cases in the contract's test module
-- Update the template table in `README.md`
+Follow these steps to add a contract that fits the existing project structure:
+
+1. **Scaffold the crate**
+
+   ```bash
+   mkdir -p contracts/<name>/src/bin
+   ```
+
+   Create a `Cargo.toml` modelled on `contracts/token/Cargo.toml`. Add the new crate to the workspace `members` list in the root `Cargo.toml`.
+
+2. **Required source files**
+
+   | File | Purpose |
+   |------|---------|
+   | `src/lib.rs` | Contract entry points (`#[contract]`, `#[contractimpl]`) |
+   | `src/storage.rs` | `DataKey` enum and storage helper types |
+   | `src/errors.rs` | Contract-specific error enum |
+   | `src/events.rs` | Event emission helpers |
+   | `src/admin.rs` | Admin auth helpers (can re-export from `soroban-common`) |
+   | `src/test.rs` | Unit tests (minimum 8 cases) |
+   | `src/prop_test.rs` | Property-based tests using `proptest` |
+   | `src/bin/deploy.rs` | CLI deploy binary |
+   | `scripts/deploy.sh` | Shell deploy script using the `stellar` CLI |
+   | `build.rs` | Build script that bakes `GIT_HASH` into the binary |
+
+3. **Test snapshots**
+
+   Run `cargo test` once to generate initial snapshots under `test_snapshots/`. Commit them alongside the contract.
+
+4. **README update**
+
+   Add a row to the contract template table in `README.md` with the contract name, a one-line description, and a link to the contract directory.
+
+5. **CHANGELOG update**
+
+   Add an entry under `[Unreleased]` in `CHANGELOG.md` describing the new template.
+
+---
+
+## PR Checklist
+
+Before opening a pull request, confirm all of the following:
+
+- [ ] `cargo fmt --all` passes with no changes
+- [ ] `cargo clippy --all-targets -- -D warnings` passes
+- [ ] `cargo test --workspace` passes
+- [ ] New functionality is covered by tests (unit + property-based where applicable)
+- [ ] Public API changes are documented with doc comments
+- [ ] `CHANGELOG.md` has an entry under `[Unreleased]`
+- [ ] `README.md` is updated if the change affects usage or the template list
+- [ ] The PR title is concise (≤ 70 characters) and follows the format `type: short description` (e.g. `feat: add vesting contract template`)
+- [ ] The PR description references the issue it closes (`Closes #NNN`)
+
+---
+
+## Issue Labelling Conventions
+
+| Label | Meaning |
+|-------|---------|
+| `bug` | Something is broken or behaves incorrectly |
+| `enhancement` | New feature or improvement to existing functionality |
+| `documentation` | Changes to docs, comments, or README only |
+| `good first issue` | Well-scoped task suitable for new contributors |
+| `help wanted` | Maintainers welcome outside contributions |
+| `question` | Clarification needed before work can begin |
+| `duplicate` | Already tracked by another issue |
+| `wontfix` | Out of scope or intentionally not addressed |
+| `security` | Security-related finding — follow `SECURITY.md` for disclosure |
+| `ci` | Changes to CI/CD workflows or tooling |
+| `breaking change` | Introduces a backwards-incompatible change |
+
+---
+
+## PR Review Process
+
+1. A maintainer will be assigned to review within **3 business days** of opening.
+2. CI must be green before review begins. Fix any failing checks first.
+3. Reviewers may request changes. Address each comment and re-request review when ready.
+4. Once approved by at least one maintainer and CI is green, the PR will be squash-merged into `main`.
+5. The merge commit message becomes the CHANGELOG entry, so keep the PR title accurate.
+
+For security issues, do **not** open a public PR. Follow the process in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
Closes #479  — Expands \`CONTRIBUTING.md\` from a 1,495-byte stub to a full contributor guide.
Closes #480  — Adds a complete \`[0.1.0]\` section to \`CHANGELOG.md\` following Keep a Changelog format.

## CONTRIBUTING.md changes

- Dev environment setup (local + devcontainer option)
- Running tests: single contract, full workspace, per-feature-flag, property tests, benchmarks, WASM builds
- Code style rules (rustfmt, clippy, doc comment conventions, no unsafe, checked arithmetic)
- Step-by-step guide for adding a new contract template (required files table, snapshot generation, README/CHANGELOG update)
- PR checklist
- Issue labelling conventions table
- PR review process

## CHANGELOG.md changes

- Added \`[0.1.0]\` section documenting all token contract features (mint, burn, transfer, approve, admin handover, pausable/upgradeable/capped-supply feature flags), escrow contract features (full state machine, dispute resolution, deadline refund), common crate utilities, test infrastructure (unit, property, snapshot, integration), CI/tooling, and documentation
- Updated comparison links at the bottom to reference \`v0.1.0\`

## Testing

Documentation-only change — no code modified." \
  --base main \
  --head docs/expand-contributing-and-changelog