### PR TITLE
fix: raise WASM size limit to 200 KB (#493)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,10 @@ jobs:
 
       - name: Check WASM sizes
         run: |
-          MAX=65536
+          # 200 KB: optimized Soroban contracts typically range 20–100 KB;
+          # 200 KB gives headroom for feature-rich contracts while still
+          # catching runaway bloat before it reaches production.
+          MAX=204800
           FAILED=0
           for wasm in target/wasm32-unknown-unknown/release/*.wasm; do
             size=$(wc -c < "$wasm")


### PR DESCRIPTION
## Summary
Closes #493

The previous 64 KB limit caused false CI failures on legitimate optimized Soroban contracts.

## Changes
- Raised `MAX` from `65536` → `204800` (200 KB) in the `Check WASM sizes` step
- Added inline comment explaining the rationale

## Root cause
Optimized Soroban contracts typically range 20–100 KB; 64 KB was too conservative.