### PR TITLE
Feat/451 452 453 454

### DIFF
--- a/benches/benches/escrow_ops.rs
+++ b/benches/benches/escrow_ops.rs
@@ -150,11 +150,40 @@ fn bench_resolve_dispute(c: &mut Criterion) {
     });
 }
 
+fn bench_full_lifecycle(c: &mut Criterion) {
+    c.bench_function("escrow::full_lifecycle", |b| {
+        b.iter(|| {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let token_admin = Address::generate(&env);
+            let buyer = Address::generate(&env);
+            let seller = Address::generate(&env);
+            let arbiter = Address::generate(&env);
+            let deadline = env.ledger().sequence() + 500;
+
+            let sac = env.register_stellar_asset_contract_v2(token_admin);
+            let token_addr = sac.address();
+            StellarAssetClient::new(&env, &token_addr).mint(&buyer, &1_000i128);
+
+            let escrow_addr = env.register_contract(None, EscrowContract);
+            let escrow = EscrowContractClient::new(&env, &escrow_addr);
+            escrow.initialize(&buyer, &seller, &arbiter, &token_addr, &1_000i128, &deadline);
+            
+            // Full lifecycle: fund → mark_delivered → approve_delivery
+            escrow.fund();
+            escrow.mark_delivered();
+            escrow.approve_delivery();
+        });
+    });
+}
+
 criterion_group!(
     benches,
     bench_initialize,
     bench_fund,
     bench_approve_delivery,
     bench_resolve_dispute,
+    bench_full_lifecycle,
 );
 criterion_main!(benches);

--- a/contracts/escrow/src/events.rs
+++ b/contracts/escrow/src/events.rs
@@ -23,6 +23,10 @@ pub fn funds_released(env: &Env, seller: &Address, amount: i128) {
     env.events().publish((Symbol::new(env, "funds_released"), seller.clone()), amount);
 }
 
+pub fn partial_release(env: &Env, seller: &Address, amount: i128) {
+    env.events().publish((Symbol::new(env, "partial_release"), seller.clone()), amount);
+}
+
 pub fn funds_refunded(env: &Env, buyer: &Address, amount: i128) {
     env.events().publish((Symbol::new(env, "funds_refunded"), buyer.clone()), amount);
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -172,6 +172,48 @@ impl EscrowContract {
         Self::release_to_seller(env)
     }
 
+    /// Buyer releases a partial amount to the seller (milestone-based payments).
+    /// Only callable in `Funded` state. Decrements the stored amount.
+    pub fn release_partial(env: Env, amount: i128) -> Result<(), EscrowError> {
+        #[cfg(feature = "pausable")]
+        Self::require_not_paused(&env)?;
+
+        let buyer: Address = env
+            .storage()
+            .instance()
+            .get(&Buyer)
+            .ok_or(EscrowError::NotInitialized)?;
+        buyer.require_auth();
+
+        let state: EscrowState = env
+            .storage()
+            .instance()
+            .get(&State)
+            .ok_or(EscrowError::NotInitialized)?;
+        if state != EscrowState::Funded {
+            return Err(EscrowError::InvalidState);
+        }
+
+        if amount <= 0 {
+            return Err(EscrowError::InvalidAmount);
+        }
+
+        let stored_amount: i128 = env.storage().instance().get(&Amount).unwrap();
+        if amount > stored_amount {
+            return Err(EscrowError::InsufficientFunds);
+        }
+
+        let seller: Address = env.storage().instance().get(&Seller).unwrap();
+        let new_amount = stored_amount - amount;
+        env.storage().instance().set(&Amount, &new_amount);
+        bump_instance(&env);
+
+        admin::transfer_token(&env, &env.current_contract_address(), &seller, amount);
+        events::partial_release(&env, &seller, amount);
+
+        Ok(())
+    }
+
     /// Buyer requests a refund after the deadline has passed.
     pub fn request_refund(env: Env) -> Result<(), EscrowError> {
         #[cfg(feature = "pausable")]

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -579,6 +579,54 @@ fn test_approve_delivery_without_mark_delivered_fails() {
     client.approve_delivery();
 }
 
+#[test]
+#[should_panic]
+fn test_approve_delivery_by_seller_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _buyer, seller, ..) = setup_funded_escrow(&env);
+    client.mark_delivered();
+    
+    // Clear auths and only authorize seller — approve_delivery requires buyer auth
+    use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+    let contract_address = env.register_contract(None, EscrowContract);
+    env.mock_auths(&[MockAuth {
+        address: &seller,
+        invoke: &MockAuthInvoke {
+            contract: &contract_address,
+            fn_name: "approve_delivery",
+            args: soroban_sdk::vec![&env].into(),
+            sub_invokes: &[],
+        },
+    }]);
+    client.approve_delivery();
+}
+
+#[test]
+#[should_panic]
+fn test_approve_delivery_by_arbiter_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _buyer, _seller, arbiter, ..) = setup_funded_escrow(&env);
+    client.mark_delivered();
+    
+    // Clear auths and only authorize arbiter — approve_delivery requires buyer auth
+    use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+    let contract_address = env.register_contract(None, EscrowContract);
+    env.mock_auths(&[MockAuth {
+        address: &arbiter,
+        invoke: &MockAuthInvoke {
+            contract: &contract_address,
+            fn_name: "approve_delivery",
+            args: soroban_sdk::vec![&env].into(),
+            sub_invokes: &[],
+        },
+    }]);
+    client.approve_delivery();
+}
+
 // ---------------------------------------------------------------------------
 // Feature-gated tests
 // ---------------------------------------------------------------------------

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -627,6 +627,68 @@ fn test_approve_delivery_by_arbiter_fails() {
     client.approve_delivery();
 }
 
+#[test]
+fn test_release_partial() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _buyer, _seller, _arbiter, _token, amount) = setup_funded_escrow(&env);
+    let partial = amount / 2;
+    
+    client.release_partial(&partial);
+    
+    // Verify state is still Funded
+    assert_eq!(client.get_state(), Some(EscrowState::Funded));
+    
+    // Verify amount was decremented
+    let info = client.get_escrow_info();
+    assert_eq!(info.amount, amount - partial);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_release_partial_invalid_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token = create_mock_token(&env);
+    let amount = 1_000i128;
+    let deadline = env.ledger().sequence() + 100;
+
+    let (client, _) = create_escrow_contract(&env);
+    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline);
+    
+    // Try to release_partial in Created state — should fail with InvalidState
+    client.release_partial(&500i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_release_partial_exceeds_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _buyer, _seller, _arbiter, _token, amount) = setup_funded_escrow(&env);
+    
+    // Try to release more than available — should fail with InsufficientFunds
+    client.release_partial(&(amount + 1));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_release_partial_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _buyer, _seller, _arbiter, _token, _amount) = setup_funded_escrow(&env);
+    
+    // Try to release zero amount — should fail with InvalidAmount
+    client.release_partial(&0i128);
+}
+
 // ---------------------------------------------------------------------------
 // Feature-gated tests
 // ---------------------------------------------------------------------------

--- a/contracts/token/src/events.rs
+++ b/contracts/token/src/events.rs
@@ -16,6 +16,18 @@ pub fn admin_changed(env: &Env, old_admin: &Address, new_admin: &Address) {
     env.events().publish((Symbol::new(env, "admin_changed"), old_admin.clone()), new_admin.clone());
 }
 
+pub fn admin_proposed(env: &Env, current_admin: &Address, pending_admin: &Address) {
+    env.events().publish((Symbol::new(env, "admin_proposed"), current_admin.clone()), pending_admin.clone());
+}
+
+pub fn admin_accepted(env: &Env, new_admin: &Address) {
+    env.events().publish((Symbol::new(env, "admin_accepted"), new_admin.clone()), ());
+}
+
+pub fn admin_proposal_cancelled(env: &Env, admin: &Address) {
+    env.events().publish((Symbol::new(env, "admin_proposal_cancelled"), admin.clone()), ());
+}
+
 pub fn approved(env: &Env, from: &Address, spender: &Address, amount: i128) {
     env.events().publish((Symbol::new(env, "approve"), from.clone(), spender.clone()), amount);
 }

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -183,10 +183,7 @@ impl TokenContract {
         admin.require_auth();
         env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
         bump_instance(&env);
-        env.events().publish(
-            (soroban_sdk::Symbol::new(&env, "admin_proposed"), admin),
-            new_admin,
-        );
+        events::admin_proposed(&env, &admin, &new_admin);
         Ok(())
     }
 
@@ -202,16 +199,17 @@ impl TokenContract {
         env.storage().instance().set(&DataKey::Admin, &pending);
         env.storage().instance().remove(&DataKey::PendingAdmin);
         bump_instance(&env);
-        events::admin_changed(&env, &old_admin, &pending);
+        events::admin_accepted(&env, &pending);
         Ok(())
     }
 
     /// Cancel a pending admin transfer. Current admin only.
-    pub fn cancel_admin_transfer(env: Env) -> Result<(), TokenError> {
+    pub fn cancel_admin_proposal(env: Env) -> Result<(), TokenError> {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().remove(&DataKey::PendingAdmin);
         bump_instance(&env);
+        events::admin_proposal_cancelled(&env, &admin);
         Ok(())
     }
 

--- a/contracts/token/src/storage.rs
+++ b/contracts/token/src/storage.rs
@@ -15,14 +15,8 @@ pub enum DataKey {
     Paused,
     /// Instance storage – maximum tokens that may ever be minted (`i128`).
     MaxSupply,
-    /// Instance storage – pending admin address for two-step admin transfer.
-    PendingAdmin,
     /// Instance storage – pending WASM upgrade: `(BytesN<32>, u32)` = (hash, ready_after_ledger).
     PendingUpgrade,
-    /// Instance storage – pending admin transfer.
-    /// Instance storage – pending admin address for two-step admin transfer.
-    /// Instance storage – address of the pending new admin awaiting acceptance.
-    PendingAdmin,
 }
 
 #[contracttype]

--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -779,3 +779,117 @@ fn test_unauthorized_admin_burn_fails() {
     env.set_auths(&[]);
     client.admin_burn(&user, &100i128);
 }
+
+
+#[test]
+fn test_propose_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let client = init_token(&env, &admin);
+
+    client.propose_admin(&new_admin);
+
+    // Admin should still be the old admin
+    assert_eq!(client.admin(), admin);
+}
+
+#[test]
+fn test_accept_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let client = init_token(&env, &admin);
+
+    client.propose_admin(&new_admin);
+    client.accept_admin();
+
+    // Admin should now be the new admin
+    assert_eq!(client.admin(), new_admin);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_accept_admin_without_proposal_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let client = init_token(&env, &admin);
+
+    // Try to accept without a proposal
+    client.accept_admin();
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_accept_admin_by_wrong_address_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let wrong_address = Address::generate(&env);
+    let client = init_token(&env, &admin);
+
+    client.propose_admin(&new_admin);
+    
+    // Try to accept as wrong address
+    use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+    let contract_address = env.register_contract(None, TokenContract);
+    env.mock_auths(&[MockAuth {
+        address: &wrong_address,
+        invoke: &MockAuthInvoke {
+            contract: &contract_address,
+            fn_name: "accept_admin",
+            args: soroban_sdk::vec![&env].into(),
+            sub_invokes: &[],
+        },
+    }]);
+    client.accept_admin();
+}
+
+#[test]
+fn test_cancel_admin_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let client = init_token(&env, &admin);
+
+    client.propose_admin(&new_admin);
+    client.cancel_admin_proposal();
+
+    // Admin should still be the old admin
+    assert_eq!(client.admin(), admin);
+    
+    // Trying to accept should fail since proposal was cancelled
+    assert!(client.try_accept_admin().is_err());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_cancel_admin_proposal_by_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let client = init_token(&env, &admin);
+
+    client.propose_admin(&new_admin);
+    
+    // Try to cancel as non-admin
+    use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
+    let contract_address = env.register_contract(None, TokenContract);
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_address,
+            fn_name: "cancel_admin_proposal",
+            args: soroban_sdk::vec![&env].into(),
+            sub_invokes: &[],
+        },
+    }]);
+    client.cancel_admin_proposal();
+}


### PR DESCRIPTION
## Summary

I've successfully implemented all four GitHub issues in a single branch feat/451-452-453-454. Here's what was completed:

### **Issue #451** - Add tests for approve_delivery called by non-buyer
- Added test_approve_delivery_by_seller_fails - verifies seller cannot call approve_delivery
- Added test_approve_delivery_by_arbiter_fails - verifies arbiter cannot call approve_delivery
- Both tests properly mock auth to ensure only the specified party is authorized

### **Issue #452** - Add benchmark for escrow full lifecycle
- Added bench_full_lifecycle benchmark that measures the combined cost of:
  - fund → mark_delivered → approve_delivery
- Integrated into the criterion benchmark group for CI tracking

### **Issue #453** - Implement release_partial on EscrowContract
- Implemented pub fn release_partial(env: Env, amount: i128) method
- Only callable by buyer in Funded state
- Transfers amount to seller and decrements stored Amount
- Returns InsufficientFunds if amount exceeds stored amount
- Emits partial_release event
- Added comprehensive unit tests:
  - test_release_partial - happy path
  - test_release_partial_invalid_state - fails in non-Funded state
  - test_release_partial_exceeds_amount - fails when amount > stored
  - test_release_partial_zero_amount - fails with zero amount

### **Issue #454** - Implement two-step admin transfer for token contract
- Fixed duplicate PendingAdmin entries in storage.rs
- Updated propose_admin to use new event function
- Updated accept_admin to use new event function  
- Renamed cancel_admin_transfer to cancel_admin_proposal with proper event
- Added new event functions: admin_proposed, admin_accepted, admin_proposal_cancelled
- Added comprehensive tests:
  - test_propose_admin - proposal doesn't change admin
  - test_accept_admin - acceptance changes admin
  - test_accept_admin_without_proposal_fails - fails without proposal
  - test_accept_admin_by_wrong_address_fails - only pending admin can accept
  - test_cancel_admin_proposal - cancellation clears pending admin
  - test_cancel_admin_proposal_by_non_admin_fails - only admin can cancel
  
  
  
 Closes #451
 Closes #452
 Closes #453
 Closes #454