### PR TITLE
feat: add timelock, NFT, DAO, and atomic swap contract templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-dao-template"
+version = "0.1.0"
+dependencies = [
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-env-common"
 version = "21.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1419,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-nft-template"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-sdk"
 version = "21.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,6 +1502,22 @@ name = "soroban-staking-template"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "soroban-swap-template"
+version = "0.1.0"
+dependencies = [
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "soroban-timelock-template"
+version = "0.1.0"
+dependencies = [
  "soroban-common",
  "soroban-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "tests", "fuzz"]
+members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/timelock", "contracts/nft", "contracts/dao", "contracts/swap", "tests", "fuzz"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ just --list
 | **Vesting** | Token vesting with cliff + linear release schedule | Team allocations, investor lockups, employee grants | ✅ Complete |
 | **Staking** | Token staking with proportional reward distribution | DeFi yield, protocol incentives, liquidity mining | ✅ Complete |
 | **Multisig** | N-of-M wallet for threshold-approved contract calls | DAO treasuries, team wallets, shared administration | ✅ Complete |
+| **Timelock** | Time-locked token release to a beneficiary | Team token locks, delayed payments, governance timelocks | ✅ Complete |
+| **NFT** | Non-fungible token with admin minting and optional supply cap | Digital collectibles, on-chain ownership, access tokens | ✅ Complete |
+| **DAO** | On-chain governance with token-weighted voting | Protocol upgrades, treasury management, community decisions | ✅ Complete |
+| **Swap** | Atomic two-party token swap with deadline | P2P token exchange, OTC trades, trustless DeFi swaps | ✅ Complete |
 
 ### Token Contract Features
 - **Standard Interface**: Full Soroban token compatibility
@@ -84,6 +88,40 @@ just --list
 - **Signature Tracking**: Prevent duplicate signatures and non-signer approvals
 - **Threshold Execution**: Execute proposed calls only after enough signatures
 - **Event Emission**: Initialization, signer changes, signatures, and execution emit events
+
+### Timelock Contract Features
+- **Time-Locked Release**: Tokens held until a specified ledger sequence number, then released to the beneficiary
+- **Admin Cancellation**: Admin can cancel and reclaim tokens at any time before release
+- **Open Release**: Once the release ledger is reached, `release` is callable by anyone
+- **Token Agnostic**: Works with any Soroban-compatible token
+- **Event Emission**: `initialized`, `released`, and `cancelled` events for off-chain tracking
+- **TTL Management**: Instance storage TTL is extended on every interaction
+
+### NFT Contract Features
+- **Unique Token Ownership**: Each token ID maps to exactly one owner tracked in persistent storage
+- **Admin-Controlled Minting**: Only the admin may mint new tokens; optional supply cap enforced at mint time
+- **Standard Operations**: `mint`, `transfer`, `burn`, `approve`, `transfer_from` matching ERC-721 semantics
+- **Per-Token Metadata**: Each token has an associated URI stored on-chain; collection has name and symbol
+- **Approval System**: Single-token approvals cleared automatically on transfer or burn
+- **Property Tests**: Proptest suite verifies supply invariants and ownership correctness
+- **Event Emission**: `minted`, `transferred`, `burned`, and `approved` events
+
+### DAO Contract Features
+- **Token-Weighted Voting**: Voting power equals the voter's token balance at vote time
+- **Configurable Parameters**: Voting period (in ledgers) and quorum threshold set at initialization
+- **Proposal Lifecycle**: `Active → Executed` (passes) or `Active → Cancelled` (admin)
+- **Quorum + Majority**: Proposals execute only when total votes ≥ quorum AND yes > no
+- **Double-Vote Prevention**: Each address may vote exactly once per proposal
+- **Event Emission**: `proposal_created`, `voted`, `prop_executed`, and `prop_cancelled` events
+- **TTL Management**: Persistent proposal and vote records are bumped on every write
+
+### Swap Contract Features
+- **Atomic Exchange**: Both token transfers occur in a single transaction — no partial fills
+- **Deadline-Based Expiry**: Swaps expire after a configurable ledger; anyone may cancel to recover party A's tokens
+- **Party A Control**: Party A can cancel any open swap before it is accepted
+- **Multi-Swap Support**: Multiple concurrent swaps tracked by auto-incrementing IDs
+- **Token Agnostic**: Works with any pair of Soroban-compatible tokens
+- **Event Emission**: `swap_proposed`, `swap_accepted`, and `swap_cancelled` events
 
 Each template includes:
 - ✅ Complete contract implementation

--- a/contracts/dao/Cargo.toml
+++ b/contracts/dao/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "soroban-dao-template"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+description = "A production-ready Soroban DAO governance contract template"
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[[bin]]
+name = "deploy"
+path = "src/bin/deploy.rs"
+doc = false
+
+[lints]
+workspace = true

--- a/contracts/dao/build.rs
+++ b/contracts/dao/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/contracts/dao/scripts/deploy.sh
+++ b/contracts/dao/scripts/deploy.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Soroban DAO Governance Contract Deployment Script
+# Usage: ./deploy.sh [network]
+# Example: ./deploy.sh testnet
+
+set -e
+
+NETWORK=${1:-testnet}
+CONTRACT_NAME="soroban-dao-template"
+
+echo "Deploying DAO Contract to $NETWORK..."
+
+echo "Building contract..."
+stellar contract build
+
+echo "Deploying to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/${CONTRACT_NAME}.wasm \
+    --network $NETWORK)
+
+echo "DAO contract deployed!"
+echo "Contract ID: $CONTRACT_ID"
+
+CONTRACT_IDS_FILE="../../../.contract-ids"
+if [ ! -f "$CONTRACT_IDS_FILE" ]; then
+    echo "{\"network\": \"$NETWORK\", \"contracts\": {\"dao\": \"$CONTRACT_ID\"}}" > "$CONTRACT_IDS_FILE"
+else
+    TEMP_FILE="${CONTRACT_IDS_FILE}.tmp"
+    jq --arg network "$NETWORK" --arg contract_id "$CONTRACT_ID" \
+        '.network = $network | .contracts.dao = $contract_id' \
+        "$CONTRACT_IDS_FILE" > "$TEMP_FILE"
+    mv "$TEMP_FILE" "$CONTRACT_IDS_FILE"
+fi
+
+# Example initialization (uncomment to use):
+# ADMIN_ADDRESS="G..."
+# TOKEN_ADDRESS="C..."         # governance token contract
+# VOTING_PERIOD=17280          # ~24h at 5s/ledger
+# QUORUM=1000000000            # minimum total votes (token units)
+
+# stellar contract invoke \
+#     --id $CONTRACT_ID \
+#     --network $NETWORK \
+#     -- initialize \
+#     --admin $ADMIN_ADDRESS \
+#     --token $TOKEN_ADDRESS \
+#     --voting_period $VOTING_PERIOD \
+#     --quorum $QUORUM
+
+echo "DAO contract ready for use!"
+echo "Save this Contract ID: $CONTRACT_ID"

--- a/contracts/dao/src/bin/deploy.rs
+++ b/contracts/dao/src/bin/deploy.rs
@@ -1,0 +1,35 @@
+//! Deploy helper for soroban-dao-template.
+//!
+//! Usage:
+//!   cargo run --bin deploy -- --network testnet --source alice
+//!   cargo run --bin deploy -- --network mainnet --source alice --wasm path/to/dao.wasm
+
+use std::process::{Command, ExitCode};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let has_wasm_flag = args.windows(2).any(|w| w[0] == "--wasm");
+    if !has_wasm_flag {
+        let status = Command::new("stellar")
+            .args(["contract", "build"])
+            .status()
+            .expect("failed to run `stellar contract build`");
+        if !status.success() {
+            eprintln!("Build failed.");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    let status = Command::new("stellar")
+        .args(["contract", "deploy"])
+        .args(&args)
+        .status()
+        .expect("failed to run `stellar contract deploy`");
+
+    if status.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}

--- a/contracts/dao/src/errors.rs
+++ b/contracts/dao/src/errors.rs
@@ -1,0 +1,33 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Copy, Debug)]
+pub enum DaoError {
+    NotAuthorized = 1,
+    AlreadyInitialized = 2,
+    NotInitialized = 3,
+    ProposalNotFound = 4,
+    InvalidState = 5,
+    DeadlineNotReached = 6,
+    AlreadyVoted = 7,
+    QuorumNotMet = 8,
+    ProposalRejected = 9,
+    InsufficientVotingPower = 10,
+}
+
+impl core::fmt::Display for DaoError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DaoError::NotAuthorized => write!(f, "not authorized"),
+            DaoError::AlreadyInitialized => write!(f, "already initialized"),
+            DaoError::NotInitialized => write!(f, "not initialized"),
+            DaoError::ProposalNotFound => write!(f, "proposal not found"),
+            DaoError::InvalidState => write!(f, "invalid proposal state"),
+            DaoError::DeadlineNotReached => write!(f, "voting deadline not yet reached"),
+            DaoError::AlreadyVoted => write!(f, "already voted on this proposal"),
+            DaoError::QuorumNotMet => write!(f, "quorum not met"),
+            DaoError::ProposalRejected => write!(f, "proposal rejected by majority"),
+            DaoError::InsufficientVotingPower => write!(f, "insufficient voting power"),
+        }
+    }
+}

--- a/contracts/dao/src/events.rs
+++ b/contracts/dao/src/events.rs
@@ -1,0 +1,34 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+pub fn initialized(env: &Env, admin: &Address, token: &Address, quorum: i128) {
+    env.events().publish(
+        (Symbol::new(env, "initialized"), admin.clone(), token.clone()),
+        quorum,
+    );
+}
+
+pub fn proposal_created(env: &Env, proposer: &Address, proposal_id: u32) {
+    env.events().publish(
+        (Symbol::new(env, "proposal_created"), proposer.clone()),
+        proposal_id,
+    );
+}
+
+pub fn voted(env: &Env, voter: &Address, proposal_id: u32, support: bool, weight: i128) {
+    env.events().publish(
+        (Symbol::new(env, "voted"), voter.clone()),
+        (proposal_id, support, weight),
+    );
+}
+
+pub fn proposal_executed(env: &Env, proposal_id: u32) {
+    env.events()
+        .publish((Symbol::new(env, "prop_executed"),), proposal_id);
+}
+
+pub fn proposal_cancelled(env: &Env, admin: &Address, proposal_id: u32) {
+    env.events().publish(
+        (Symbol::new(env, "prop_cancelled"), admin.clone()),
+        proposal_id,
+    );
+}

--- a/contracts/dao/src/lib.rs
+++ b/contracts/dao/src/lib.rs
@@ -1,0 +1,296 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, token, Address, Env, String};
+
+mod errors;
+mod events;
+mod storage;
+
+pub use errors::DaoError;
+pub use storage::{DataKey, Proposal, ProposalKey, ProposalState, VoteKey};
+
+use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+fn bump_persistent<K>(env: &Env, key: &K)
+where
+    K: soroban_sdk::TryIntoVal<Env, soroban_sdk::Val>
+        + soroban_sdk::IntoVal<Env, soroban_sdk::Val>,
+{
+    env.storage()
+        .persistent()
+        .extend_ttl(key, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+/// DAO governance contract for on-chain proposal creation and token-weighted voting.
+///
+/// Voting power is the voter's token balance at vote time (simplified snapshot).
+/// A proposal passes when `yes_votes > no_votes` and total votes reach the quorum.
+#[contract]
+pub struct DaoContract;
+
+#[contractimpl]
+impl DaoContract {
+    /// Initialize the DAO.
+    ///
+    /// - `voting_period` — number of ledgers a proposal stays open for voting.
+    /// - `quorum` — minimum total votes (in token units) required for a valid result.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DaoError::AlreadyInitialized`] if called again.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        token: Address,
+        voting_period: u32,
+        quorum: i128,
+    ) -> Result<(), DaoError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(DaoError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Token, &token);
+        env.storage().instance().set(&DataKey::VotingPeriod, &voting_period);
+        env.storage().instance().set(&DataKey::Quorum, &quorum);
+        env.storage().instance().set(&DataKey::ProposalCount, &0u32);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+
+        bump_instance(&env);
+        events::initialized(&env, &admin, &token, quorum);
+
+        Ok(())
+    }
+
+    /// Create a new proposal. The proposer must hold > 0 governance tokens.
+    ///
+    /// Returns the newly created `proposal_id`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DaoError::NotInitialized`] if the DAO has not been set up.
+    /// Returns [`DaoError::InsufficientVotingPower`] if the proposer has no tokens.
+    pub fn create_proposal(
+        env: Env,
+        proposer: Address,
+        title: String,
+        description: String,
+    ) -> Result<u32, DaoError> {
+        Self::require_initialized(&env)?;
+        proposer.require_auth();
+
+        let token: Address = env.storage().instance().get(&DataKey::Token)
+            .ok_or(DaoError::NotInitialized)?;
+        let balance = token::Client::new(&env, &token).balance(&proposer);
+        if balance <= 0 {
+            return Err(DaoError::InsufficientVotingPower);
+        }
+
+        let count: u32 = env.storage().instance().get(&DataKey::ProposalCount).unwrap_or(0);
+        let proposal_id = count;
+
+        let voting_period: u32 = env.storage().instance().get(&DataKey::VotingPeriod)
+            .ok_or(DaoError::NotInitialized)?;
+        let deadline = env.ledger().sequence() + voting_period;
+
+        let proposal = Proposal {
+            id: proposal_id,
+            proposer: proposer.clone(),
+            title,
+            description,
+            deadline,
+            yes_votes: 0,
+            no_votes: 0,
+            state: ProposalState::Active,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&ProposalKey::Proposal(proposal_id), &proposal);
+        env.storage().instance().set(&DataKey::ProposalCount, &(count + 1));
+
+        bump_instance(&env);
+        bump_persistent(&env, &ProposalKey::Proposal(proposal_id));
+        events::proposal_created(&env, &proposer, proposal_id);
+
+        Ok(proposal_id)
+    }
+
+    /// Cast a vote on an active proposal. Voting weight is the voter's current token balance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DaoError::ProposalNotFound`] if the proposal does not exist.
+    /// Returns [`DaoError::InvalidState`] if the proposal is not `Active`.
+    /// Returns [`DaoError::DeadlineNotReached`] if the voting period has expired (deadline passed).
+    /// Returns [`DaoError::AlreadyVoted`] if the voter has already voted.
+    /// Returns [`DaoError::InsufficientVotingPower`] if the voter has no tokens.
+    pub fn vote(
+        env: Env,
+        voter: Address,
+        proposal_id: u32,
+        support: bool,
+    ) -> Result<(), DaoError> {
+        Self::require_initialized(&env)?;
+        voter.require_auth();
+
+        let mut proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&ProposalKey::Proposal(proposal_id))
+            .ok_or(DaoError::ProposalNotFound)?;
+
+        if proposal.state != ProposalState::Active {
+            return Err(DaoError::InvalidState);
+        }
+        if env.ledger().sequence() > proposal.deadline {
+            return Err(DaoError::DeadlineNotReached);
+        }
+
+        let vote_key = VoteKey {
+            proposal_id,
+            voter: voter.clone(),
+        };
+        if env.storage().persistent().has(&vote_key) {
+            return Err(DaoError::AlreadyVoted);
+        }
+
+        let token: Address = env.storage().instance().get(&DataKey::Token)
+            .ok_or(DaoError::NotInitialized)?;
+        let weight = token::Client::new(&env, &token).balance(&voter);
+        if weight <= 0 {
+            return Err(DaoError::InsufficientVotingPower);
+        }
+
+        if support {
+            proposal.yes_votes += weight;
+        } else {
+            proposal.no_votes += weight;
+        }
+
+        env.storage()
+            .persistent()
+            .set(&ProposalKey::Proposal(proposal_id), &proposal);
+        env.storage().persistent().set(&vote_key, &weight);
+
+        bump_persistent(&env, &ProposalKey::Proposal(proposal_id));
+        bump_persistent(&env, &vote_key);
+        events::voted(&env, &voter, proposal_id, support, weight);
+
+        Ok(())
+    }
+
+    /// Execute a passed proposal. Callable after the deadline when quorum and majority are met.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DaoError::ProposalNotFound`] if the proposal does not exist.
+    /// Returns [`DaoError::InvalidState`] if the proposal is not `Active`.
+    /// Returns [`DaoError::DeadlineNotReached`] if the voting deadline has not passed.
+    /// Returns [`DaoError::QuorumNotMet`] if total votes are below the quorum threshold.
+    /// Returns [`DaoError::ProposalRejected`] if `no_votes >= yes_votes`.
+    pub fn execute_proposal(env: Env, proposal_id: u32) -> Result<(), DaoError> {
+        Self::require_initialized(&env)?;
+
+        let mut proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&ProposalKey::Proposal(proposal_id))
+            .ok_or(DaoError::ProposalNotFound)?;
+
+        if proposal.state != ProposalState::Active {
+            return Err(DaoError::InvalidState);
+        }
+        if env.ledger().sequence() <= proposal.deadline {
+            return Err(DaoError::DeadlineNotReached);
+        }
+
+        let quorum: i128 = env.storage().instance().get(&DataKey::Quorum)
+            .ok_or(DaoError::NotInitialized)?;
+        let total_votes = proposal.yes_votes + proposal.no_votes;
+
+        if total_votes < quorum {
+            return Err(DaoError::QuorumNotMet);
+        }
+        if proposal.yes_votes <= proposal.no_votes {
+            return Err(DaoError::ProposalRejected);
+        }
+
+        proposal.state = ProposalState::Executed;
+        env.storage()
+            .persistent()
+            .set(&ProposalKey::Proposal(proposal_id), &proposal);
+
+        bump_persistent(&env, &ProposalKey::Proposal(proposal_id));
+        events::proposal_executed(&env, proposal_id);
+
+        Ok(())
+    }
+
+    /// Cancel a proposal. Admin only; works only on `Active` proposals.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DaoError::NotAuthorized`] if the caller is not the admin.
+    /// Returns [`DaoError::ProposalNotFound`] if the proposal does not exist.
+    /// Returns [`DaoError::InvalidState`] if the proposal is not `Active`.
+    pub fn cancel_proposal(env: Env, proposal_id: u32) -> Result<(), DaoError> {
+        Self::require_initialized(&env)?;
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .ok_or(DaoError::NotInitialized)?;
+        admin.require_auth();
+
+        let mut proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&ProposalKey::Proposal(proposal_id))
+            .ok_or(DaoError::ProposalNotFound)?;
+
+        if proposal.state != ProposalState::Active {
+            return Err(DaoError::InvalidState);
+        }
+
+        proposal.state = ProposalState::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&ProposalKey::Proposal(proposal_id), &proposal);
+
+        bump_persistent(&env, &ProposalKey::Proposal(proposal_id));
+        events::proposal_cancelled(&env, &admin, proposal_id);
+
+        Ok(())
+    }
+
+    /// Return a proposal by ID.
+    #[must_use]
+    pub fn get_proposal(env: Env, proposal_id: u32) -> Result<Proposal, DaoError> {
+        env.storage()
+            .persistent()
+            .get(&ProposalKey::Proposal(proposal_id))
+            .ok_or(DaoError::ProposalNotFound)
+    }
+
+    /// Return total number of proposals created.
+    #[must_use]
+    pub fn proposal_count(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::ProposalCount).unwrap_or(0)
+    }
+
+    fn require_initialized(env: &Env) -> Result<(), DaoError> {
+        if !env.storage().instance().has(&DataKey::Initialized) {
+            return Err(DaoError::NotInitialized);
+        }
+        Ok(())
+    }
+}
+
+mod test;

--- a/contracts/dao/src/storage.rs
+++ b/contracts/dao/src/storage.rs
@@ -1,0 +1,59 @@
+use soroban_sdk::{contracttype, Address, String};
+
+/// Instance-storage keys (contract-level state).
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Token,
+    VotingPeriod,
+    Quorum,
+    ProposalCount,
+    Initialized,
+}
+
+/// Persistent-storage keys (per-proposal and per-vote data).
+#[contracttype]
+#[derive(Clone)]
+pub enum ProposalKey {
+    Proposal(u32),
+}
+
+/// Composite key for vote deduplication.
+#[contracttype]
+#[derive(Clone)]
+pub struct VoteKey {
+    pub proposal_id: u32,
+    pub voter: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ProposalState {
+    Active = 0,
+    Executed = 1,
+    Cancelled = 2,
+}
+
+impl core::fmt::Display for ProposalState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            ProposalState::Active => "active",
+            ProposalState::Executed => "executed",
+            ProposalState::Cancelled => "cancelled",
+        })
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Proposal {
+    pub id: u32,
+    pub proposer: Address,
+    pub title: String,
+    pub description: String,
+    pub deadline: u32,
+    pub yes_votes: i128,
+    pub no_votes: i128,
+    pub state: ProposalState,
+}

--- a/contracts/dao/src/test.rs
+++ b/contracts/dao/src/test.rs
@@ -1,0 +1,264 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::StellarAssetClient,
+    Address, Env, String,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup(env: &Env) -> (DaoContractClient, Address, Address, Address) {
+    let admin = Address::generate(env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    let token = sac.address();
+
+    let addr = env.register_contract(None, DaoContract);
+    let client = DaoContractClient::new(env, &addr);
+    client.initialize(&admin, &token, &100, &500);
+
+    (client, admin, token, addr)
+}
+
+fn mint_tokens(env: &Env, token: &Address, admin: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+    let _ = admin;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _) = setup(&env);
+    assert_eq!(client.proposal_count(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_initialize_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin, &token, &100, &500);
+}
+
+#[test]
+fn test_create_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "Upgrade Protocol"),
+        &String::from_str(&env, "Upgrade to v2"),
+    );
+    assert_eq!(id, 0);
+    assert_eq!(client.proposal_count(), 1);
+
+    let proposal = client.get_proposal(&0);
+    assert_eq!(proposal.state, ProposalState::Active);
+    assert_eq!(proposal.yes_votes, 0);
+    assert_eq!(proposal.no_votes, 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_create_proposal_no_tokens_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _) = setup(&env);
+
+    let proposer = Address::generate(&env);
+    // proposer has no tokens
+    client.create_proposal(
+        &proposer,
+        &String::from_str(&env, "Bad Proposal"),
+        &String::from_str(&env, "no tokens"),
+    );
+}
+
+#[test]
+fn test_vote_yes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "P1"),
+        &String::from_str(&env, "Desc"),
+    );
+
+    let voter = Address::generate(&env);
+    mint_tokens(&env, &token, &admin, &voter, 600);
+    client.vote(&voter, &id, &true);
+
+    let proposal = client.get_proposal(&id);
+    assert_eq!(proposal.yes_votes, 600);
+    assert_eq!(proposal.no_votes, 0);
+}
+
+#[test]
+fn test_vote_no() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "P1"),
+        &String::from_str(&env, "Desc"),
+    );
+
+    let voter = Address::generate(&env);
+    mint_tokens(&env, &token, &admin, &voter, 300);
+    client.vote(&voter, &id, &false);
+
+    let proposal = client.get_proposal(&id);
+    assert_eq!(proposal.yes_votes, 0);
+    assert_eq!(proposal.no_votes, 300);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_vote_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "P"),
+        &String::from_str(&env, "D"),
+    );
+
+    let voter = Address::generate(&env);
+    mint_tokens(&env, &token, &admin, &voter, 100);
+    client.vote(&voter, &id, &true);
+    client.vote(&voter, &id, &true);
+}
+
+#[test]
+fn test_execute_proposal_passes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "P"),
+        &String::from_str(&env, "D"),
+    );
+
+    let voter = Address::generate(&env);
+    mint_tokens(&env, &token, &admin, &voter, 600);
+    client.vote(&voter, &id, &true);
+
+    // Advance past voting deadline (voting_period = 100)
+    let deadline = client.get_proposal(&id).deadline;
+    env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
+
+    client.execute_proposal(&id);
+    assert_eq!(client.get_proposal(&id).state, ProposalState::Executed);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_execute_before_deadline_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "P"),
+        &String::from_str(&env, "D"),
+    );
+
+    let voter = Address::generate(&env);
+    mint_tokens(&env, &token, &admin, &voter, 600);
+    client.vote(&voter, &id, &true);
+    // Do NOT advance past deadline
+    client.execute_proposal(&id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_execute_quorum_not_met_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // quorum = 500
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "P"),
+        &String::from_str(&env, "D"),
+    );
+
+    let voter = Address::generate(&env);
+    mint_tokens(&env, &token, &admin, &voter, 100); // only 100 < 500 quorum
+    client.vote(&voter, &id, &true);
+
+    let deadline = client.get_proposal(&id).deadline;
+    env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
+    client.execute_proposal(&id);
+}
+
+#[test]
+fn test_cancel_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "P"),
+        &String::from_str(&env, "D"),
+    );
+
+    client.cancel_proposal(&id);
+    assert_eq!(client.get_proposal(&id).state, ProposalState::Cancelled);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_cancel_already_executed_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+
+    mint_tokens(&env, &token, &admin, &admin, 1_000);
+    let id = client.create_proposal(
+        &admin,
+        &String::from_str(&env, "P"),
+        &String::from_str(&env, "D"),
+    );
+
+    let voter = Address::generate(&env);
+    mint_tokens(&env, &token, &admin, &voter, 600);
+    client.vote(&voter, &id, &true);
+
+    let deadline = client.get_proposal(&id).deadline;
+    env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
+    client.execute_proposal(&id);
+
+    client.cancel_proposal(&id);
+}

--- a/contracts/nft/Cargo.toml
+++ b/contracts/nft/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "soroban-nft-template"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+description = "A production-ready Soroban NFT contract template"
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = { workspace = true }
+
+[[bin]]
+name = "deploy"
+path = "src/bin/deploy.rs"
+doc = false
+
+[lints]
+workspace = true

--- a/contracts/nft/build.rs
+++ b/contracts/nft/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/contracts/nft/scripts/deploy.sh
+++ b/contracts/nft/scripts/deploy.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Soroban NFT Contract Deployment Script
+# Usage: ./deploy.sh [network]
+# Example: ./deploy.sh testnet
+
+set -e
+
+NETWORK=${1:-testnet}
+CONTRACT_NAME="soroban-nft-template"
+
+echo "Deploying NFT Contract to $NETWORK..."
+
+echo "Building contract..."
+stellar contract build
+
+echo "Deploying to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/${CONTRACT_NAME}.wasm \
+    --network $NETWORK)
+
+echo "NFT contract deployed!"
+echo "Contract ID: $CONTRACT_ID"
+
+CONTRACT_IDS_FILE="../../../.contract-ids"
+if [ ! -f "$CONTRACT_IDS_FILE" ]; then
+    echo "{\"network\": \"$NETWORK\", \"contracts\": {\"nft\": \"$CONTRACT_ID\"}}" > "$CONTRACT_IDS_FILE"
+else
+    TEMP_FILE="${CONTRACT_IDS_FILE}.tmp"
+    jq --arg network "$NETWORK" --arg contract_id "$CONTRACT_ID" \
+        '.network = $network | .contracts.nft = $contract_id' \
+        "$CONTRACT_IDS_FILE" > "$TEMP_FILE"
+    mv "$TEMP_FILE" "$CONTRACT_IDS_FILE"
+fi
+
+# Example initialization (uncomment to use):
+# ADMIN_ADDRESS="G..."
+# COLLECTION_NAME="My NFT Collection"
+# COLLECTION_SYMBOL="MNC"
+# MAX_SUPPLY=10000  # set to 0 for no cap
+
+# stellar contract invoke \
+#     --id $CONTRACT_ID \
+#     --network $NETWORK \
+#     -- initialize \
+#     --admin $ADMIN_ADDRESS \
+#     --name "$COLLECTION_NAME" \
+#     --symbol "$COLLECTION_SYMBOL" \
+#     --max_supply $MAX_SUPPLY
+
+# Example minting (uncomment to use):
+# TOKEN_ID=1
+# RECIPIENT_ADDRESS="G..."
+# TOKEN_URI="ipfs://QmYourHashHere/1.json"
+
+# stellar contract invoke \
+#     --id $CONTRACT_ID \
+#     --network $NETWORK \
+#     -- mint \
+#     --to $RECIPIENT_ADDRESS \
+#     --token_id $TOKEN_ID \
+#     --token_uri "$TOKEN_URI"
+
+echo "NFT contract ready for use!"
+echo "Save this Contract ID: $CONTRACT_ID"

--- a/contracts/nft/src/bin/deploy.rs
+++ b/contracts/nft/src/bin/deploy.rs
@@ -1,0 +1,35 @@
+//! Deploy helper for soroban-nft-template.
+//!
+//! Usage:
+//!   cargo run --bin deploy -- --network testnet --source alice
+//!   cargo run --bin deploy -- --network mainnet --source alice --wasm path/to/nft.wasm
+
+use std::process::{Command, ExitCode};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let has_wasm_flag = args.windows(2).any(|w| w[0] == "--wasm");
+    if !has_wasm_flag {
+        let status = Command::new("stellar")
+            .args(["contract", "build"])
+            .status()
+            .expect("failed to run `stellar contract build`");
+        if !status.success() {
+            eprintln!("Build failed.");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    let status = Command::new("stellar")
+        .args(["contract", "deploy"])
+        .args(&args)
+        .status()
+        .expect("failed to run `stellar contract deploy`");
+
+    if status.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}

--- a/contracts/nft/src/errors.rs
+++ b/contracts/nft/src/errors.rs
@@ -1,0 +1,31 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Copy, Debug)]
+pub enum NftError {
+    NotAuthorized = 1,
+    AlreadyInitialized = 2,
+    NotInitialized = 3,
+    TokenNotFound = 4,
+    TokenAlreadyMinted = 5,
+    NotOwner = 6,
+    NotApproved = 7,
+    SupplyCapReached = 8,
+    InvalidTokenId = 9,
+}
+
+impl core::fmt::Display for NftError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            NftError::NotAuthorized => write!(f, "not authorized"),
+            NftError::AlreadyInitialized => write!(f, "already initialized"),
+            NftError::NotInitialized => write!(f, "not initialized"),
+            NftError::TokenNotFound => write!(f, "token not found"),
+            NftError::TokenAlreadyMinted => write!(f, "token already minted"),
+            NftError::NotOwner => write!(f, "not the token owner"),
+            NftError::NotApproved => write!(f, "not approved for this token"),
+            NftError::SupplyCapReached => write!(f, "supply cap reached"),
+            NftError::InvalidTokenId => write!(f, "invalid token id"),
+        }
+    }
+}

--- a/contracts/nft/src/events.rs
+++ b/contracts/nft/src/events.rs
@@ -1,0 +1,32 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+pub fn initialized(env: &Env, admin: &Address, name: &soroban_sdk::String, symbol: &soroban_sdk::String) {
+    env.events().publish(
+        (Symbol::new(env, "initialized"), admin.clone()),
+        (name.clone(), symbol.clone()),
+    );
+}
+
+pub fn minted(env: &Env, to: &Address, token_id: u32) {
+    env.events()
+        .publish((Symbol::new(env, "minted"), to.clone()), token_id);
+}
+
+pub fn transferred(env: &Env, from: &Address, to: &Address, token_id: u32) {
+    env.events().publish(
+        (Symbol::new(env, "transferred"), from.clone(), to.clone()),
+        token_id,
+    );
+}
+
+pub fn burned(env: &Env, from: &Address, token_id: u32) {
+    env.events()
+        .publish((Symbol::new(env, "burned"), from.clone()), token_id);
+}
+
+pub fn approved(env: &Env, owner: &Address, spender: &Address, token_id: u32) {
+    env.events().publish(
+        (Symbol::new(env, "approved"), owner.clone(), spender.clone()),
+        token_id,
+    );
+}

--- a/contracts/nft/src/lib.rs
+++ b/contracts/nft/src/lib.rs
@@ -1,0 +1,322 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env, String};
+
+mod errors;
+mod events;
+mod storage;
+
+pub use errors::NftError;
+pub use storage::{DataKey, TokenKey, TokenMetadata};
+
+use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+fn bump_token(env: &Env, key: &TokenKey) {
+    env.storage()
+        .persistent()
+        .extend_ttl(key, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+/// Non-fungible token (NFT) contract with admin-controlled minting and optional supply cap.
+///
+/// Each token has a unique `token_id` (`u32`), an owner, an optional approved spender,
+/// and a URI pointing to off-chain metadata.
+#[contract]
+pub struct NftContract;
+
+#[contractimpl]
+impl NftContract {
+    /// Initialize the NFT collection.
+    ///
+    /// `max_supply` of `0` means no cap.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NftError::AlreadyInitialized`] if called a second time.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        name: String,
+        symbol: String,
+        max_supply: u32,
+    ) -> Result<(), NftError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(NftError::AlreadyInitialized);
+        }
+
+        admin.require_auth();
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Name, &name);
+        env.storage().instance().set(&DataKey::Symbol, &symbol);
+        env.storage().instance().set(&DataKey::TotalSupply, &0u32);
+        if max_supply > 0 {
+            env.storage().instance().set(&DataKey::MaxSupply, &max_supply);
+        }
+        env.storage().instance().set(&DataKey::Initialized, &true);
+
+        bump_instance(&env);
+        events::initialized(&env, &admin, &name, &symbol);
+
+        Ok(())
+    }
+
+    /// Mint a new token to `to` with the given `token_id` and `token_uri`. Admin only.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NftError::NotInitialized`] if the contract has not been set up.
+    /// Returns [`NftError::NotAuthorized`] if the caller is not the admin.
+    /// Returns [`NftError::TokenAlreadyMinted`] if `token_id` is already taken.
+    /// Returns [`NftError::SupplyCapReached`] if minting would exceed the max supply.
+    pub fn mint(
+        env: Env,
+        to: Address,
+        token_id: u32,
+        token_uri: String,
+    ) -> Result<(), NftError> {
+        Self::require_initialized(&env)?;
+
+        let admin: Address = env.storage().instance().get(&DataKey::Admin)
+            .ok_or(NftError::NotInitialized)?;
+        admin.require_auth();
+
+        if env.storage().persistent().has(&TokenKey::Owner(token_id)) {
+            return Err(NftError::TokenAlreadyMinted);
+        }
+
+        let total: u32 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0);
+        if let Some(max) = env.storage().instance().get::<DataKey, u32>(&DataKey::MaxSupply) {
+            if total >= max {
+                return Err(NftError::SupplyCapReached);
+            }
+        }
+
+        env.storage().persistent().set(&TokenKey::Owner(token_id), &to);
+        env.storage().persistent().set(&TokenKey::Uri(token_id), &token_uri);
+        env.storage().instance().set(&DataKey::TotalSupply, &(total + 1));
+
+        bump_instance(&env);
+        bump_token(&env, &TokenKey::Owner(token_id));
+        bump_token(&env, &TokenKey::Uri(token_id));
+        events::minted(&env, &to, token_id);
+
+        Ok(())
+    }
+
+    /// Transfer token `token_id` from `from` to `to`. Requires auth from `from` (the owner).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NftError::TokenNotFound`] if the token does not exist.
+    /// Returns [`NftError::NotOwner`] if `from` is not the current owner.
+    pub fn transfer(
+        env: Env,
+        from: Address,
+        to: Address,
+        token_id: u32,
+    ) -> Result<(), NftError> {
+        Self::require_initialized(&env)?;
+        from.require_auth();
+
+        let owner: Address = env
+            .storage()
+            .persistent()
+            .get(&TokenKey::Owner(token_id))
+            .ok_or(NftError::TokenNotFound)?;
+
+        if owner != from {
+            return Err(NftError::NotOwner);
+        }
+
+        env.storage().persistent().set(&TokenKey::Owner(token_id), &to);
+        // Clear any existing approval on transfer.
+        env.storage().persistent().remove(&TokenKey::Approval(token_id));
+
+        bump_token(&env, &TokenKey::Owner(token_id));
+        events::transferred(&env, &from, &to, token_id);
+
+        Ok(())
+    }
+
+    /// Burn (destroy) token `token_id`. Requires auth from the current owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NftError::TokenNotFound`] if the token does not exist.
+    /// Returns [`NftError::NotOwner`] if `from` is not the current owner.
+    pub fn burn(env: Env, from: Address, token_id: u32) -> Result<(), NftError> {
+        Self::require_initialized(&env)?;
+        from.require_auth();
+
+        let owner: Address = env
+            .storage()
+            .persistent()
+            .get(&TokenKey::Owner(token_id))
+            .ok_or(NftError::TokenNotFound)?;
+
+        if owner != from {
+            return Err(NftError::NotOwner);
+        }
+
+        env.storage().persistent().remove(&TokenKey::Owner(token_id));
+        env.storage().persistent().remove(&TokenKey::Uri(token_id));
+        env.storage().persistent().remove(&TokenKey::Approval(token_id));
+
+        let total: u32 = env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(1);
+        env.storage().instance().set(&DataKey::TotalSupply, &total.saturating_sub(1));
+
+        bump_instance(&env);
+        events::burned(&env, &from, token_id);
+
+        Ok(())
+    }
+
+    /// Grant `spender` approval to transfer token `token_id`. Caller must be the owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NftError::TokenNotFound`] if the token does not exist.
+    /// Returns [`NftError::NotOwner`] if the caller is not the current owner.
+    pub fn approve(
+        env: Env,
+        token_id: u32,
+        spender: Address,
+    ) -> Result<(), NftError> {
+        Self::require_initialized(&env)?;
+
+        let owner: Address = env
+            .storage()
+            .persistent()
+            .get(&TokenKey::Owner(token_id))
+            .ok_or(NftError::TokenNotFound)?;
+
+        owner.require_auth();
+
+        env.storage().persistent().set(&TokenKey::Approval(token_id), &spender);
+        bump_token(&env, &TokenKey::Approval(token_id));
+        events::approved(&env, &owner, &spender, token_id);
+
+        Ok(())
+    }
+
+    /// Transfer token `token_id` from `from` to `to` using a prior approval. Auth from `spender`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NftError::TokenNotFound`] if the token does not exist.
+    /// Returns [`NftError::NotOwner`] if `from` is not the current owner.
+    /// Returns [`NftError::NotApproved`] if `spender` is not approved for this token.
+    pub fn transfer_from(
+        env: Env,
+        spender: Address,
+        from: Address,
+        to: Address,
+        token_id: u32,
+    ) -> Result<(), NftError> {
+        Self::require_initialized(&env)?;
+        spender.require_auth();
+
+        let owner: Address = env
+            .storage()
+            .persistent()
+            .get(&TokenKey::Owner(token_id))
+            .ok_or(NftError::TokenNotFound)?;
+
+        if owner != from {
+            return Err(NftError::NotOwner);
+        }
+
+        let approved: Option<Address> = env
+            .storage()
+            .persistent()
+            .get(&TokenKey::Approval(token_id));
+
+        match approved {
+            Some(ref a) if *a == spender => {}
+            _ => return Err(NftError::NotApproved),
+        }
+
+        env.storage().persistent().set(&TokenKey::Owner(token_id), &to);
+        env.storage().persistent().remove(&TokenKey::Approval(token_id));
+
+        bump_token(&env, &TokenKey::Owner(token_id));
+        events::transferred(&env, &from, &to, token_id);
+
+        Ok(())
+    }
+
+    /// Return the owner of `token_id`.
+    #[must_use]
+    pub fn owner_of(env: Env, token_id: u32) -> Result<Address, NftError> {
+        env.storage()
+            .persistent()
+            .get(&TokenKey::Owner(token_id))
+            .ok_or(NftError::TokenNotFound)
+    }
+
+    /// Return the approved spender for `token_id`, if any.
+    #[must_use]
+    pub fn get_approved(env: Env, token_id: u32) -> Option<Address> {
+        env.storage().persistent().get(&TokenKey::Approval(token_id))
+    }
+
+    /// Return the token URI for `token_id`.
+    #[must_use]
+    pub fn token_uri(env: Env, token_id: u32) -> Result<String, NftError> {
+        env.storage()
+            .persistent()
+            .get(&TokenKey::Uri(token_id))
+            .ok_or(NftError::TokenNotFound)
+    }
+
+    /// Return collection metadata as a [`TokenMetadata`] struct.
+    #[must_use]
+    pub fn metadata(env: Env) -> Result<TokenMetadata, NftError> {
+        Self::require_initialized(&env)?;
+        Ok(TokenMetadata {
+            name: env.storage().instance().get(&DataKey::Name).ok_or(NftError::NotInitialized)?,
+            symbol: env.storage().instance().get(&DataKey::Symbol).ok_or(NftError::NotInitialized)?,
+            token_uri: String::from_str(&env, ""),
+        })
+    }
+
+    /// Return the collection name.
+    #[must_use]
+    pub fn name(env: Env) -> Result<String, NftError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Name)
+            .ok_or(NftError::NotInitialized)
+    }
+
+    /// Return the collection symbol.
+    #[must_use]
+    pub fn symbol(env: Env) -> Result<String, NftError> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Symbol)
+            .ok_or(NftError::NotInitialized)
+    }
+
+    /// Return the total number of minted (non-burned) tokens.
+    #[must_use]
+    pub fn total_supply(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0)
+    }
+
+    fn require_initialized(env: &Env) -> Result<(), NftError> {
+        if !env.storage().instance().has(&DataKey::Initialized) {
+            return Err(NftError::NotInitialized);
+        }
+        Ok(())
+    }
+}
+
+mod test;

--- a/contracts/nft/src/prop_test.rs
+++ b/contracts/nft/src/prop_test.rs
@@ -1,0 +1,80 @@
+#![cfg(test)]
+
+extern crate std;
+
+use proptest::prelude::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::{NftContract, NftContractClient};
+
+fn setup_nft<'a>(env: &'a Env) -> (NftContractClient<'a>, Address) {
+    let admin = Address::generate(env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(env, &addr);
+    client.initialize(
+        &admin,
+        &String::from_str(env, "PropTest"),
+        &String::from_str(env, "PT"),
+        &0,
+    );
+    (client, admin)
+}
+
+proptest! {
+    /// Minting `n` distinct tokens always results in `total_supply == n`.
+    #[test]
+    fn prop_total_supply_equals_mint_count(n in 1u32..=20u32) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup_nft(&env);
+        let owner = Address::generate(&env);
+
+        for token_id in 0..n {
+            client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"));
+        }
+
+        prop_assert_eq!(client.total_supply(), n);
+    }
+
+    /// Mint then burn returns total_supply to 0 for a single token.
+    #[test]
+    fn prop_burn_decrements_supply(token_id in 0u32..=1000u32) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup_nft(&env);
+        let owner = Address::generate(&env);
+
+        client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"));
+        prop_assert_eq!(client.total_supply(), 1);
+
+        client.burn(&owner, &token_id);
+        prop_assert_eq!(client.total_supply(), 0);
+    }
+
+    /// Transfer does not change total_supply.
+    #[test]
+    fn prop_transfer_does_not_change_supply(token_id in 0u32..=1000u32) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup_nft(&env);
+        let alice = Address::generate(&env);
+        let bob = Address::generate(&env);
+
+        client.mint(&alice, &token_id, &String::from_str(&env, "ipfs://x"));
+        let before = client.total_supply();
+        client.transfer(&alice, &bob, &token_id);
+        prop_assert_eq!(client.total_supply(), before);
+    }
+
+    /// owner_of returns the correct owner after mint.
+    #[test]
+    fn prop_owner_of_after_mint(token_id in 0u32..=1000u32) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (client, _) = setup_nft(&env);
+        let owner = Address::generate(&env);
+
+        client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"));
+        prop_assert_eq!(client.owner_of(&token_id), owner);
+    }
+}

--- a/contracts/nft/src/storage.rs
+++ b/contracts/nft/src/storage.rs
@@ -1,0 +1,30 @@
+use soroban_sdk::{contracttype, Address, String};
+
+/// Instance-storage keys (shared TTL for contract-level data).
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Name,
+    Symbol,
+    TotalSupply,
+    MaxSupply,
+    Initialized,
+}
+
+/// Persistent-storage keys (per-key TTL for per-token data).
+#[contracttype]
+#[derive(Clone)]
+pub enum TokenKey {
+    Owner(u32),
+    Approval(u32),
+    Uri(u32),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TokenMetadata {
+    pub name: String,
+    pub symbol: String,
+    pub token_uri: String,
+}

--- a/contracts/nft/src/test.rs
+++ b/contracts/nft/src/test.rs
@@ -1,0 +1,221 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup(env: &Env) -> (NftContractClient, Address) {
+    let admin = Address::generate(env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(env, &addr);
+    client.initialize(
+        &admin,
+        &String::from_str(env, "My Collection"),
+        &String::from_str(env, "MYC"),
+        &0,
+    );
+    (client, admin)
+}
+
+fn setup_with_cap(env: &Env, max_supply: u32) -> (NftContractClient, Address) {
+    let admin = Address::generate(env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(env, &addr);
+    client.initialize(
+        &admin,
+        &String::from_str(env, "Capped"),
+        &String::from_str(env, "CAP"),
+        &max_supply,
+    );
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    assert_eq!(client.name(), String::from_str(&env, "My Collection"));
+    assert_eq!(client.symbol(), String::from_str(&env, "MYC"));
+    assert_eq!(client.total_supply(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_initialize_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(&env, &addr);
+    client.initialize(&admin, &String::from_str(&env, "A"), &String::from_str(&env, "A"), &0);
+    client.initialize(&admin, &String::from_str(&env, "B"), &String::from_str(&env, "B"), &0);
+}
+
+#[test]
+fn test_mint() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.mint(&owner, &1, &String::from_str(&env, "ipfs://token/1"));
+
+    assert_eq!(client.owner_of(&1), owner);
+    assert_eq!(client.total_supply(), 1);
+    assert_eq!(
+        client.token_uri(&1),
+        String::from_str(&env, "ipfs://token/1")
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_mint_duplicate_token_id_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1b"));
+}
+
+#[test]
+fn test_transfer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    client.transfer(&alice, &bob, &1);
+
+    assert_eq!(client.owner_of(&1), bob);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_transfer_not_owner_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    // bob tries to transfer alice's token
+    client.transfer(&bob, &carol, &1);
+}
+
+#[test]
+fn test_burn() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1"));
+    assert_eq!(client.total_supply(), 1);
+
+    client.burn(&owner, &1);
+    assert_eq!(client.total_supply(), 0);
+}
+
+#[test]
+fn test_approve_and_transfer_from() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    client.approve(&1, &bob);
+    assert_eq!(client.get_approved(&1), Some(bob.clone()));
+
+    client.transfer_from(&bob, &alice, &carol, &1);
+    assert_eq!(client.owner_of(&1), carol);
+    // Approval should be cleared after transfer.
+    assert_eq!(client.get_approved(&1), None);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_transfer_from_without_approval_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    // Bob was never approved.
+    client.transfer_from(&bob, &alice, &carol, &1);
+}
+
+#[test]
+fn test_transfer_clears_approval() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let carol = Address::generate(&env);
+
+    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    client.approve(&1, &bob);
+
+    // Direct transfer should clear the approval.
+    client.transfer(&alice, &carol, &1);
+    assert_eq!(client.get_approved(&1), None);
+}
+
+#[test]
+fn test_supply_cap_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup_with_cap(&env, 2);
+
+    let owner = Address::generate(&env);
+    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(&owner, &2, &String::from_str(&env, "ipfs://2"));
+    assert_eq!(client.total_supply(), 2);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_supply_cap_exceeded_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup_with_cap(&env, 1);
+
+    let owner = Address::generate(&env);
+    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(&owner, &2, &String::from_str(&env, "ipfs://2"));
+}
+
+#[test]
+fn test_metadata() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let meta = client.metadata();
+    assert_eq!(meta.name, String::from_str(&env, "My Collection"));
+    assert_eq!(meta.symbol, String::from_str(&env, "MYC"));
+}

--- a/contracts/swap/Cargo.toml
+++ b/contracts/swap/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "soroban-swap-template"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+description = "A production-ready Soroban atomic token swap contract template"
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[[bin]]
+name = "deploy"
+path = "src/bin/deploy.rs"
+doc = false
+
+[lints]
+workspace = true

--- a/contracts/swap/build.rs
+++ b/contracts/swap/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/contracts/swap/scripts/deploy.sh
+++ b/contracts/swap/scripts/deploy.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Soroban Atomic Swap Contract Deployment Script
+# Usage: ./deploy.sh [network]
+# Example: ./deploy.sh testnet
+
+set -e
+
+NETWORK=${1:-testnet}
+CONTRACT_NAME="soroban-swap-template"
+
+echo "Deploying Swap Contract to $NETWORK..."
+
+echo "Building contract..."
+stellar contract build
+
+echo "Deploying to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/${CONTRACT_NAME}.wasm \
+    --network $NETWORK)
+
+echo "Swap contract deployed!"
+echo "Contract ID: $CONTRACT_ID"
+
+CONTRACT_IDS_FILE="../../../.contract-ids"
+if [ ! -f "$CONTRACT_IDS_FILE" ]; then
+    echo "{\"network\": \"$NETWORK\", \"contracts\": {\"swap\": \"$CONTRACT_ID\"}}" > "$CONTRACT_IDS_FILE"
+else
+    TEMP_FILE="${CONTRACT_IDS_FILE}.tmp"
+    jq --arg network "$NETWORK" --arg contract_id "$CONTRACT_ID" \
+        '.network = $network | .contracts.swap = $contract_id' \
+        "$CONTRACT_IDS_FILE" > "$TEMP_FILE"
+    mv "$TEMP_FILE" "$CONTRACT_IDS_FILE"
+fi
+
+# Example propose_swap (uncomment to use):
+# PARTY_A_ADDRESS="G..."
+# TOKEN_A_ADDRESS="C..."
+# AMOUNT_A=1000000000
+# TOKEN_B_ADDRESS="C..."
+# AMOUNT_B=500000000
+# DEADLINE=1234567  # ledger sequence number
+
+# stellar contract invoke \
+#     --id $CONTRACT_ID \
+#     --network $NETWORK \
+#     -- propose_swap \
+#     --party_a $PARTY_A_ADDRESS \
+#     --token_a $TOKEN_A_ADDRESS \
+#     --amount_a $AMOUNT_A \
+#     --token_b $TOKEN_B_ADDRESS \
+#     --amount_b $AMOUNT_B \
+#     --deadline $DEADLINE
+
+echo "Swap contract ready for use!"
+echo "Save this Contract ID: $CONTRACT_ID"

--- a/contracts/swap/src/bin/deploy.rs
+++ b/contracts/swap/src/bin/deploy.rs
@@ -1,0 +1,35 @@
+//! Deploy helper for soroban-swap-template.
+//!
+//! Usage:
+//!   cargo run --bin deploy -- --network testnet --source alice
+//!   cargo run --bin deploy -- --network mainnet --source alice --wasm path/to/swap.wasm
+
+use std::process::{Command, ExitCode};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let has_wasm_flag = args.windows(2).any(|w| w[0] == "--wasm");
+    if !has_wasm_flag {
+        let status = Command::new("stellar")
+            .args(["contract", "build"])
+            .status()
+            .expect("failed to run `stellar contract build`");
+        if !status.success() {
+            eprintln!("Build failed.");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    let status = Command::new("stellar")
+        .args(["contract", "deploy"])
+        .args(&args)
+        .status()
+        .expect("failed to run `stellar contract deploy`");
+
+    if status.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}

--- a/contracts/swap/src/errors.rs
+++ b/contracts/swap/src/errors.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Copy, Debug)]
+pub enum SwapError {
+    NotAuthorized = 1,
+    SwapNotFound = 2,
+    InvalidState = 3,
+    DeadlineExpired = 4,
+    InvalidAmount = 5,
+    InvalidDeadline = 6,
+    AlreadyCompleted = 7,
+    AlreadyCancelled = 8,
+}
+
+impl core::fmt::Display for SwapError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SwapError::NotAuthorized => write!(f, "not authorized"),
+            SwapError::SwapNotFound => write!(f, "swap not found"),
+            SwapError::InvalidState => write!(f, "invalid swap state"),
+            SwapError::DeadlineExpired => write!(f, "swap deadline has expired"),
+            SwapError::InvalidAmount => write!(f, "invalid amount"),
+            SwapError::InvalidDeadline => write!(f, "invalid deadline"),
+            SwapError::AlreadyCompleted => write!(f, "swap already completed"),
+            SwapError::AlreadyCancelled => write!(f, "swap already cancelled"),
+        }
+    }
+}

--- a/contracts/swap/src/events.rs
+++ b/contracts/swap/src/events.rs
@@ -1,0 +1,28 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+pub fn swap_proposed(
+    env: &Env,
+    party_a: &Address,
+    swap_id: u32,
+    token_a: &Address,
+    amount_a: i128,
+    token_b: &Address,
+    amount_b: i128,
+) {
+    env.events().publish(
+        (Symbol::new(env, "swap_proposed"), party_a.clone()),
+        (swap_id, token_a.clone(), amount_a, token_b.clone(), amount_b),
+    );
+}
+
+pub fn swap_accepted(env: &Env, party_b: &Address, swap_id: u32) {
+    env.events().publish(
+        (Symbol::new(env, "swap_accepted"), party_b.clone()),
+        swap_id,
+    );
+}
+
+pub fn swap_cancelled(env: &Env, swap_id: u32) {
+    env.events()
+        .publish((Symbol::new(env, "swap_cancelled"),), swap_id);
+}

--- a/contracts/swap/src/lib.rs
+++ b/contracts/swap/src/lib.rs
@@ -1,0 +1,216 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+mod errors;
+mod events;
+mod storage;
+
+pub use errors::SwapError;
+pub use storage::{DataKey, SwapInfo, SwapKey, SwapState};
+
+use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+
+fn bump_persistent<K>(env: &Env, key: &K)
+where
+    K: soroban_sdk::TryIntoVal<Env, soroban_sdk::Val>
+        + soroban_sdk::IntoVal<Env, soroban_sdk::Val>,
+{
+    env.storage()
+        .persistent()
+        .extend_ttl(key, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+/// Atomic token swap contract. Party A proposes a swap, party B accepts, or party A cancels.
+///
+/// Party A specifies what they offer (`token_a`, `amount_a`) and what they want
+/// (`token_b`, `amount_b`). On acceptance, both transfers execute atomically in one transaction.
+#[contract]
+pub struct SwapContract;
+
+#[contractimpl]
+impl SwapContract {
+    /// Propose a new swap. Party A deposits `amount_a` of `token_a` into the contract.
+    ///
+    /// Returns the `swap_id` for use in `accept_swap` or `cancel_swap`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SwapError::InvalidAmount`] if either amount is <= 0.
+    /// Returns [`SwapError::InvalidDeadline`] if `deadline` <= current ledger.
+    pub fn propose_swap(
+        env: Env,
+        party_a: Address,
+        token_a: Address,
+        amount_a: i128,
+        token_b: Address,
+        amount_b: i128,
+        deadline: u32,
+    ) -> Result<u32, SwapError> {
+        if amount_a <= 0 || amount_b <= 0 {
+            return Err(SwapError::InvalidAmount);
+        }
+        if deadline <= env.ledger().sequence() {
+            return Err(SwapError::InvalidDeadline);
+        }
+
+        party_a.require_auth();
+
+        // Transfer token_a from party_a to this contract.
+        token::Client::new(&env, &token_a)
+            .transfer(&party_a, &env.current_contract_address(), &amount_a);
+
+        let swap_id: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SwapCount)
+            .unwrap_or(0);
+
+        let swap = SwapInfo {
+            id: swap_id,
+            party_a: party_a.clone(),
+            token_a: token_a.clone(),
+            amount_a,
+            token_b: token_b.clone(),
+            amount_b,
+            deadline,
+            state: SwapState::Open,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&SwapKey::Swap(swap_id), &swap);
+        env.storage()
+            .instance()
+            .set(&DataKey::SwapCount, &(swap_id + 1));
+
+        bump_persistent(&env, &SwapKey::Swap(swap_id));
+        events::swap_proposed(
+            &env, &party_a, swap_id, &token_a, amount_a, &token_b, amount_b,
+        );
+
+        Ok(swap_id)
+    }
+
+    /// Accept a swap as party B. Party B deposits `amount_b` of `token_b` and both parties
+    /// receive their requested tokens in the same transaction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SwapError::SwapNotFound`] if the swap does not exist.
+    /// Returns [`SwapError::AlreadyCompleted`] or [`SwapError::AlreadyCancelled`] for finished swaps.
+    /// Returns [`SwapError::DeadlineExpired`] if the swap deadline has passed.
+    pub fn accept_swap(env: Env, swap_id: u32, party_b: Address) -> Result<(), SwapError> {
+        party_b.require_auth();
+
+        let mut swap: SwapInfo = env
+            .storage()
+            .persistent()
+            .get(&SwapKey::Swap(swap_id))
+            .ok_or(SwapError::SwapNotFound)?;
+
+        match swap.state {
+            SwapState::Completed => return Err(SwapError::AlreadyCompleted),
+            SwapState::Cancelled => return Err(SwapError::AlreadyCancelled),
+            SwapState::Open => {}
+        }
+
+        if env.ledger().sequence() > swap.deadline {
+            return Err(SwapError::DeadlineExpired);
+        }
+
+        swap.state = SwapState::Completed;
+        env.storage()
+            .persistent()
+            .set(&SwapKey::Swap(swap_id), &swap);
+        bump_persistent(&env, &SwapKey::Swap(swap_id));
+
+        // Party B sends token_b to this contract, then contract forwards both tokens.
+        token::Client::new(&env, &swap.token_b).transfer(
+            &party_b,
+            &env.current_contract_address(),
+            &swap.amount_b,
+        );
+
+        // Party B receives token_a.
+        token::Client::new(&env, &swap.token_a).transfer(
+            &env.current_contract_address(),
+            &party_b,
+            &swap.amount_a,
+        );
+
+        // Party A receives token_b.
+        token::Client::new(&env, &swap.token_b).transfer(
+            &env.current_contract_address(),
+            &swap.party_a,
+            &swap.amount_b,
+        );
+
+        events::swap_accepted(&env, &party_b, swap_id);
+
+        Ok(())
+    }
+
+    /// Cancel a swap. Party A can cancel any time before acceptance. After the deadline,
+    /// anyone may cancel to return party A's tokens.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SwapError::SwapNotFound`] if the swap does not exist.
+    /// Returns [`SwapError::AlreadyCompleted`] or [`SwapError::AlreadyCancelled`] if already done.
+    /// Returns [`SwapError::NotAuthorized`] if the caller is not party A and the deadline has not passed.
+    pub fn cancel_swap(env: Env, swap_id: u32) -> Result<(), SwapError> {
+        let mut swap: SwapInfo = env
+            .storage()
+            .persistent()
+            .get(&SwapKey::Swap(swap_id))
+            .ok_or(SwapError::SwapNotFound)?;
+
+        match swap.state {
+            SwapState::Completed => return Err(SwapError::AlreadyCompleted),
+            SwapState::Cancelled => return Err(SwapError::AlreadyCancelled),
+            SwapState::Open => {}
+        }
+
+        let deadline_passed = env.ledger().sequence() > swap.deadline;
+        if !deadline_passed {
+            // Before deadline: only party A may cancel.
+            swap.party_a.require_auth();
+        }
+        // After deadline: no auth required; anyone can trigger to return party A's funds.
+
+        swap.state = SwapState::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&SwapKey::Swap(swap_id), &swap);
+        bump_persistent(&env, &SwapKey::Swap(swap_id));
+
+        // Return token_a to party_a.
+        token::Client::new(&env, &swap.token_a).transfer(
+            &env.current_contract_address(),
+            &swap.party_a,
+            &swap.amount_a,
+        );
+
+        events::swap_cancelled(&env, swap_id);
+
+        Ok(())
+    }
+
+    /// Return swap details by ID.
+    #[must_use]
+    pub fn get_swap(env: Env, swap_id: u32) -> Result<SwapInfo, SwapError> {
+        env.storage()
+            .persistent()
+            .get(&SwapKey::Swap(swap_id))
+            .ok_or(SwapError::SwapNotFound)
+    }
+
+    /// Return total number of swaps proposed.
+    #[must_use]
+    pub fn swap_count(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::SwapCount).unwrap_or(0)
+    }
+}
+
+mod test;

--- a/contracts/swap/src/storage.rs
+++ b/contracts/swap/src/storage.rs
@@ -1,0 +1,47 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Instance-storage keys.
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    SwapCount,
+    Initialized,
+}
+
+/// Persistent-storage key for individual swaps.
+#[contracttype]
+#[derive(Clone)]
+pub enum SwapKey {
+    Swap(u32),
+}
+
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SwapState {
+    Open = 0,
+    Completed = 1,
+    Cancelled = 2,
+}
+
+impl core::fmt::Display for SwapState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            SwapState::Open => "open",
+            SwapState::Completed => "completed",
+            SwapState::Cancelled => "cancelled",
+        })
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct SwapInfo {
+    pub id: u32,
+    pub party_a: Address,
+    pub token_a: Address,
+    pub amount_a: i128,
+    pub token_b: Address,
+    pub amount_b: i128,
+    pub deadline: u32,
+    pub state: SwapState,
+}

--- a/contracts/swap/src/test.rs
+++ b/contracts/swap/src/test.rs
@@ -1,0 +1,187 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::StellarAssetClient,
+    Address, Env,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn register_token(env: &Env) -> (Address, Address) {
+    let admin = Address::generate(env);
+    let sac = env.register_stellar_asset_contract_v2(admin.clone());
+    (sac.address(), admin)
+}
+
+fn mint(env: &Env, token: &Address, to: &Address, amount: i128) {
+    let token_admin = Address::generate(env);
+    // Use the SAC admin from the token's own admin key via mock_all_auths
+    let _ = token_admin;
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn setup(
+    env: &Env,
+) -> (
+    SwapContractClient,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let (token_a, _) = register_token(env);
+    let (token_b, _) = register_token(env);
+    let party_a = Address::generate(env);
+    let party_b = Address::generate(env);
+
+    mint(env, &token_a, &party_a, 10_000);
+    mint(env, &token_b, &party_b, 10_000);
+
+    let addr = env.register_contract(None, SwapContract);
+    let client = SwapContractClient::new(env, &addr);
+
+    (client, party_a, party_b, token_a, token_b)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_propose_swap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, _, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    let swap_id = client.propose_swap(&party_a, &token_a, &1_000, &token_b, &500, &deadline);
+    assert_eq!(swap_id, 0);
+    assert_eq!(client.swap_count(), 1);
+
+    let swap = client.get_swap(&0);
+    assert_eq!(swap.party_a, party_a);
+    assert_eq!(swap.state, SwapState::Open);
+    assert_eq!(swap.amount_a, 1_000);
+    assert_eq!(swap.amount_b, 500);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_propose_swap_zero_amount_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, _, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    client.propose_swap(&party_a, &token_a, &0, &token_b, &500, &deadline);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_propose_swap_past_deadline_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 200);
+
+    let (client, party_a, _, token_a, token_b) = setup(&env);
+    client.propose_swap(&party_a, &token_a, &1_000, &token_b, &500, &100);
+}
+
+#[test]
+fn test_accept_swap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, party_b, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    let swap_id = client.propose_swap(&party_a, &token_a, &1_000, &token_b, &500, &deadline);
+    client.accept_swap(&swap_id, &party_b);
+
+    let swap = client.get_swap(&swap_id);
+    assert_eq!(swap.state, SwapState::Completed);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_accept_swap_after_deadline_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, party_b, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 10;
+
+    let swap_id = client.propose_swap(&party_a, &token_a, &1_000, &token_b, &500, &deadline);
+    env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
+    client.accept_swap(&swap_id, &party_b);
+}
+
+#[test]
+fn test_cancel_swap_by_party_a() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, _, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    let swap_id = client.propose_swap(&party_a, &token_a, &1_000, &token_b, &500, &deadline);
+    client.cancel_swap(&swap_id);
+
+    assert_eq!(client.get_swap(&swap_id).state, SwapState::Cancelled);
+}
+
+#[test]
+fn test_cancel_swap_after_deadline_by_anyone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, _, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 10;
+
+    let swap_id = client.propose_swap(&party_a, &token_a, &1_000, &token_b, &500, &deadline);
+    env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
+    // anyone can cancel after deadline
+    client.cancel_swap(&swap_id);
+
+    assert_eq!(client.get_swap(&swap_id).state, SwapState::Cancelled);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_accept_completed_swap_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, party_b, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    let swap_id = client.propose_swap(&party_a, &token_a, &1_000, &token_b, &500, &deadline);
+    client.accept_swap(&swap_id, &party_b);
+    client.accept_swap(&swap_id, &party_b);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_cancel_already_cancelled_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, _, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    let swap_id = client.propose_swap(&party_a, &token_a, &1_000, &token_b, &500, &deadline);
+    client.cancel_swap(&swap_id);
+    client.cancel_swap(&swap_id);
+}
+
+#[test]
+fn test_multiple_swaps_increment_id() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, party_a, _, token_a, token_b) = setup(&env);
+    let deadline = env.ledger().sequence() + 100;
+
+    let id0 = client.propose_swap(&party_a, &token_a, &100, &token_b, &50, &deadline);
+    let id1 = client.propose_swap(&party_a, &token_a, &200, &token_b, &100, &deadline);
+    assert_eq!(id0, 0);
+    assert_eq!(id1, 1);
+    assert_eq!(client.swap_count(), 2);
+}

--- a/contracts/timelock/Cargo.toml
+++ b/contracts/timelock/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "soroban-timelock-template"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+description = "A production-ready Soroban timelock contract template"
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[[bin]]
+name = "deploy"
+path = "src/bin/deploy.rs"
+doc = false
+
+[lints]
+workspace = true

--- a/contracts/timelock/build.rs
+++ b/contracts/timelock/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/contracts/timelock/scripts/deploy.sh
+++ b/contracts/timelock/scripts/deploy.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Soroban Timelock Contract Deployment Script
+# Usage: ./deploy.sh [network]
+# Example: ./deploy.sh testnet
+
+set -e
+
+NETWORK=${1:-testnet}
+CONTRACT_NAME="soroban-timelock-template"
+
+echo "Deploying Timelock Contract to $NETWORK..."
+
+echo "Building contract..."
+stellar contract build
+
+echo "Deploying to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+    --wasm target/wasm32-unknown-unknown/release/${CONTRACT_NAME}.wasm \
+    --network $NETWORK)
+
+echo "Timelock contract deployed!"
+echo "Contract ID: $CONTRACT_ID"
+
+CONTRACT_IDS_FILE="../../../.contract-ids"
+if [ ! -f "$CONTRACT_IDS_FILE" ]; then
+    echo "{\"network\": \"$NETWORK\", \"contracts\": {\"timelock\": \"$CONTRACT_ID\"}}" > "$CONTRACT_IDS_FILE"
+else
+    TEMP_FILE="${CONTRACT_IDS_FILE}.tmp"
+    jq --arg network "$NETWORK" --arg contract_id "$CONTRACT_ID" \
+        '.network = $network | .contracts.timelock = $contract_id' \
+        "$CONTRACT_IDS_FILE" > "$TEMP_FILE"
+    mv "$TEMP_FILE" "$CONTRACT_IDS_FILE"
+fi
+
+# Example initialization (uncomment to use):
+# ADMIN_ADDRESS="G..."
+# TOKEN_ADDRESS="C..."
+# BENEFICIARY_ADDRESS="G..."
+# RELEASE_LEDGER=1234567        # target ledger sequence number
+# AMOUNT=1000000000             # in token stroops
+
+# stellar contract invoke \
+#     --id $CONTRACT_ID \
+#     --network $NETWORK \
+#     -- initialize \
+#     --admin $ADMIN_ADDRESS \
+#     --token $TOKEN_ADDRESS \
+#     --beneficiary $BENEFICIARY_ADDRESS \
+#     --release_ledger $RELEASE_LEDGER \
+#     --amount $AMOUNT
+
+echo "Timelock contract ready for use!"
+echo "Save this Contract ID: $CONTRACT_ID"

--- a/contracts/timelock/src/bin/deploy.rs
+++ b/contracts/timelock/src/bin/deploy.rs
@@ -1,0 +1,35 @@
+//! Deploy helper for soroban-timelock-template.
+//!
+//! Usage:
+//!   cargo run --bin deploy -- --network testnet --source alice
+//!   cargo run --bin deploy -- --network mainnet --source alice --wasm path/to/timelock.wasm
+
+use std::process::{Command, ExitCode};
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    let has_wasm_flag = args.windows(2).any(|w| w[0] == "--wasm");
+    if !has_wasm_flag {
+        let status = Command::new("stellar")
+            .args(["contract", "build"])
+            .status()
+            .expect("failed to run `stellar contract build`");
+        if !status.success() {
+            eprintln!("Build failed.");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    let status = Command::new("stellar")
+        .args(["contract", "deploy"])
+        .args(&args)
+        .status()
+        .expect("failed to run `stellar contract deploy`");
+
+    if status.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}

--- a/contracts/timelock/src/errors.rs
+++ b/contracts/timelock/src/errors.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Copy, Debug)]
+pub enum TimelockError {
+    NotAuthorized = 1,
+    AlreadyInitialized = 2,
+    NotInitialized = 3,
+    NotYetReleasable = 4,
+    AlreadyReleased = 5,
+    AlreadyCancelled = 6,
+    InvalidAmount = 7,
+    InvalidReleaseLedger = 8,
+}
+
+impl core::fmt::Display for TimelockError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TimelockError::NotAuthorized => write!(f, "not authorized"),
+            TimelockError::AlreadyInitialized => write!(f, "already initialized"),
+            TimelockError::NotInitialized => write!(f, "not initialized"),
+            TimelockError::NotYetReleasable => write!(f, "not yet releasable"),
+            TimelockError::AlreadyReleased => write!(f, "already released"),
+            TimelockError::AlreadyCancelled => write!(f, "already cancelled"),
+            TimelockError::InvalidAmount => write!(f, "invalid amount"),
+            TimelockError::InvalidReleaseLedger => write!(f, "invalid release ledger"),
+        }
+    }
+}

--- a/contracts/timelock/src/events.rs
+++ b/contracts/timelock/src/events.rs
@@ -1,0 +1,30 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+pub fn initialized(
+    env: &Env,
+    admin: &Address,
+    beneficiary: &Address,
+    release_ledger: u32,
+    amount: i128,
+) {
+    env.events().publish(
+        (
+            Symbol::new(env, "initialized"),
+            admin.clone(),
+            beneficiary.clone(),
+        ),
+        (release_ledger, amount),
+    );
+}
+
+pub fn released(env: &Env, beneficiary: &Address, amount: i128) {
+    env.events().publish(
+        (Symbol::new(env, "released"), beneficiary.clone()),
+        amount,
+    );
+}
+
+pub fn cancelled(env: &Env, admin: &Address) {
+    env.events()
+        .publish((Symbol::new(env, "cancelled"), admin.clone()), ());
+}

--- a/contracts/timelock/src/lib.rs
+++ b/contracts/timelock/src/lib.rs
@@ -1,0 +1,182 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
+
+mod errors;
+mod events;
+mod storage;
+
+pub use errors::TimelockError;
+pub use storage::{DataKey, TimelockInfo, TimelockState};
+
+use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+use storage::DataKey::*;
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+fn get_required<T: soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>(
+    env: &Env,
+    key: &DataKey,
+) -> Result<T, TimelockError> {
+    env.storage()
+        .instance()
+        .get(key)
+        .ok_or(TimelockError::NotInitialized)
+}
+
+/// Timelock contract: holds tokens until a specified ledger, then releases to a beneficiary.
+///
+/// Lifecycle: `Active → Released` (via `release`) or `Active → Cancelled` (via `cancel`).
+#[contract]
+pub struct TimelockContract;
+
+#[contractimpl]
+impl TimelockContract {
+    /// Initialize the timelock. Transfers `amount` tokens from `admin` to the contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TimelockError::AlreadyInitialized`] if already set up.
+    /// Returns [`TimelockError::InvalidAmount`] if `amount` <= 0.
+    /// Returns [`TimelockError::InvalidReleaseLedger`] if `release_ledger` <= current ledger.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        token: Address,
+        beneficiary: Address,
+        release_ledger: u32,
+        amount: i128,
+    ) -> Result<(), TimelockError> {
+        if env.storage().instance().has(&State) {
+            return Err(TimelockError::AlreadyInitialized);
+        }
+        if amount <= 0 {
+            return Err(TimelockError::InvalidAmount);
+        }
+        if release_ledger <= env.ledger().sequence() {
+            return Err(TimelockError::InvalidReleaseLedger);
+        }
+
+        admin.require_auth();
+
+        token::Client::new(&env, &token)
+            .transfer(&admin, &env.current_contract_address(), &amount);
+
+        env.storage().instance().set(&Admin, &admin);
+        env.storage().instance().set(&Token, &token);
+        env.storage().instance().set(&Beneficiary, &beneficiary);
+        env.storage().instance().set(&ReleaseLedger, &release_ledger);
+        env.storage().instance().set(&Amount, &amount);
+        env.storage().instance().set(&State, &TimelockState::Active);
+
+        bump_instance(&env);
+        events::initialized(&env, &admin, &beneficiary, release_ledger, amount);
+
+        Ok(())
+    }
+
+    /// Release locked tokens to the beneficiary. Callable by anyone after `release_ledger`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TimelockError::NotInitialized`] if not yet set up.
+    /// Returns [`TimelockError::AlreadyReleased`] if tokens were already released.
+    /// Returns [`TimelockError::AlreadyCancelled`] if the timelock was cancelled.
+    /// Returns [`TimelockError::NotYetReleasable`] if `release_ledger` has not been reached.
+    pub fn release(env: Env) -> Result<(), TimelockError> {
+        let state: TimelockState = get_required(&env, &State)?;
+        match state {
+            TimelockState::Released => return Err(TimelockError::AlreadyReleased),
+            TimelockState::Cancelled => return Err(TimelockError::AlreadyCancelled),
+            TimelockState::Active => {}
+        }
+
+        let release_ledger: u32 = get_required(&env, &ReleaseLedger)?;
+        if env.ledger().sequence() < release_ledger {
+            return Err(TimelockError::NotYetReleasable);
+        }
+
+        let token: Address = get_required(&env, &Token)?;
+        let beneficiary: Address = get_required(&env, &Beneficiary)?;
+        let amount: i128 = get_required(&env, &Amount)?;
+
+        env.storage().instance().set(&State, &TimelockState::Released);
+        bump_instance(&env);
+
+        token::Client::new(&env, &token)
+            .transfer(&env.current_contract_address(), &beneficiary, &amount);
+
+        events::released(&env, &beneficiary, amount);
+
+        Ok(())
+    }
+
+    /// Cancel the timelock and return tokens to admin. Admin only; works while in `Active` state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TimelockError::NotInitialized`] if not yet set up.
+    /// Returns [`TimelockError::NotAuthorized`] if caller is not the admin.
+    /// Returns [`TimelockError::AlreadyReleased`] if tokens were already released.
+    /// Returns [`TimelockError::AlreadyCancelled`] if already cancelled.
+    pub fn cancel(env: Env) -> Result<(), TimelockError> {
+        let admin: Address = get_required(&env, &Admin)?;
+        admin.require_auth();
+
+        let state: TimelockState = get_required(&env, &State)?;
+        match state {
+            TimelockState::Released => return Err(TimelockError::AlreadyReleased),
+            TimelockState::Cancelled => return Err(TimelockError::AlreadyCancelled),
+            TimelockState::Active => {}
+        }
+
+        let token: Address = get_required(&env, &Token)?;
+        let amount: i128 = get_required(&env, &Amount)?;
+
+        env.storage().instance().set(&State, &TimelockState::Cancelled);
+        bump_instance(&env);
+
+        token::Client::new(&env, &token)
+            .transfer(&env.current_contract_address(), &admin, &amount);
+
+        events::cancelled(&env, &admin);
+
+        Ok(())
+    }
+
+    /// Return full timelock details.
+    #[must_use]
+    pub fn get_info(env: Env) -> Result<TimelockInfo, TimelockError> {
+        Ok(TimelockInfo {
+            admin: get_required(&env, &Admin)?,
+            token: get_required(&env, &Token)?,
+            beneficiary: get_required(&env, &Beneficiary)?,
+            release_ledger: get_required(&env, &ReleaseLedger)?,
+            amount: get_required(&env, &Amount)?,
+            state: get_required(&env, &State)?,
+        })
+    }
+
+    /// Return `true` if the release ledger has been reached and the state is still `Active`.
+    #[must_use]
+    pub fn is_releasable(env: Env) -> bool {
+        let state: Option<TimelockState> = env.storage().instance().get(&State);
+        if !matches!(state, Some(TimelockState::Active)) {
+            return false;
+        }
+        let release_ledger: u32 = env.storage().instance().get(&ReleaseLedger).unwrap_or(0);
+        env.ledger().sequence() >= release_ledger
+    }
+
+    /// Return ledgers remaining until release (negative if already past).
+    pub fn get_remaining_ledgers(env: Env) -> i64 {
+        let release_ledger: u32 = env.storage().instance().get(&ReleaseLedger).unwrap_or(0);
+        release_ledger as i64 - env.ledger().sequence() as i64
+    }
+}
+
+mod test;

--- a/contracts/timelock/src/storage.rs
+++ b/contracts/timelock/src/storage.rs
@@ -1,0 +1,41 @@
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Token,
+    Beneficiary,
+    ReleaseLedger,
+    Amount,
+    State,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum TimelockState {
+    Active = 0,
+    Released = 1,
+    Cancelled = 2,
+}
+
+impl core::fmt::Display for TimelockState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(match self {
+            TimelockState::Active => "active",
+            TimelockState::Released => "released",
+            TimelockState::Cancelled => "cancelled",
+        })
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TimelockInfo {
+    pub admin: Address,
+    pub token: Address,
+    pub beneficiary: Address,
+    pub release_ledger: u32,
+    pub amount: i128,
+    pub state: TimelockState,
+}

--- a/contracts/timelock/src/test.rs
+++ b/contracts/timelock/src/test.rs
@@ -1,0 +1,210 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token::TokenInterface,
+    Address, Env, String,
+};
+
+// ---------------------------------------------------------------------------
+// MockToken — no-op token for unit tests.
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct MockToken;
+
+#[contractimpl]
+impl TokenInterface for MockToken {
+    fn allowance(_env: Env, _from: Address, _spender: Address) -> i128 { 0 }
+    fn approve(_env: Env, _from: Address, _spender: Address, _amount: i128, _exp: u32) {}
+    fn balance(_env: Env, _id: Address) -> i128 { i128::MAX }
+    fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
+    fn transfer_from(_env: Env, _spender: Address, _from: Address, _to: Address, _amount: i128) {}
+    fn burn(_env: Env, _from: Address, _amount: i128) {}
+    fn burn_from(_env: Env, _spender: Address, _from: Address, _amount: i128) {}
+    fn decimals(_env: Env) -> u32 { 7 }
+    fn name(env: Env) -> String { String::from_str(&env, "Mock") }
+    fn symbol(env: Env) -> String { String::from_str(&env, "MCK") }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn setup(env: &Env) -> (TimelockContractClient, Address, Address, Address, u32, i128) {
+    let admin = Address::generate(env);
+    let beneficiary = Address::generate(env);
+    let token = env.register_contract(None, MockToken);
+    let release_ledger = env.ledger().sequence() + 100;
+    let amount = 1_000i128;
+
+    let contract_addr = env.register_contract(None, TimelockContract);
+    let client = TimelockContractClient::new(env, &contract_addr);
+    client.initialize(&admin, &token, &beneficiary, &release_ledger, &amount);
+
+    (client, admin, beneficiary, token, release_ledger, amount)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token, release_ledger, amount) = setup(&env);
+
+    let info = client.get_info();
+    assert_eq!(info.admin, admin);
+    assert_eq!(info.beneficiary, beneficiary);
+    assert_eq!(info.token, token);
+    assert_eq!(info.release_ledger, release_ledger);
+    assert_eq!(info.amount, amount);
+    assert_eq!(info.state, TimelockState::Active);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_initialize_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let token = env.register_contract(None, MockToken);
+    let release_ledger = env.ledger().sequence() + 100;
+
+    let addr = env.register_contract(None, TimelockContract);
+    let client = TimelockContractClient::new(&env, &addr);
+    client.initialize(&admin, &token, &beneficiary, &release_ledger, &1_000);
+    client.initialize(&admin, &token, &beneficiary, &release_ledger, &1_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_initialize_zero_amount_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let token = env.register_contract(None, MockToken);
+    let release_ledger = env.ledger().sequence() + 100;
+
+    let addr = env.register_contract(None, TimelockContract);
+    let client = TimelockContractClient::new(&env, &addr);
+    client.initialize(&admin, &token, &beneficiary, &release_ledger, &0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_initialize_past_release_ledger_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 200);
+
+    let admin = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let token = env.register_contract(None, MockToken);
+
+    let addr = env.register_contract(None, TimelockContract);
+    let client = TimelockContractClient::new(&env, &addr);
+    client.initialize(&admin, &token, &beneficiary, &50, &1_000);
+}
+
+#[test]
+fn test_release_after_ledger() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _, _, release_ledger, _) = setup(&env);
+
+    env.ledger().with_mut(|l| l.sequence_number = release_ledger);
+    client.release();
+
+    assert_eq!(client.get_info().state, TimelockState::Released);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_release_too_early_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, ..) = setup(&env);
+    // release_ledger is current + 100; we're still before it.
+    client.release();
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_release_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _, _, release_ledger, _) = setup(&env);
+    env.ledger().with_mut(|l| l.sequence_number = release_ledger);
+    client.release();
+    client.release();
+}
+
+#[test]
+fn test_cancel_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, ..) = setup(&env);
+    client.cancel();
+
+    assert_eq!(client.get_info().state, TimelockState::Cancelled);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_cancel_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, ..) = setup(&env);
+    client.cancel();
+    client.cancel();
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_cancel_after_release_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _, _, release_ledger, _) = setup(&env);
+    env.ledger().with_mut(|l| l.sequence_number = release_ledger);
+    client.release();
+    client.cancel();
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_release_after_cancel_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _, _, release_ledger, _) = setup(&env);
+    client.cancel();
+    env.ledger().with_mut(|l| l.sequence_number = release_ledger);
+    client.release();
+}
+
+#[test]
+fn test_is_releasable() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _, _, _, release_ledger, _) = setup(&env);
+    assert!(!client.is_releasable());
+
+    env.ledger().with_mut(|l| l.sequence_number = release_ledger);
+    assert!(client.is_releasable());
+}


### PR DESCRIPTION
Implements four new production-ready Soroban smart contract templates, each following the established conventions of the starter kit (storage/errors/events modules, deploy script, unit tests, README documentation).

## contracts/timelock (#525)
- `initialize(admin, token, beneficiary, release_ledger, amount)` — transfers tokens from admin to contract and records release parameters
- `release()` — callable by anyone after `release_ledger`; sends tokens to beneficiary
- `cancel()` — admin only; returns tokens to admin while state is Active
- Views: `get_info`, `is_releasable`, `get_remaining_ledgers`
- 12 unit tests covering happy path, double-init, early release, cancel lifecycle, and invalid state transitions

## contracts/nft (#526)
- `initialize(admin, name, symbol, max_supply)` — sets up the NFT collection; `max_supply = 0` means no cap
- `mint(to, token_id, token_uri)` — admin only; enforces supply cap
- `transfer(from, to, token_id)` — requires auth from current owner; clears approval
- `burn(from, token_id)` — owner only; decrements total supply
- `approve(token_id, spender)` — owner grants single-token approval
- `transfer_from(spender, from, to, token_id)` — consumes approval atomically
- Views: `owner_of`, `get_approved`, `token_uri`, `metadata`, `name`, `symbol`, `total_supply`
- Per-token data (owner, approval, URI) stored in persistent storage with TTL bumps
- 13 unit tests; property tests in `prop_test.rs` (supply invariants, ownership)

## contracts/dao (#527)
- `initialize(admin, token, voting_period, quorum)` — configures governance token, ledger-based voting window, and minimum total-vote quorum
- `create_proposal(proposer, title, description)` — requires proposer holds > 0 tokens; returns `proposal_id`
- `vote(voter, proposal_id, support)` — records voter's current token balance as weight; prevents double voting
- `execute_proposal(proposal_id)` — passes when deadline elapsed, quorum met, and yes > no
- `cancel_proposal(proposal_id)` — admin only; Active proposals only
- Views: `get_proposal`, `proposal_count`
- 12 unit tests covering initialize, create, vote, execute, quorum enforcement, and cancel lifecycle

## contracts/swap (#528)
- `propose_swap(party_a, token_a, amount_a, token_b, amount_b, deadline)` — party A deposits token A; returns `swap_id`
- `accept_swap(swap_id, party_b)` — party B deposits token B; both transfers execute atomically in one call
- `cancel_swap(swap_id)` — party A can cancel any time; anyone can cancel after deadline
- Views: `get_swap`, `swap_count`
- 10 unit tests covering happy path, expired deadline, double accept/cancel, and multi-swap ID sequencing

## Shared changes
- `Cargo.toml` workspace: added timelock, nft, dao, swap members
- `README.md`: updated contract table and added feature sections for all four contracts

Closes #525
Closes #526
Closes #527
Closes #528