### PR TITLE
Add multisig contract template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Rust
 target/
 **/*.rs.bk
+**/test_snapshots/
+**/proptest-regressions/
 
 # Environment
 .env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-multisig-template"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-sdk"
 version = "21.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "tests", "fuzz"]
+members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/multisig", "tests", "fuzz"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ cargo test
 |----------|-------------|-----------|---------|
 | **Token** | Custom fungible token with mint/burn/admin controls | DeFi tokens, governance tokens, utility tokens | ✅ Complete |
 | **Escrow** | Two-party escrow with timeout and refund mechanism | P2P trading, service payments, milestone payments | ✅ Complete |
+| **Multisig** | N-of-M wallet for threshold-approved contract calls | DAO treasuries, team wallets, shared administration | ✅ Complete |
 
 ### Token Contract Features
 - **Standard Interface**: Full Soroban token compatibility
@@ -45,6 +46,14 @@ cargo test
 - **State Management**: Clear transaction lifecycle
 - **Token Agnostic**: Works with any Soroban token
 - **Event Emission**: All operations emit events for tracking
+
+### Multisig Contract Features
+- **N-of-M Authorization**: Configure any valid threshold across unique signers
+- **Signer Management**: Add or remove signers with threshold-approved changes
+- **Transaction Proposals**: Store target contract, function, and arguments
+- **Signature Tracking**: Prevent duplicate signatures and non-signer approvals
+- **Threshold Execution**: Execute proposed calls only after enough signatures
+- **Event Emission**: Initialization, signer changes, signatures, and execution emit events
 
 Each template includes:
 - ✅ Complete contract implementation
@@ -116,6 +125,21 @@ docker compose up stellar-node
 | 7 | `InsufficientFunds` | The buyer's token balance is too low to cover the escrowed amount |
 | 8 | `InvalidAmount` | The specified amount is zero or otherwise invalid |
 | 9 | `InvalidParties` | Buyer, seller, or arbiter addresses are invalid or conflict with each other |
+
+### Multisig Contract Errors (`MultisigError`)
+
+| Code | Name | Description |
+|------|------|-------------|
+| 1 | `AlreadyInitialized` | `initialize` was called after the signer set was already configured |
+| 2 | `NotInitialized` | An operation was attempted before the multisig was initialized |
+| 3 | `InvalidThreshold` | Threshold is zero or greater than the number of signers |
+| 4 | `InvalidSigners` | Signer or approval lists are empty or contain duplicates |
+| 5 | `NotSigner` | Caller, approver, or signer is not part of the wallet signer set |
+| 6 | `TransactionNotFound` | Requested transaction ID does not exist |
+| 7 | `AlreadyExecuted` | Transaction has already been executed |
+| 8 | `AlreadySigned` | Signer already approved the transaction |
+| 9 | `ThresholdNotMet` | Transaction does not have enough signatures to execute |
+| 10 | `InsufficientApprovals` | Signer-management change lacks enough threshold approvals |
 
 ## 🤝 Contributing
 

--- a/contracts/multisig/Cargo.toml
+++ b/contracts/multisig/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "soroban-multisig-template"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+description = "A production-ready Soroban N-of-M multisig wallet contract template"
+license.workspace = true
+
+[features]
+pausable = []
+upgradeable = []
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { workspace = true }
+
+[[bin]]
+name = "deploy"
+path = "src/bin/deploy.rs"
+doc = false
+
+[lints]
+workspace = true

--- a/contracts/multisig/build.rs
+++ b/contracts/multisig/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/contracts/multisig/scripts/deploy.sh
+++ b/contracts/multisig/scripts/deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Soroban Multisig Contract Deployment Script
+# Usage: ./deploy.sh [network] [source]
+# Example: ./deploy.sh testnet alice
+
+set -e
+
+NETWORK=${1:-testnet}
+SOURCE=${2:-}
+CONTRACT_NAME="soroban_multisig_template"
+
+echo "Deploying Multisig Contract to $NETWORK..."
+
+echo "Building contract..."
+stellar contract build
+
+DEPLOY_ARGS=(contract deploy --wasm "target/wasm32-unknown-unknown/release/${CONTRACT_NAME}.wasm" --network "$NETWORK")
+if [ -n "$SOURCE" ]; then
+    DEPLOY_ARGS+=(--source "$SOURCE")
+fi
+
+echo "Deploying to $NETWORK..."
+CONTRACT_ID=$(stellar "${DEPLOY_ARGS[@]}")
+
+echo "Multisig contract deployed."
+echo "Contract ID: $CONTRACT_ID"
+echo "multisig: $CONTRACT_ID" >> ../../../.contract-ids
+
+echo "Initialize with:"
+echo "stellar contract invoke --id $CONTRACT_ID --network $NETWORK -- initialize --signers '[...]' --threshold 2"

--- a/contracts/multisig/src/bin/deploy.rs
+++ b/contracts/multisig/src/bin/deploy.rs
@@ -1,0 +1,35 @@
+//! Deploy helper for soroban-multisig-template.
+//!
+//! Usage:
+//!   cargo run --bin deploy -- --network testnet --source alice
+//!   cargo run --bin deploy -- --network mainnet --source alice --wasm path/to/multisig.wasm
+
+use std::process::{Command, ExitCode};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let has_wasm_flag = args.windows(2).any(|w| w[0] == "--wasm");
+    if !has_wasm_flag {
+        let status = Command::new("stellar")
+            .args(["contract", "build"])
+            .status()
+            .expect("failed to run `stellar contract build`");
+        if !status.success() {
+            eprintln!("Build failed.");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    let status = Command::new("stellar")
+        .args(["contract", "deploy"])
+        .args(&args)
+        .status()
+        .expect("failed to run `stellar contract deploy`");
+
+    if status.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}

--- a/contracts/multisig/src/errors.rs
+++ b/contracts/multisig/src/errors.rs
@@ -1,0 +1,44 @@
+use soroban_sdk::contracterror;
+
+/// Error codes returned by [`MultisigContract`](crate::MultisigContract).
+#[contracterror]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MultisigError {
+    /// The contract has already been initialized.
+    AlreadyInitialized = 1,
+    /// The contract has not been initialized.
+    NotInitialized = 2,
+    /// The threshold must be greater than zero and no greater than signer count.
+    InvalidThreshold = 3,
+    /// Signer lists cannot be empty or contain duplicates.
+    InvalidSigners = 4,
+    /// The caller or approver is not a signer.
+    NotSigner = 5,
+    /// The transaction does not exist.
+    TransactionNotFound = 6,
+    /// The transaction has already been executed.
+    AlreadyExecuted = 7,
+    /// The signer has already signed the transaction.
+    AlreadySigned = 8,
+    /// The transaction has too few signatures to execute.
+    ThresholdNotMet = 9,
+    /// Signer-management approval list does not satisfy the threshold.
+    InsufficientApprovals = 10,
+}
+
+impl core::fmt::Display for MultisigError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            MultisigError::AlreadyInitialized => write!(f, "already initialized"),
+            MultisigError::NotInitialized => write!(f, "not initialized"),
+            MultisigError::InvalidThreshold => write!(f, "invalid threshold"),
+            MultisigError::InvalidSigners => write!(f, "invalid signers"),
+            MultisigError::NotSigner => write!(f, "not signer"),
+            MultisigError::TransactionNotFound => write!(f, "transaction not found"),
+            MultisigError::AlreadyExecuted => write!(f, "already executed"),
+            MultisigError::AlreadySigned => write!(f, "already signed"),
+            MultisigError::ThresholdNotMet => write!(f, "threshold not met"),
+            MultisigError::InsufficientApprovals => write!(f, "insufficient approvals"),
+        }
+    }
+}

--- a/contracts/multisig/src/events.rs
+++ b/contracts/multisig/src/events.rs
@@ -1,0 +1,43 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+pub fn initialized(env: &Env, threshold: u32, signer_count: u32) {
+    env.events()
+        .publish((Symbol::new(env, "initialized"), threshold), signer_count);
+}
+
+pub fn signer_added(env: &Env, signer: &Address, threshold: u32) {
+    env.events().publish(
+        (Symbol::new(env, "signer_added"), signer.clone()),
+        threshold,
+    );
+}
+
+pub fn signer_removed(env: &Env, signer: &Address, threshold: u32) {
+    env.events().publish(
+        (Symbol::new(env, "signer_removed"), signer.clone()),
+        threshold,
+    );
+}
+
+pub fn transaction_proposed(env: &Env, tx_id: u64, proposer: &Address) {
+    env.events().publish(
+        (Symbol::new(env, "transaction_proposed"), proposer.clone()),
+        tx_id,
+    );
+}
+
+pub fn transaction_signed(env: &Env, tx_id: u64, signer: &Address, signature_count: u32) {
+    env.events().publish(
+        (
+            Symbol::new(env, "transaction_signed"),
+            signer.clone(),
+            tx_id,
+        ),
+        signature_count,
+    );
+}
+
+pub fn transaction_executed(env: &Env, tx_id: u64) {
+    env.events()
+        .publish((Symbol::new(env, "transaction_executed"), tx_id), ());
+}

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -1,0 +1,335 @@
+#![no_std]
+
+#[cfg(test)]
+extern crate std;
+
+use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Val, Vec};
+
+mod errors;
+mod events;
+mod storage;
+
+#[cfg(test)]
+mod prop_test;
+#[cfg(test)]
+mod test;
+
+pub use errors::MultisigError;
+pub use storage::{DataKey, Transaction};
+
+use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+
+#[contract]
+pub struct MultisigContract;
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+fn bump_transaction(env: &Env, tx_id: u64) {
+    env.storage().persistent().extend_ttl(
+        &DataKey::Transaction(tx_id),
+        LEDGER_LIFETIME_THRESHOLD,
+        LEDGER_BUMP_AMOUNT,
+    );
+}
+
+fn contains(list: &Vec<Address>, address: &Address) -> bool {
+    for item in list.iter() {
+        if item == *address {
+            return true;
+        }
+    }
+    false
+}
+
+fn validate_unique_signers(signers: &Vec<Address>) -> Result<(), MultisigError> {
+    if signers.is_empty() {
+        return Err(MultisigError::InvalidSigners);
+    }
+
+    let mut seen = Vec::new(signers.env());
+    for signer in signers.iter() {
+        if contains(&seen, &signer) {
+            return Err(MultisigError::InvalidSigners);
+        }
+        seen.push_back(signer);
+    }
+    Ok(())
+}
+
+fn validate_threshold(threshold: u32, signer_count: u32) -> Result<(), MultisigError> {
+    if threshold == 0 || threshold > signer_count {
+        return Err(MultisigError::InvalidThreshold);
+    }
+    Ok(())
+}
+
+#[contractimpl]
+impl MultisigContract {
+    /// Initialize the wallet with an initial signer set and threshold.
+    pub fn initialize(
+        env: Env,
+        signers: Vec<Address>,
+        threshold: u32,
+    ) -> Result<(), MultisigError> {
+        if env.storage().instance().has(&DataKey::Signers) {
+            return Err(MultisigError::AlreadyInitialized);
+        }
+
+        validate_unique_signers(&signers)?;
+        validate_threshold(threshold, signers.len())?;
+
+        for signer in signers.iter() {
+            signer.require_auth();
+        }
+
+        env.storage().instance().set(&DataKey::Signers, &signers);
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &threshold);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextTransactionId, &0u64);
+        env.storage().instance().set(&DataKey::Version, &1u32);
+        bump_instance(&env);
+
+        events::initialized(&env, threshold, signers.len());
+        Ok(())
+    }
+
+    /// Add a signer and optionally adjust the threshold.
+    pub fn add_signer(
+        env: Env,
+        approvals: Vec<Address>,
+        signer: Address,
+        new_threshold: u32,
+    ) -> Result<(), MultisigError> {
+        let mut signers = Self::get_required_signers(&env)?;
+        Self::require_threshold_approvals(&env, &approvals)?;
+
+        if contains(&signers, &signer) {
+            return Err(MultisigError::InvalidSigners);
+        }
+
+        signers.push_back(signer.clone());
+        validate_threshold(new_threshold, signers.len())?;
+
+        env.storage().instance().set(&DataKey::Signers, &signers);
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &new_threshold);
+        bump_instance(&env);
+
+        events::signer_added(&env, &signer, new_threshold);
+        Ok(())
+    }
+
+    /// Remove a signer and optionally adjust the threshold.
+    pub fn remove_signer(
+        env: Env,
+        approvals: Vec<Address>,
+        signer: Address,
+        new_threshold: u32,
+    ) -> Result<(), MultisigError> {
+        let signers = Self::get_required_signers(&env)?;
+        Self::require_threshold_approvals(&env, &approvals)?;
+
+        if !contains(&signers, &signer) {
+            return Err(MultisigError::NotSigner);
+        }
+
+        let mut remaining = Vec::new(&env);
+        for existing in signers.iter() {
+            if existing != signer {
+                remaining.push_back(existing);
+            }
+        }
+
+        validate_unique_signers(&remaining)?;
+        validate_threshold(new_threshold, remaining.len())?;
+
+        env.storage().instance().set(&DataKey::Signers, &remaining);
+        env.storage()
+            .instance()
+            .set(&DataKey::Threshold, &new_threshold);
+        bump_instance(&env);
+
+        events::signer_removed(&env, &signer, new_threshold);
+        Ok(())
+    }
+
+    /// Propose a transaction. The proposer signs it automatically.
+    pub fn propose_transaction(
+        env: Env,
+        proposer: Address,
+        target: Address,
+        function: Symbol,
+        args: Vec<Val>,
+    ) -> Result<u64, MultisigError> {
+        Self::require_signer(&env, &proposer)?;
+        proposer.require_auth();
+
+        let tx_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextTransactionId)
+            .ok_or(MultisigError::NotInitialized)?;
+        let mut signatures = Vec::new(&env);
+        signatures.push_back(proposer.clone());
+
+        let transaction = Transaction {
+            id: tx_id,
+            proposer: proposer.clone(),
+            target,
+            function,
+            args,
+            signatures,
+            executed: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transaction(tx_id), &transaction);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextTransactionId, &(tx_id + 1));
+        bump_instance(&env);
+        bump_transaction(&env, tx_id);
+
+        events::transaction_proposed(&env, tx_id, &proposer);
+        Ok(tx_id)
+    }
+
+    /// Sign a pending transaction.
+    pub fn sign_transaction(env: Env, signer: Address, tx_id: u64) -> Result<(), MultisigError> {
+        Self::require_signer(&env, &signer)?;
+        signer.require_auth();
+
+        let mut transaction = Self::get_required_transaction(&env, tx_id)?;
+        if transaction.executed {
+            return Err(MultisigError::AlreadyExecuted);
+        }
+        if contains(&transaction.signatures, &signer) {
+            return Err(MultisigError::AlreadySigned);
+        }
+
+        transaction.signatures.push_back(signer.clone());
+        let signature_count = transaction.signatures.len();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transaction(tx_id), &transaction);
+        bump_transaction(&env, tx_id);
+
+        events::transaction_signed(&env, tx_id, &signer, signature_count);
+        Ok(())
+    }
+
+    /// Execute a transaction once it has enough signatures.
+    pub fn execute_transaction(env: Env, tx_id: u64) -> Result<Val, MultisigError> {
+        let mut transaction = Self::get_required_transaction(&env, tx_id)?;
+        if transaction.executed {
+            return Err(MultisigError::AlreadyExecuted);
+        }
+
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .ok_or(MultisigError::NotInitialized)?;
+        if transaction.signatures.len() < threshold {
+            return Err(MultisigError::ThresholdNotMet);
+        }
+
+        transaction.executed = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transaction(tx_id), &transaction);
+        bump_transaction(&env, tx_id);
+        events::transaction_executed(&env, tx_id);
+
+        let result: Val =
+            env.invoke_contract(&transaction.target, &transaction.function, transaction.args);
+        Ok(result)
+    }
+
+    pub fn get_signers(env: Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    pub fn get_threshold(env: Env) -> Option<u32> {
+        env.storage().instance().get(&DataKey::Threshold)
+    }
+
+    pub fn is_signer(env: Env, address: Address) -> bool {
+        env.storage()
+            .instance()
+            .get::<DataKey, Vec<Address>>(&DataKey::Signers)
+            .is_some_and(|signers| contains(&signers, &address))
+    }
+
+    pub fn get_transaction(env: Env, tx_id: u64) -> Option<Transaction> {
+        let transaction = env.storage().persistent().get(&DataKey::Transaction(tx_id));
+        if transaction.is_some() {
+            bump_transaction(&env, tx_id);
+        }
+        transaction
+    }
+
+    pub fn signature_count(env: Env, tx_id: u64) -> Option<u32> {
+        Self::get_transaction(env, tx_id).map(|tx| tx.signatures.len())
+    }
+
+    fn get_required_signers(env: &Env) -> Result<Vec<Address>, MultisigError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Signers)
+            .ok_or(MultisigError::NotInitialized)
+    }
+
+    fn get_required_transaction(env: &Env, tx_id: u64) -> Result<Transaction, MultisigError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Transaction(tx_id))
+            .ok_or(MultisigError::TransactionNotFound)
+    }
+
+    fn require_signer(env: &Env, signer: &Address) -> Result<(), MultisigError> {
+        let signers = Self::get_required_signers(env)?;
+        if !contains(&signers, signer) {
+            return Err(MultisigError::NotSigner);
+        }
+        Ok(())
+    }
+
+    fn require_threshold_approvals(
+        env: &Env,
+        approvals: &Vec<Address>,
+    ) -> Result<(), MultisigError> {
+        validate_unique_signers(approvals)?;
+
+        let signers = Self::get_required_signers(env)?;
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .ok_or(MultisigError::NotInitialized)?;
+        if approvals.len() < threshold {
+            return Err(MultisigError::InsufficientApprovals);
+        }
+
+        for approver in approvals.iter() {
+            if !contains(&signers, &approver) {
+                return Err(MultisigError::NotSigner);
+            }
+            approver.require_auth();
+        }
+
+        Ok(())
+    }
+}

--- a/contracts/multisig/src/prop_test.rs
+++ b/contracts/multisig/src/prop_test.rs
@@ -1,0 +1,60 @@
+#![cfg(test)]
+
+use std::format;
+
+use proptest::prelude::*;
+use soroban_sdk::{testutils::Address as _, vec, Address, Env};
+
+use crate::{MultisigContract, MultisigContractClient};
+
+fn signer_vec(env: &Env, count: u32) -> soroban_sdk::Vec<Address> {
+    let mut signers = soroban_sdk::Vec::new(env);
+    for _ in 0..count {
+        signers.push_back(Address::generate(env));
+    }
+    signers
+}
+
+proptest! {
+    #[test]
+    fn prop_valid_thresholds_initialize(signer_count in 1u32..=10, threshold in 1u32..=10) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let signers = signer_vec(&env, signer_count);
+        let contract_address = env.register_contract(None, MultisigContract);
+        let client = MultisigContractClient::new(&env, &contract_address);
+
+        let result = client.try_initialize(&signers, &threshold);
+        if threshold <= signer_count {
+            prop_assert!(result.is_ok());
+            prop_assert_eq!(client.get_threshold(), Some(threshold));
+            prop_assert_eq!(client.get_signers().len(), signer_count);
+        } else {
+            prop_assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn prop_duplicate_approvals_never_satisfy_threshold(extra_signers in 0u32..=6) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let signers = signer_vec(&env, 2 + extra_signers);
+        let alice = signers.get(0).unwrap();
+        let bob = signers.get(1).unwrap();
+        let contract_address = env.register_contract(None, MultisigContract);
+        let client = MultisigContractClient::new(&env, &contract_address);
+        client.initialize(&signers, &2);
+
+        let new_signer = Address::generate(&env);
+        let duplicate_approvals = vec![&env, alice.clone(), alice.clone()];
+        let result = client.try_add_signer(&duplicate_approvals, &new_signer, &2);
+
+        prop_assert!(result.is_err());
+        prop_assert!(!client.is_signer(&new_signer));
+
+        let valid_approvals = vec![&env, alice, bob];
+        let result = client.try_add_signer(&valid_approvals, &new_signer, &2);
+        prop_assert!(result.is_ok());
+        prop_assert!(client.is_signer(&new_signer));
+    }
+}

--- a/contracts/multisig/src/storage.rs
+++ b/contracts/multisig/src/storage.rs
@@ -1,0 +1,24 @@
+use soroban_sdk::{contracttype, Address, Symbol, Val, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Signers,
+    Threshold,
+    NextTransactionId,
+    Transaction(u64),
+    Paused,
+    Version,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Transaction {
+    pub id: u64,
+    pub proposer: Address,
+    pub target: Address,
+    pub function: Symbol,
+    pub args: Vec<Val>,
+    pub signatures: Vec<Address>,
+    pub executed: bool,
+}

--- a/contracts/multisig/src/test.rs
+++ b/contracts/multisig/src/test.rs
@@ -1,0 +1,266 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    contract, contractimpl,
+    testutils::{Address as _, Events as _},
+    vec, Address, Env, FromVal, IntoVal, Symbol,
+};
+
+#[contract]
+pub struct CounterContract;
+
+#[contractimpl]
+impl CounterContract {
+    pub fn increment(env: Env, amount: u32) -> u32 {
+        let current = Self::get(env.clone());
+        let next = current + amount;
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "count"), &next);
+        next
+    }
+
+    pub fn get(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&Symbol::new(&env, "count"))
+            .unwrap_or(0)
+    }
+}
+
+fn create_multisig<'a>(
+    env: &'a Env,
+) -> (
+    MultisigContractClient<'a>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let alice = Address::generate(env);
+    let bob = Address::generate(env);
+    let carol = Address::generate(env);
+    let contract_address = env.register_contract(None, MultisigContract);
+    let client = MultisigContractClient::new(env, &contract_address);
+
+    client.initialize(&vec![env, alice.clone(), bob.clone(), carol.clone()], &2);
+
+    (client, alice, bob, carol, contract_address)
+}
+
+#[test]
+fn initialize_stores_signers_and_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, alice, bob, carol, contract_address) = create_multisig(&env);
+
+    assert_eq!(client.get_threshold(), Some(2));
+    assert_eq!(client.get_signers(), vec![&env, alice, bob, carol]);
+    assert_eq!(
+        env.events().all(),
+        vec![
+            &env,
+            (
+                contract_address,
+                (Symbol::new(&env, "initialized"), 2u32).into_val(&env),
+                3u32.into_val(&env),
+            )
+        ]
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn initialize_rejects_zero_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let alice = Address::generate(&env);
+    let contract_address = env.register_contract(None, MultisigContract);
+    let client = MultisigContractClient::new(&env, &contract_address);
+
+    client.initialize(&vec![&env, alice], &0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn initialize_rejects_duplicate_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let alice = Address::generate(&env);
+    let contract_address = env.register_contract(None, MultisigContract);
+    let client = MultisigContractClient::new(&env, &contract_address);
+
+    client.initialize(&vec![&env, alice.clone(), alice], &1);
+}
+
+#[test]
+fn add_signer_with_threshold_approvals_updates_signer_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, bob, carol, _) = create_multisig(&env);
+    let dave = Address::generate(&env);
+
+    client.add_signer(&vec![&env, alice.clone(), bob.clone()], &dave, &3);
+
+    assert_eq!(client.get_threshold(), Some(3));
+    assert_eq!(client.get_signers(), vec![&env, alice, bob, carol, dave]);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn add_signer_rejects_insufficient_approvals() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, _, _, _) = create_multisig(&env);
+    let dave = Address::generate(&env);
+
+    client.add_signer(&vec![&env, alice], &dave, &2);
+}
+
+#[test]
+fn remove_signer_with_threshold_approvals_updates_signer_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, bob, carol, _) = create_multisig(&env);
+
+    client.remove_signer(&vec![&env, alice.clone(), bob.clone()], &carol, &2);
+
+    assert_eq!(client.get_threshold(), Some(2));
+    assert_eq!(client.get_signers(), vec![&env, alice, bob]);
+    assert!(!client.is_signer(&carol));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn remove_signer_rejects_threshold_above_remaining_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, bob, carol, _) = create_multisig(&env);
+
+    client.remove_signer(&vec![&env, alice, bob], &carol, &3);
+}
+
+#[test]
+fn propose_transaction_stores_transaction_and_auto_signature() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, _, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 7u32.into_val(&env)],
+    );
+
+    let transaction = client.get_transaction(&tx_id).expect("transaction exists");
+    assert_eq!(tx_id, 0);
+    assert_eq!(transaction.proposer, alice.clone());
+    assert_eq!(transaction.target, target);
+    assert_eq!(transaction.signatures, vec![&env, alice]);
+    assert!(!transaction.executed);
+    assert_eq!(client.signature_count(&tx_id), Some(1));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn non_signer_cannot_propose_transaction() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _) = create_multisig(&env);
+    let outsider = Address::generate(&env);
+    let target = env.register_contract(None, CounterContract);
+
+    client.propose_transaction(
+        &outsider,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 1u32.into_val(&env)],
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn signer_cannot_sign_same_transaction_twice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, _, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 1u32.into_val(&env)],
+    );
+
+    client.sign_transaction(&alice, &tx_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn execute_rejects_when_threshold_not_met() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, _, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 1u32.into_val(&env)],
+    );
+
+    client.execute_transaction(&tx_id);
+}
+
+#[test]
+fn execute_runs_target_call_once_when_threshold_met() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, bob, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+    let counter = CounterContractClient::new(&env, &target);
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 5u32.into_val(&env)],
+    );
+
+    client.sign_transaction(&bob, &tx_id);
+    let result = client.execute_transaction(&tx_id);
+    let value = u32::from_val(&env, &result);
+
+    assert_eq!(value, 5);
+    assert_eq!(counter.get(), 5);
+    assert!(
+        client
+            .get_transaction(&tx_id)
+            .expect("transaction exists")
+            .executed
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn execute_rejects_second_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, bob, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 5u32.into_val(&env)],
+    );
+
+    client.sign_transaction(&bob, &tx_id);
+    client.execute_transaction(&tx_id);
+    client.execute_transaction(&tx_id);
+}


### PR DESCRIPTION
## Description

Adds a new Soroban N-of-M multisig wallet contract template under `contracts/multisig/`. The contract supports threshold initialization, signer add/remove flows with threshold approvals, transaction proposal, transaction signing, and execution of generic contract calls once the threshold is met.

Closes #522

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Other

## Testing Done

- [x] `cargo fmt --check -p soroban-multisig-template`
- [x] `cargo test -p soroban-multisig-template`

## Checklist

- [x] I have reviewed my changes.
- [x] I have added or updated documentation where needed.
- [x] I have tested the changes locally where applicable.
- [x] My changes do not introduce new warnings or errors.