### PR TITLE
feat: developer experience improvements (Makefile, justfile, test script, devcontainer)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,6 +20,8 @@
     "vscode": {
       "extensions": [
         "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "serayuzgur.crates",
         "ms-azuretools.vscode-docker"
       ],
       "settings": {

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help build test test-all-features clippy fmt deploy-testnet deploy-local bench clean
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build all contracts
+	cargo build --release
+
+test: ## Run unit tests
+	cargo test
+
+test-all-features: ## Run unit tests with all features enabled
+	cargo test --all-features
+
+clippy: ## Run Clippy lints
+	cargo clippy --all-targets --all-features -- -D warnings
+
+fmt: ## Format source code
+	cargo fmt --all
+
+deploy-testnet: ## Deploy contracts to testnet
+	./scripts/deploy.sh testnet
+
+deploy-local: ## Deploy contracts to local node
+	./scripts/deploy.sh local
+
+bench: ## Run benchmarks
+	cargo bench
+
+clean: ## Remove build artifacts
+	cargo clean

--- a/README.md
+++ b/README.md
@@ -12,15 +12,26 @@ A curated collection of production-ready Soroban smart contract templates. These
 git clone https://github.com/your-username/soroban-contract-templates.git
 cd soroban-contract-templates
 
-# Build a contract from the repo root (example: token)
-stellar contract build --manifest-path contracts/token/Cargo.toml
-# Alternatively: cd contracts/token && stellar contract build
-
-# Deploy to testnet
-./scripts/deploy.sh testnet
+# Build all contracts
+make build
 
 # Run tests
-cargo test
+make test
+
+# Deploy to testnet
+make deploy-testnet
+
+# See all available commands
+make help
+```
+
+Or use `just` (see [dev-environment.md](docs/dev-environment.md) for installation):
+
+```bash
+just build
+just test
+just deploy-testnet
+just --list
 ```
 
 ## 📦 Contract Templates

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -8,6 +8,24 @@
 | Docker | 24+ | https://docs.docker.com/get-docker/ |
 | Rust | 1.78+ | https://rustup.rs |
 | Stellar CLI | latest | `cargo install --locked stellar-cli --features opt` |
+| just (optional) | latest | `cargo install just` |
+
+### Installing `just`
+
+`just` is a command runner popular in the Rust ecosystem with better cross-platform support than `make`:
+
+```bash
+# Via cargo (all platforms)
+cargo install just
+
+# Via homebrew (macOS/Linux)
+brew install just
+
+# Via winget (Windows)
+winget install Casey.Just
+```
+
+Run `just --list` from the project root to see all available recipes.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,39 @@
+# List available recipes
+default:
+    @just --list
+
+# Build all contracts
+build:
+    cargo build --release
+
+# Run unit tests
+test:
+    cargo test
+
+# Run unit tests with all features enabled
+test-all-features:
+    cargo test --all-features
+
+# Run Clippy lints
+clippy:
+    cargo clippy --all-targets --all-features -- -D warnings
+
+# Format source code
+fmt:
+    cargo fmt --all
+
+# Deploy contracts to testnet
+deploy-testnet:
+    ./scripts/deploy.sh testnet
+
+# Deploy contracts to local node
+deploy-local:
+    ./scripts/deploy.sh local
+
+# Run benchmarks
+bench:
+    cargo bench
+
+# Remove build artifacts
+clean:
+    cargo clean

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+run_suite() {
+    local name="$1"
+    shift
+    if "$@" 2>&1; then
+        echo "[PASS] $name"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $name"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Running all test suites ==="
+
+run_suite "unit tests"              cargo test
+run_suite "unit tests (all-features)" cargo test --all-features
+run_suite "integration tests"       cargo test --test '*'
+run_suite "property-based tests"    cargo test --features proptest
+run_suite "benchmarks (dry-run)"    cargo bench --no-run
+
+echo ""
+echo "=== Summary ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- **#512** — Add `tamasfe.even-better-toml` and `serayuzgur.crates` VS Code extensions to `.devcontainer/devcontainer.json`
- **#513** — Add `Makefile` with `build`, `test`, `test-all-features`, `clippy`, `fmt`, `deploy-testnet`, `deploy-local`, `bench`, `clean` targets and a `make help` command; update README Quick Start
- **#514** — Add `justfile` as a cross-platform alternative; add `just` installation instructions to `docs/dev-environment.md`
- **#515** — Add `scripts/test-all.sh` that runs all test suites (unit, all-features, integration, property-based, bench dry-run), prints pass/fail summary, and exits non-zero on any failure

## Test plan

- [ ] Open repo in a devcontainer — verify `rust-analyzer`, `Even Better TOML`, and `crates` extensions install automatically
- [ ] Run `make help` — verify all targets are listed
- [ ] Run `make build`, `make test`, `make clippy`, `make fmt`
- [ ] Run `just --list` — verify all recipes are listed
- [ ] Run `bash scripts/test-all.sh` — verify summary and non-zero exit on failure

Closes #512, closes #513, closes #514, closes #515
