### PR TITLE
feat: add feature flag matrix to CI test job (#494)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,32 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
-    name: Tests
+    name: Tests (${{ matrix.package }} / ${{ matrix.features || 'no features' }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # token feature combinations
+          - package: soroban-token-template
+            features: ""
+          - package: soroban-token-template
+            features: pausable
+          - package: soroban-token-template
+            features: upgradeable
+          - package: soroban-token-template
+            features: capped-supply
+          - package: soroban-token-template
+            features: pausable,upgradeable,capped-supply,freeze
+          # escrow feature combinations
+          - package: soroban-escrow-template
+            features: ""
+          - package: soroban-escrow-template
+            features: pausable
+          - package: soroban-escrow-template
+            features: upgradeable
+          - package: soroban-escrow-template
+            features: pausable,upgradeable
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +76,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run tests
-        run: cargo test --workspace
+        run: |
+          if [ -n "${{ matrix.features }}" ]; then
+            cargo test -p ${{ matrix.package }} --features ${{ matrix.features }}
+          else
+            cargo test -p ${{ matrix.package }}
+          fi
 
   coverage:
     name: Code Coverage


### PR DESCRIPTION
## Summary
Closes #494

Feature-gated code was never tested in CI because `cargo test --workspace` runs with no features.

## Changes
- Replaced single test run with a `matrix.include` strategy
- Token: no features, `pausable`, `upgradeable`, `capped-supply`, all combined
- Escrow: no features, `pausable`, `upgradeable`, both combined
- `fail-fast: false` so one failure doesn't cancel other matrix entries