### PR TITLE
Feat/issues implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, 
 - [Freighter Wallet](https://freighter.app/)
 - [Stellar Laboratory](https://laboratory.stellar.org/)
 - [Security Best Practices](docs/security.md)
+ - [Architecture Decision Records](docs/adr/README.md)
 
 ## 📄 License
 

--- a/docs/adr/0006-escrow-arbiter-model.md
+++ b/docs/adr/0006-escrow-arbiter-model.md
@@ -1,0 +1,61 @@
+# ADR 0006: Escrow Arbiter Model
+
+- Status: Accepted
+- Date: 2026-05-29
+
+## Context
+
+The escrow contract in this repository uses an arbiter model where a single designated arbiter can resolve disputes and direct the transfer of funds between buyer and seller. This model simplifies dispute resolution and minimizes on-chain complexity, but concentrates authority in one actor.
+
+## Decision
+
+We accept the single-arbiter model for the escrow contract. The arbiter is a trusted off-chain entity with the authority to resolve escrow disputes and trigger fund settlement on-chain.
+
+## Rationale / Single-arbiter benefits
+
+- Simplicity: implementation and on-chain logic are straightforward, reducing surface area for bugs.
+- Low gas and UX cost: fewer on-chain operations and simpler workflows for users.
+- Fast dispute resolution: a single, identified actor can act quickly without coordination overhead.
+
+## Trust assumptions
+
+- The arbiter is honest, available, and will follow agreed rules for dispute resolution.
+- Arbiter's private key(s) are securely managed and not compromised.
+- Participants (buyer, seller) accept the arbiter's authority as part of the escrow terms.
+
+## Known risks
+
+- Centralization risk: a single arbiter can redirect funds or act maliciously.
+- Key compromise: if the arbiter's signing key is stolen, attacker can resolve escrows illegitimately.
+- Censorship/unavailability: the arbiter may become unreachable, delaying or preventing resolution.
+- Governance and accountability: decisions depend on off-chain processes; on-chain auditability is limited to the resolution action but not the reasoning.
+
+## Alternatives considered
+
+- Multi-signature (multi-sig) arbiter group: require multiple independent arbiters to co-sign resolution transactions. Improves decentralization and resilience but increases coordination complexity and gas costs.
+- On-chain voting/DAO: let token holders vote to resolve disputes. Offers decentralization but is slow and may be unsuitable for time-sensitive disputes.
+- Algorithmic or rule-based auto-resolution: use pre-defined rules to automatically decide outcomes. Avoids trusted parties but may not cover complex disputes and risks unfair automated outcomes.
+- Threshold cryptography / MPC: distribute signing power using threshold keys. Provides strong decentralization and single-transaction UX but increases operational complexity.
+
+## Migration path to multi-sig
+
+1. Design a multi-sig contract or adopt an existing, audited multisig wallet pattern compatible with Soroban.
+2. Add an upgrade path in the escrow contract allowing the `arbiter` role to be replaced by a `resolution_contract` address (an indirection layer) via an on-chain governance or admin action.
+3. Deploy the multi-sig/threshold resolution contract and configure it as the `resolution_contract` in escrow instances.
+4. Revoke or rotate the single-arbiter key(s) and publish transition notices for users.
+5. For existing escrows, provide a migration window during which disputes can still be appealed to the original arbiter if necessary; after the window, new resolutions must use the multi-sig.
+
+## Mitigations
+
+- Operational controls: use hardware security modules (HSMs) or multisig for arbiter key custody where possible.
+- Auditing and transparency: publish arbiter policies, dispute logs, and rationale where feasible to build trust.
+- Key rotation and monitoring: enforce regular key rotation, alerts on signing activity, and incident response plans.
+
+## Consequences
+
+- Short-term: easier implementation and lower cost for users and developers.
+- Long-term: centralization risks require governance and operational safeguards; plan for migration to a more decentralized resolution mechanism if user needs evolve.
+
+## References
+
+- See related ADRs: [0003 Admin Model](0003-admin-model.md), [0004 Escrow State Machine Design](0004-escrow-state-machine.md)

--- a/docs/adr/0007-token-interface-compliance.md
+++ b/docs/adr/0007-token-interface-compliance.md
@@ -1,0 +1,58 @@
+# ADR 0007: Token Interface Compliance
+
+- Status: Accepted
+- Date: 2026-05-29
+
+## Context
+
+The `contracts/token` implementation in this repo implements `soroban_sdk::token::TokenInterface` (see `impl token::TokenInterface for TokenContract` in `contracts/token/src/lib.rs`). Consumers and integrators need clear documentation of which standard this corresponds to, what compliance means in practice, and any repository-specific deviations or extensions.
+
+## Decision
+
+Document the contract as compliant with the Soroban SDK token interface (`soroban_sdk::token::TokenInterface`). There is no single formal SEP number for the Soroban token interface at the time of this ADR; instead this ADR records the contract's compliance checklist, deviations, and verification steps.
+
+## Compliance checklist
+
+- Implements the `TokenInterface` trait on the contract type.
+- Public methods required by the interface and expected behaviors:
+  - `name() -> String` — returns token name
+  - `symbol() -> String` — returns token symbol
+  - `decimals() -> u32` — returns decimals
+  - `total_supply() -> i128` — reports current total supply
+  - `balance(id: Address) -> i128` — returns 0 for unknown or zero balances
+  - `allowance(from, spender) -> i128` — returns numeric allowance (0 when none or expired)
+  - `approve(from, spender, amount, expiration_ledger)` — sets temporary allowance
+  - `transfer(from, to, amount)` — requires `from` auth, updates balances and emits event
+  - `transfer_from(spender, from, to, amount)` — requires `spender` auth, deducts allowance, updates balances
+  - `burn(from, amount)` and `burn_from(spender, from, amount)` — supports authorized burns
+
+## Known deviations and extensions
+
+- `balance_of(id) -> Option<i128>`: this contract provides `balance_of` (returns `Some(balance)` or `None`) in addition to `balance()`; this is an extension for clients that need to distinguish unknown addresses from explicit zero balances.
+- Allowance expirations: allowances are stored in temporary storage with an `expiration_ledger` field; this extends the basic approve/allowance semantics with expiry semantics.
+- Admin-controlled operations: the contract exposes admin-only functions such as `mint`, `batch_mint`, `admin_burn`, `propose_admin`, `pause`/`unpause` (feature-gated), `freeze_account` (feature-gated), and upgrade-related functions (feature-gated). These are optional extensions and are not required by the `TokenInterface` trait.
+- Event names and shapes: the contract emits custom event names defined in its `events` module; while functionally equivalent for many consumers, consumers should verify expected event payloads.
+
+## How to verify compliance
+
+1. Source inspection: confirm the presence of `impl token::TokenInterface for TokenContract` and that all trait methods are implemented (see `contracts/token/src/lib.rs`).
+2. ABI / interface check: build the contract and inspect the generated contract interface (WASM exports or manifest) to ensure the expected functions are present.
+3. Unit tests: review and run unit tests in `contracts/token/src/test.rs` to validate behaviors like transfers, allowances, and edge cases (note: this repo includes tests that exercise the interface).
+4. Integration checks: exercise the built contract via the Soroban CLI or test harness to validate event emission, allowance expirations, and admin operations.
+5. Review deviations: pay special attention to `balance_of` semantics, allowance expiry behavior, and admin-only extensions when integrating with wallets or marketplaces.
+
+## Consequences
+
+- Positive: clearly documenting compliance and deviations helps integrators and auditors understand expected behavior and reduces integration surprises.
+- Negative: the added extensions (allowance expirations, admin ops) mean third-party integrators must be aware of differences from minimal token standards (e.g., ERC-20-like expectations).
+
+## Migration / compatibility notes
+
+- If a stricter or different token SEP emerges for Soroban, we can adapt by:
+  1. Implementing any missing trait methods or changing semantics to match the canonical SEP.
+  2. Providing adapter contracts or wrapper layers that translate between this contract's extensions and the canonical interface.
+
+## References
+
+- Source implementation: `contracts/token/src/lib.rs`
+- Related ADRs: [0003 Admin Model](0003-admin-model.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@ Each ADR documents a significant design decision: the context that motivated it,
 | [0003](0003-admin-model.md) | Admin Model | Accepted |
 | [0004](0004-escrow-state-machine.md) | Escrow State Machine Design | Accepted |
 | [0006](0006-escrow-arbiter-model.md) | Escrow Arbiter Model | Accepted |
+| [0007](0007-token-interface-compliance.md) | Token Interface Compliance | Accepted |
 
 ## Format
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ Each ADR documents a significant design decision: the context that motivated it,
 | [0002](0002-error-handling-strategy.md) | Error Handling Strategy | Accepted |
 | [0003](0003-admin-model.md) | Admin Model | Accepted |
 | [0004](0004-escrow-state-machine.md) | Escrow State Machine Design | Accepted |
+| [0006](0006-escrow-arbiter-model.md) | Escrow Arbiter Model | Accepted |
 
 ## Format
 


### PR DESCRIPTION
# PR Summary 

Title: docs: add ADR 0006 (escrow arbiter) and ADR 0007 (token interface) and link from READMEs

Added [0006-escrow-arbiter-model.md](https://animated-halibut-969rx79rgv77cxp74.github.dev/) — documents single-arbiter rationale, trust assumptions, risks, alternatives, and migration path to multi-sig.
Added [0007-token-interface-compliance.md](https://animated-halibut-969rx79rgv77cxp74.github.dev/) — documents [TokenInterface](https://animated-halibut-969rx79rgv77cxp74.github.dev/) compliance checklist, deviations (e.g., [balance_of](https://animated-halibut-969rx79rgv77cxp74.github.dev/), allowance expiry), verification steps, and compatibility notes.
Updated [README.md](https://animated-halibut-969rx79rgv77cxp74.github.dev/) — added entries for ADR 0006 and ADR 0007.
Updated [README.md](https://animated-halibut-969rx79rgv77cxp74.github.dev/) — added link to [README.md](https://animated-halibut-969rx79rgv77cxp74.github.dev/) under Resources.
No contract logic or tests changed; purely documentation.

## Closes
Closes #491 
Closes #491 