### PR TITLE
docs: add ADR 0007 token interface compliance and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, 
 - [Freighter Wallet](https://freighter.app/)
 - [Stellar Laboratory](https://laboratory.stellar.org/)
 - [Security Best Practices](docs/security.md)
- - [Architecture Decision Records](docs/adr/README.md)
+- [Token Interface Compliance ADR](docs/adr/0007-token-interface-compliance.md)
+- [Architecture Decision Records](docs/adr/README.md)
 
 ## 📄 License
 

--- a/docs/adr/0007-token-interface-compliance.md
+++ b/docs/adr/0007-token-interface-compliance.md
@@ -9,7 +9,7 @@ The `contracts/token` implementation in this repo implements `soroban_sdk::token
 
 ## Decision
 
-Document the contract as compliant with the Soroban SDK token interface (`soroban_sdk::token::TokenInterface`). There is no single formal SEP number for the Soroban token interface at the time of this ADR; instead this ADR records the contract's compliance checklist, deviations, and verification steps.
+Document the contract as compliant with the Soroban SDK token interface (`soroban_sdk::token::TokenInterface`). This implementation aligns with SEP-41 token transfer semantics as referenced in the project changelog. At the time of this ADR, the Soroban token interface is exercised through the SDK trait rather than a single canonical SEP document; this ADR records the compliance checklist, deviations, and verification steps.
 
 ## Compliance checklist
 


### PR DESCRIPTION
# PR Summay

Added ADR 0007 documenting the token contract’s` [soroban_sdk::token::TokenInterface](https://solid-waddle-wv7p4r7pq6jvc5jrx.github.dev/)` compliance, SEP-41 alignment, compliance checklist, known deviations, and verification guidance; also added a direct link from `[README.md](https://solid-waddle-wv7p4r7pq6jvc5jrx.github.dev/)`.

## Closes
Closes  #492 
