### PR TITLE
feat: post-deploy init script, pre-commit hooks, machete & udeps CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,39 @@ jobs:
           name: wasm-contracts
           path: target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 7
+
+  machete:
+    name: Unused dependencies (cargo-machete)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-machete
+        run: cargo install cargo-machete --locked
+
+      - name: Check for unused dependencies
+        run: cargo machete --workspace
+
+  udeps:
+    name: Unused dev-dependencies (cargo-udeps)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps --locked
+
+      - name: Check for unused dev-dependencies
+        run: cargo +nightly udeps --workspace --all-targets

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: clippy
+        name: cargo clippy
+        entry: cargo clippy --workspace --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+## Pre-commit hooks
+
+This project ships a `.pre-commit-config.yaml` that runs `cargo fmt` and `cargo clippy` before every commit so you catch issues locally instead of in CI.
+
+### Setup
+
+```bash
+pip install pre-commit          # or: brew install pre-commit
+pre-commit install              # wire the hook into .git/hooks/pre-commit
+```
+
+From now on, every `git commit` will automatically run:
+
+- **`cargo fmt --check`** — rejects commits with unformatted Rust code. Run `cargo fmt` to fix.
+- **`cargo clippy`** — rejects commits that introduce Clippy warnings treated as errors.
+
+To run the hooks manually without committing:
+
+```bash
+pre-commit run --all-files
+```
+
+---
+
+## CI checks
+
+### cargo-machete (unused dependencies)
+
+The `machete` CI job runs `cargo machete --workspace` to detect unused entries in `Cargo.toml`.
+If the job fails, remove the flagged dependencies and push again.
+
+Install locally:
+
+```bash
+cargo install cargo-machete
+cargo machete --workspace
+```
+
+### cargo-udeps (unused dev-dependencies)
+
+The `udeps` CI job runs `cargo +nightly udeps --workspace --all-targets` using nightly Rust.
+It catches unused `[dev-dependencies]` that `cargo-machete` may miss.
+
+Install locally:
+
+```bash
+rustup toolchain install nightly
+cargo install cargo-udeps --locked
+cargo +nightly udeps --workspace --all-targets
+```
+
+---
+
+## Code style
+
+- Format: `cargo fmt --all`
+- Lint: `cargo clippy --workspace --all-targets -- -D warnings`
+- Tests: `cargo test --workspace`

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -87,6 +87,32 @@ Save the contract IDs printed to stdout — you'll need them in `.env`.
 
 ---
 
+## 3b. Post-Deploy Initialization
+
+After deploying contracts, run the initialization script to call each contract's `initialize` function:
+
+```bash
+# Populate .contract-ids with deployed IDs (one per line: name=CONTRACT_ID)
+echo "token=CABC..." >> .contract-ids
+echo "escrow=CDEF..." >> .contract-ids
+
+# Initialize all contracts on the current network
+./scripts/initialize.sh testnet   # or local / mainnet
+```
+
+**Environment variable overrides:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `INIT_FN` | `initialize` | Function name to invoke |
+| `SOURCE_ACCOUNT` | `default` | Stellar key to sign transactions |
+| `CONTRACT_IDS_FILE` | `.contract-ids` | Path to contract ID list |
+| `INIT_ARGS_<NAME>` | _(none)_ | Extra CLI args for a specific contract, e.g. `INIT_ARGS_TOKEN="--admin GABC..."` |
+
+The script is idempotent: contracts that return an "already initialized" error are reported as skipped rather than failures.
+
+---
+
 ## 4. Mainnet Deployment
 
 > ⚠️ Mainnet deployments are irreversible. Complete testnet validation first.

--- a/scripts/initialize.sh
+++ b/scripts/initialize.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# initialize.sh — run post-deploy initialization on deployed Soroban contracts
+# Usage: ./scripts/initialize.sh [testnet|mainnet|local]
+#
+# Reads contract IDs from .contract-ids (one "name=CONTRACT_ID" per line),
+# then calls `stellar contract invoke --id <id> -- initialize` for each.
+#
+# Override per-contract init args via env:  INIT_ARGS_<NAME>="--arg val"
+# Set INIT_FN to change the function name (default: initialize).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACT_IDS_FILE="${CONTRACT_IDS_FILE:-$ROOT/.contract-ids}"
+NETWORK="${1:-testnet}"
+INIT_FN="${INIT_FN:-initialize}"
+
+case "$NETWORK" in
+  testnet)
+    RPC_URL="https://soroban-testnet.stellar.org"
+    PASSPHRASE="Test SDF Network ; September 2015"
+    ;;
+  mainnet)
+    RPC_URL="https://soroban.stellar.org"
+    PASSPHRASE="Public Global Stellar Network ; September 2015"
+    ;;
+  local)
+    RPC_URL="http://localhost:${LOCAL_RPC_PORT:-8000}"
+    PASSPHRASE="Standalone Network ; February 2017"
+    ;;
+  *)
+    echo "Unknown network: $NETWORK (use testnet|mainnet|local)" >&2
+    exit 1
+    ;;
+esac
+
+if [[ ! -f "$CONTRACT_IDS_FILE" ]]; then
+  echo "No .contract-ids file found at $CONTRACT_IDS_FILE — nothing to initialize." >&2
+  exit 1
+fi
+
+INITIALIZED=0
+SKIPPED=0
+FAILED=0
+
+while IFS='=' read -r name contract_id || [[ -n "$name" ]]; do
+  # skip blank lines and comments
+  [[ -z "$name" || "$name" == \#* ]] && continue
+  contract_id="${contract_id:-}"
+  if [[ -z "$contract_id" ]]; then
+    echo "WARN: no contract ID for '$name', skipping."
+    ((SKIPPED++)) || true
+    continue
+  fi
+
+  # per-contract extra args, e.g. INIT_ARGS_TOKEN="--admin GABC..."
+  extra_var="INIT_ARGS_$(echo "$name" | tr '[:lower:]' '[:upper:]' | tr '-' '_')"
+  extra_args="${!extra_var:-}"
+
+  echo "── Initializing $name ($contract_id) ──"
+  if stellar contract invoke \
+      --id "$contract_id" \
+      --rpc-url "$RPC_URL" \
+      --network-passphrase "$PASSPHRASE" \
+      --source-account "${SOURCE_ACCOUNT:-default}" \
+      -- "$INIT_FN" $extra_args 2>&1 | tee /tmp/init_output.txt; then
+    ((INITIALIZED++)) || true
+  else
+    # treat "already initialized" style errors as non-fatal
+    if grep -qiE "already.init|AlreadyInitialized|HostError.*1" /tmp/init_output.txt; then
+      echo "  → $name already initialized, skipping."
+      ((SKIPPED++)) || true
+    else
+      echo "ERROR: initialization of $name failed." >&2
+      ((FAILED++)) || true
+    fi
+  fi
+done < "$CONTRACT_IDS_FILE"
+
+echo ""
+echo "Done — initialized: $INITIALIZED  skipped: $SKIPPED  failed: $FAILED"
+[[ "$FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
- scripts/initialize.sh: idempotent post-deploy initializer that reads .contract-ids and invokes each contract's initialize function (#508)
- docs/deployment-guide.md: document the new initialize script (#508)
- .pre-commit-config.yaml: cargo fmt + clippy hooks via pre-commit (#509)
- CONTRIBUTING.md: setup guide for pre-commit, machete, and udeps (#509 #510 #511)
- .github/workflows/ci.yml: add machete and udeps jobs (#510 #511)

Closes #508, closes #509, closes #510, closes #511