### PR TITLE
fix: CI/CD improvements for issues #495-498

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,19 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    groups:
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2
 
   audit:
-    name: Security Audit
+    name: WASM Build and Check
     runs-on: ubuntu-latest
     needs: [fmt, clippy, test]
     steps:
@@ -149,8 +149,20 @@ jobs:
           path: target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 7
 
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
 
       - name: Run cargo audit
-        run: cargo audit
+        run: cargo audit --deny warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli --features opt
+
+      - name: Build all contracts (release)
+        run: |
+          for dir in contracts/*/; do
+            if [ -f "$dir/Cargo.toml" ]; then
+              echo "Building $(basename $dir)..."
+              stellar contract build --manifest-path "$dir/Cargo.toml"
+            fi
+          done
+
+      - name: Calculate SHA256 checksums
+        run: |
+          cd target/wasm32-unknown-unknown/release
+          sha256sum *.wasm > checksums.sha256
+          cat checksums.sha256
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            target/wasm32-unknown-unknown/release/*.wasm
+            target/wasm32-unknown-unknown/release/checksums.sha256
+          generate_release_notes: true


### PR DESCRIPTION
- deny.toml already satisfies #495 (license allowlist + bans section)
- dependabot.yml: add github-actions ecosystem, reduce cargo PR limit to 5, group patch updates (#496)
- release.yml: new workflow to build WASM and publish release on v* tags with SHA256 checksums (#497)
- ci.yml: extract cargo audit into standalone security-audit job (no needs deps, --deny warnings flag) (#498)
closes #495 
closes #496 
closes #497 
closes #498 