### PR TITLE
fix: resolve issues #537 #541 #542 #547 — refactor, lint, tests, docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,27 @@ jobs:
           path: target/wasm32-unknown-unknown/release/*.wasm
           retention-days: 7
 
+  datakey-discriminants:
+    name: DataKey Discriminant Stability
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Check token DataKey discriminants
+        run: cargo test -p soroban-token-template -- discriminant_tests --nocapture
+
+      - name: Check escrow DataKey discriminants
+        run: cargo test -p soroban-escrow-template -- discriminant_tests --nocapture
+
   security-audit:
     name: Security Audit
   machete:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,36 @@ Additional conventions:
 
 ---
 
+## DataKey Variant Stability
+
+`DataKey` enums (in `contracts/*/src/storage.rs`) define the on-chain storage layout for each contract. In Soroban, `#[contracttype]` enums use the **variant name** as the XDR storage discriminant. Changing any variant in an incompatible way corrupts storage for any live deployment.
+
+### Rules
+
+| Operation | Effect | Allowed? |
+|-----------|--------|----------|
+| Rename a variant | Changes its XDR key — existing storage entries become unreachable | **Never** |
+| Remove a variant | Same as rename from the runtime's perspective | **Never** |
+| Reorder variants | Changes the numeric fallback index in some SDK versions | **Never** |
+| Add a variant | Appending at the **end** is safe; inserting in the middle is not | **Append only** |
+
+### How to add a new storage key
+
+1. Open `contracts/<name>/src/storage.rs`.
+2. Add the new variant at the **bottom** of the `DataKey` enum, after all existing variants.
+3. Update the exhaustive `match` in `discriminant_tests::*_data_key_index` to include the new variant with the next sequential index.
+4. Run the tests: `cargo test -p <package>`.
+
+### Why the tests use an exhaustive match
+
+The `discriminant_tests` module in each `storage.rs` contains an exhaustive `match` over `DataKey`. This is intentional:
+
+- **Compile error** if a variant is renamed or removed (the old name no longer exists).
+- **Non-exhaustive warning** (treated as an error in CI) if a variant is added without updating the match.
+- **Runtime assertions** document the expected position of each variant and serve as a human-readable snapshot of the storage layout.
+
+---
+
 ## Adding a New Contract Template
 
 For the full step-by-step guide, see [docs/adding-a-contract.md](docs/adding-a-contract.md).

--- a/contracts/escrow/src/admin.rs
+++ b/contracts/escrow/src/admin.rs
@@ -2,7 +2,6 @@ use soroban_sdk::{token, Address, Env};
 use crate::storage::DataKey;
 use crate::errors::EscrowError;
 
-#[allow(dead_code)]
 pub fn require_admin(env: &Env) -> Result<Address, EscrowError> {
     soroban_common::try_get_admin(env).ok_or(EscrowError::NotInitialized)
 }

--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -1,8 +1,9 @@
 use soroban_sdk::{Address, Env, Symbol};
 
 use crate::errors::EscrowError;
-use crate::lifecycle::{bump_instance, get_required, refund_to_buyer, release_to_seller};
+use crate::lifecycle::{get_required, refund_to_buyer, release_to_seller};
 use crate::storage::{DataKey, EscrowState};
+use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
 use DataKey::*;
 
@@ -24,7 +25,7 @@ pub fn raise_dispute(env: Env, caller: Address) -> Result<(), EscrowError> {
     }
 
     env.storage().instance().set(&State, &EscrowState::Disputed);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     env.events()
         .publish((Symbol::new(&env, "dispute_raised"), caller), ());

--- a/contracts/escrow/src/events.rs
+++ b/contracts/escrow/src/events.rs
@@ -17,28 +17,24 @@ pub fn escrow_created(env: &Env, buyer: &Address, seller: &Address, amount: i128
 
 /// Emitted when an escrow is funded.
 /// Topics: (Symbol, Address) — event name, buyer
-#[allow(dead_code)]
 pub fn escrow_funded(env: &Env, buyer: &Address, amount: i128) {
     env.events().publish((Symbol::new(env, "escrow_funded"), buyer.clone()), amount);
 }
 
 /// Emitted when delivery is marked.
 /// Topics: (Symbol, Address) — event name, seller
-#[allow(dead_code)]
 pub fn delivery_marked(env: &Env, seller: &Address) {
     env.events().publish((Symbol::new(env, "delivery_marked"), seller.clone()), ());
 }
 
 /// Emitted when funds are released to the seller.
 /// Topics: (Symbol, Address) — event name, seller
-#[allow(dead_code)]
 pub fn funds_released(env: &Env, seller: &Address, amount: i128) {
     env.events().publish((Symbol::new(env, "funds_released"), seller.clone()), amount);
 }
 
 /// Emitted when funds are refunded to the buyer.
 /// Topics: (Symbol, Address) — event name, buyer
-#[allow(dead_code)]
 pub fn partial_release(env: &Env, seller: &Address, amount: i128) {
     env.events().publish((Symbol::new(env, "partial_release"), seller.clone()), amount);
 }
@@ -49,21 +45,18 @@ pub fn funds_refunded(env: &Env, buyer: &Address, amount: i128) {
 
 /// Emitted when the contract is paused.
 /// Topics: (Symbol, Address) — event name, admin
-#[allow(dead_code)]
 pub fn paused(env: &Env, admin: &Address) {
     env.events().publish((Symbol::new(env, "paused"), admin.clone()), ());
 }
 
 /// Emitted when the contract is unpaused.
 /// Topics: (Symbol, Address) — event name, admin
-#[allow(dead_code)]
 pub fn unpaused(env: &Env, admin: &Address) {
     env.events().publish((Symbol::new(env, "unpaused"), admin.clone()), ());
 }
 
 /// Emitted when the contract is upgraded.
 /// Topics: (Symbol, Address) — event name, admin
-#[allow(dead_code)]
 pub fn upgraded(env: &Env, admin: &Address, new_wasm_hash: &soroban_sdk::BytesN<32>) {
     env.events().publish((Symbol::new(env, "upgraded"), admin.clone()), new_wasm_hash.clone());
 }

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env};
+use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
 mod admin;
 mod dispute;
@@ -126,7 +127,7 @@ impl EscrowContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
-        lifecycle::bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::paused(&env, &admin);
         Ok(())
     }
@@ -135,7 +136,7 @@ impl EscrowContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
-        lifecycle::bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::unpaused(&env, &admin);
         Ok(())
     }
@@ -152,7 +153,7 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::PendingUpgrade, &(wasm_hash.clone(), ready_after));
-        lifecycle::bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         env.events().publish(
             (soroban_sdk::Symbol::new(&env, "upgrade_proposed"), admin),
             (wasm_hash, ready_after),

--- a/contracts/escrow/src/lifecycle.rs
+++ b/contracts/escrow/src/lifecycle.rs
@@ -4,15 +4,9 @@ use crate::admin;
 use crate::errors::EscrowError;
 use crate::events;
 use crate::storage::{DataKey, EscrowState};
-use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD, MIN_DEADLINE_BUFFER};
+use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD, MIN_DEADLINE_BUFFER};
 
 use DataKey::*;
-
-pub fn bump_instance(env: &Env) {
-    env.storage()
-        .instance()
-        .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
-}
 
 pub fn get_required<T: soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>(
     env: &Env,
@@ -66,7 +60,7 @@ pub fn initialize(
     env.storage().instance().set(&State, &EscrowState::Created);
     env.storage().instance().set(&RequiredSignatures, &1u32);
 
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     events::escrow_created(&env, &buyer, &seller, amount);
     events::initialized(&env, &buyer, &seller, &arbiter, amount);
@@ -115,7 +109,7 @@ pub fn initialize_with_arbiters(
     env.storage().instance().set(&Deadline, &deadline_ledger);
     env.storage().instance().set(&State, &EscrowState::Created);
 
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     events::escrow_created(&env, &buyer, &seller, amount);
     events::initialized(&env, &buyer, &seller, &arbiters.get(0).unwrap(), amount);
@@ -145,7 +139,7 @@ pub fn update_amount(env: Env, new_amount: i128) -> Result<(), EscrowError> {
     }
 
     env.storage().instance().set(&Amount, &new_amount);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     env.events()
         .publish((Symbol::new(&env, "amount_updated"), buyer), new_amount);
@@ -175,7 +169,7 @@ pub fn fund(env: Env) -> Result<(), EscrowError> {
     token_client.transfer(&buyer, &env.current_contract_address(), &amount);
 
     env.storage().instance().set(&State, &EscrowState::Funded);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     env.events()
         .publish((Symbol::new(&env, "escrow_funded"), buyer), amount);
@@ -196,7 +190,7 @@ pub fn mark_delivered(env: Env) -> Result<(), EscrowError> {
     }
 
     env.storage().instance().set(&State, &EscrowState::Delivered);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     env.events()
         .publish((Symbol::new(&env, "delivery_marked"), seller), ());
@@ -246,7 +240,7 @@ pub fn release_partial(env: Env, amount: i128) -> Result<(), EscrowError> {
     let seller: Address = env.storage().instance().get(&Seller).unwrap();
     let new_amount = stored_amount - amount;
     env.storage().instance().set(&Amount, &new_amount);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     admin::transfer_token(&env, &env.current_contract_address(), &seller, amount);
     events::partial_release(&env, &seller, amount);
@@ -283,7 +277,7 @@ pub fn cancel(env: Env) -> Result<(), EscrowError> {
     }
 
     env.storage().instance().set(&State, &EscrowState::Cancelled);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     env.events()
         .publish((Symbol::new(&env, "escrow_cancelled"), buyer), ());
@@ -326,7 +320,7 @@ pub fn extend_deadline(env: Env, new_deadline: u32) -> Result<(), EscrowError> {
     }
 
     env.storage().instance().set(&Deadline, &new_deadline);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     env.events()
         .publish((Symbol::new(&env, "deadline_extended"), buyer), new_deadline);
@@ -341,7 +335,7 @@ pub fn release_to_seller(env: Env) -> Result<(), EscrowError> {
     let amount: i128 = get_required(&env, &Amount)?;
 
     env.storage().instance().set(&State, &EscrowState::Completed);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     admin::transfer_token(&env, &env.current_contract_address(), &seller, amount);
 
@@ -358,7 +352,7 @@ pub fn refund_to_buyer(env: Env) -> Result<(), EscrowError> {
     let amount: i128 = get_required(&env, &Amount)?;
 
     env.storage().instance().set(&State, &EscrowState::Refunded);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
     admin::transfer_token(&env, &env.current_contract_address(), &buyer, amount);
 

--- a/contracts/escrow/src/queries.rs
+++ b/contracts/escrow/src/queries.rs
@@ -3,6 +3,7 @@ use soroban_sdk::Env;
 use crate::errors::EscrowError;
 use crate::lifecycle::get_required;
 use crate::storage::{DataKey, EscrowInfo, EscrowState};
+use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
 use DataKey::*;
 
@@ -37,6 +38,6 @@ pub fn bump(env: Env) -> Result<(), EscrowError> {
     if !env.storage().instance().has(&State) {
         return Err(EscrowError::NotInitialized);
     }
-    crate::lifecycle::bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
     Ok(())
 }

--- a/contracts/escrow/src/storage.rs
+++ b/contracts/escrow/src/storage.rs
@@ -88,6 +88,52 @@ mod tests {
     }
 }
 
+#[cfg(test)]
+mod discriminant_tests {
+    use super::*;
+
+    // In Soroban, #[contracttype] enums use the variant NAME as the XDR storage discriminant.
+    // NEVER rename, reorder, or remove variants — doing so will corrupt on-chain storage for
+    // any live deployment. To add a new key, append it at the END of the enum definition.
+    //
+    // This exhaustive match is the primary guard: it causes a COMPILE ERROR if a variant is
+    // renamed or removed, and a non-exhaustive warning if one is added without updating here.
+    fn escrow_data_key_index(key: &DataKey) -> u32 {
+        match key {
+            DataKey::Buyer => 0,
+            DataKey::Seller => 1,
+            DataKey::Arbiter => 2,
+            DataKey::TokenContract => 3,
+            DataKey::Amount => 4,
+            DataKey::Deadline => 5,
+            DataKey::State => 6,
+            DataKey::Paused => 7,
+            DataKey::Version => 8,
+            DataKey::PendingUpgrade => 9,
+            DataKey::Arbiters => 10,
+            DataKey::RequiredSignatures => 11,
+            DataKey::ArbiterVotes => 12,
+        }
+    }
+
+    #[test]
+    fn data_key_discriminants_are_stable() {
+        assert_eq!(escrow_data_key_index(&DataKey::Buyer), 0);
+        assert_eq!(escrow_data_key_index(&DataKey::Seller), 1);
+        assert_eq!(escrow_data_key_index(&DataKey::Arbiter), 2);
+        assert_eq!(escrow_data_key_index(&DataKey::TokenContract), 3);
+        assert_eq!(escrow_data_key_index(&DataKey::Amount), 4);
+        assert_eq!(escrow_data_key_index(&DataKey::Deadline), 5);
+        assert_eq!(escrow_data_key_index(&DataKey::State), 6);
+        assert_eq!(escrow_data_key_index(&DataKey::Paused), 7);
+        assert_eq!(escrow_data_key_index(&DataKey::Version), 8);
+        assert_eq!(escrow_data_key_index(&DataKey::PendingUpgrade), 9);
+        assert_eq!(escrow_data_key_index(&DataKey::Arbiters), 10);
+        assert_eq!(escrow_data_key_index(&DataKey::RequiredSignatures), 11);
+        assert_eq!(escrow_data_key_index(&DataKey::ArbiterVotes), 12);
+    }
+}
+
 /// Snapshot of all escrow fields returned by
 /// [`EscrowContract::get_escrow_info`](crate::EscrowContract::get_escrow_info).
 #[contracttype]

--- a/contracts/token/src/events.rs
+++ b/contracts/token/src/events.rs
@@ -56,21 +56,18 @@ pub fn transferred(env: &Env, from: &Address, to: &Address, amount: i128) {
 
 /// Emitted when the contract is paused.
 /// Topics: (Symbol, Address) — event name, admin
-#[allow(dead_code)]
 pub fn paused(env: &Env, admin: &Address) {
     env.events().publish((Symbol::new(env, "paused"), admin.clone()), ());
 }
 
 /// Emitted when the contract is unpaused.
 /// Topics: (Symbol, Address) — event name, admin
-#[allow(dead_code)]
 pub fn unpaused(env: &Env, admin: &Address) {
     env.events().publish((Symbol::new(env, "unpaused"), admin.clone()), ());
 }
 
 /// Emitted when the contract is upgraded.
 /// Topics: (Symbol, Address) — event name, admin
-#[allow(dead_code)]
 pub fn upgraded(env: &Env, admin: &Address, new_wasm_hash: &soroban_sdk::BytesN<32>) {
     env.events().publish((Symbol::new(env, "upgraded"), admin.clone()), new_wasm_hash.clone());
 }

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -16,20 +16,8 @@ mod test;
 
 use admin::require_admin;
 use errors::TokenError;
-use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+use soroban_common::{extend_ttl_instance, extend_ttl_persistent, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 use storage::{AllowanceDataKey, AllowanceValue, DataKey, MetadataKey};
-
-pub(crate) fn bump_instance(env: &Env) {
-    env.storage()
-        .instance()
-        .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
-}
-
-pub(crate) fn bump_persistent(env: &Env, key: &DataKey) {
-    env.storage()
-        .persistent()
-        .extend_ttl(key, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
-}
 
 #[cfg(feature = "pausable")]
 pub(crate) fn require_not_paused(env: &Env) -> Result<(), TokenError> {
@@ -96,7 +84,7 @@ impl TokenContract {
         }
         #[cfg(not(feature = "capped-supply"))]
         let _ = max_supply;
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::initialized(&env, &admin, name, symbol, decimals);
         Ok(())
     }
@@ -136,7 +124,7 @@ impl TokenContract {
         env.storage()
             .instance()
             .set(&DataKey::TotalSupply, &(supply + amount));
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::minted(&env, &to, amount);
         Ok(())
     }
@@ -187,7 +175,7 @@ impl TokenContract {
             env.storage()
                 .persistent()
                 .set(&DataKey::Balance(to.clone()), &new_balance);
-            bump_persistent(&env, &DataKey::Balance(to.clone()));
+            extend_ttl_persistent(&env, &DataKey::Balance(to.clone()), LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
             events::minted(&env, &to, amount);
         }
 
@@ -199,7 +187,7 @@ impl TokenContract {
         env.storage()
             .instance()
             .set(&DataKey::TotalSupply, &(supply + total_amount));
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
         Ok(())
     }
@@ -222,7 +210,7 @@ impl TokenContract {
         env.storage()
             .instance()
             .set(&DataKey::TotalSupply, &(supply.checked_sub(amount).ok_or(TokenError::Overflow)?));
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::burned(&env, &from, amount);
         Ok(())
     }
@@ -232,7 +220,7 @@ impl TokenContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::admin_proposed(&env, &admin, &new_admin);
         Ok(())
     }
@@ -247,7 +235,7 @@ impl TokenContract {
         pending.require_auth();
         env.storage().instance().set(&DataKey::Admin, &pending);
         env.storage().instance().remove(&DataKey::PendingAdmin);
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::admin_accepted(&env, &pending);
         Ok(())
     }
@@ -257,7 +245,7 @@ impl TokenContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().remove(&DataKey::PendingAdmin);
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::admin_proposal_cancelled(&env, &admin);
         Ok(())
     }
@@ -267,7 +255,7 @@ impl TokenContract {
         let old_admin = require_admin(&env)?;
         old_admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &new_admin);
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::admin_changed(&env, &old_admin, &new_admin);
         Ok(())
     }
@@ -331,7 +319,7 @@ impl TokenContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::paused(&env, &admin);
         Ok(())
     }
@@ -340,7 +328,7 @@ impl TokenContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::unpaused(&env, &admin);
         Ok(())
     }
@@ -354,7 +342,7 @@ impl TokenContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Frozen(account.clone()), &true);
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         env.events().publish(
             (soroban_sdk::Symbol::new(&env, "account_frozen"), account),
             (),
@@ -366,7 +354,7 @@ impl TokenContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Frozen(account.clone()), &false);
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         env.events().publish(
             (soroban_sdk::Symbol::new(&env, "account_unfrozen"), account),
             (),
@@ -388,7 +376,7 @@ impl TokenContract {
         env.storage()
             .instance()
             .set(&DataKey::PendingUpgrade, &(wasm_hash.clone(), ready_after));
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         env.events().publish(
             (soroban_sdk::Symbol::new(&env, "upgrade_proposed"), admin),
             (wasm_hash, ready_after),
@@ -416,7 +404,7 @@ impl TokenContract {
         env.storage()
             .instance()
             .set(&DataKey::Version, &(current_version + 1));
-        bump_instance(&env);
+        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         events::upgraded(&env, &admin, &wasm_hash);
         env.events().publish(
             (soroban_sdk::Symbol::new(&env, "upgrade_executed"), admin),
@@ -451,7 +439,7 @@ impl TokenContract {
         env.storage()
             .persistent()
             .set(&DataKey::Balance(account.clone()), &new_balance);
-        bump_persistent(env, &DataKey::Balance(account.clone()));
+        extend_ttl_persistent(env, &DataKey::Balance(account.clone()), LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
         Ok(())
     }
 

--- a/contracts/token/src/storage.rs
+++ b/contracts/token/src/storage.rs
@@ -44,3 +44,65 @@ pub enum MetadataKey {
     Symbol,
     Decimals,
 }
+
+#[cfg(test)]
+mod discriminant_tests {
+    use super::*;
+    use soroban_sdk::{testutils::Address as _, Address, Env};
+
+    // In Soroban, #[contracttype] enums use the variant NAME as the XDR storage discriminant.
+    // NEVER rename, reorder, or remove variants — doing so will corrupt on-chain storage for
+    // any live deployment. To add a new key, append it at the END of the enum definition.
+    //
+    // This exhaustive match is the primary guard: it causes a COMPILE ERROR if a variant is
+    // renamed or removed, and a non-exhaustive warning if one is added without updating here.
+    fn token_data_key_index(key: &DataKey) -> u32 {
+        match key {
+            DataKey::Admin => 0,
+            DataKey::PendingAdmin => 1,
+            DataKey::Balance(_) => 2,
+            DataKey::Allowance(_) => 3,
+            DataKey::Metadata(_) => 4,
+            DataKey::TotalSupply => 5,
+            DataKey::Paused => 6,
+            DataKey::MaxSupply => 7,
+            DataKey::PendingUpgrade => 8,
+            DataKey::Version => 9,
+            DataKey::Frozen(_) => 10,
+        }
+    }
+
+    fn metadata_key_index(key: &MetadataKey) -> u32 {
+        match key {
+            MetadataKey::Name => 0,
+            MetadataKey::Symbol => 1,
+            MetadataKey::Decimals => 2,
+        }
+    }
+
+    #[test]
+    fn data_key_discriminants_are_stable() {
+        let env = Env::default();
+        let addr = Address::generate(&env);
+        let allowance_key = AllowanceDataKey { from: addr.clone(), spender: addr.clone() };
+
+        assert_eq!(token_data_key_index(&DataKey::Admin), 0);
+        assert_eq!(token_data_key_index(&DataKey::PendingAdmin), 1);
+        assert_eq!(token_data_key_index(&DataKey::Balance(addr.clone())), 2);
+        assert_eq!(token_data_key_index(&DataKey::Allowance(allowance_key)), 3);
+        assert_eq!(token_data_key_index(&DataKey::Metadata(MetadataKey::Name)), 4);
+        assert_eq!(token_data_key_index(&DataKey::TotalSupply), 5);
+        assert_eq!(token_data_key_index(&DataKey::Paused), 6);
+        assert_eq!(token_data_key_index(&DataKey::MaxSupply), 7);
+        assert_eq!(token_data_key_index(&DataKey::PendingUpgrade), 8);
+        assert_eq!(token_data_key_index(&DataKey::Version), 9);
+        assert_eq!(token_data_key_index(&DataKey::Frozen(addr)), 10);
+    }
+
+    #[test]
+    fn metadata_key_discriminants_are_stable() {
+        assert_eq!(metadata_key_index(&MetadataKey::Name), 0);
+        assert_eq!(metadata_key_index(&MetadataKey::Symbol), 1);
+        assert_eq!(metadata_key_index(&MetadataKey::Decimals), 2);
+    }
+}

--- a/contracts/token/src/token_interface.rs
+++ b/contracts/token/src/token_interface.rs
@@ -8,7 +8,8 @@ use soroban_sdk::{panic_with_error, Address, Env, String};
 use crate::errors::TokenError;
 use crate::events;
 use crate::storage::{AllowanceDataKey, AllowanceValue, DataKey, MetadataKey};
-use crate::{bump_instance, TokenContract};
+use crate::TokenContract;
+use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
 #[cfg(feature = "pausable")]
 use crate::require_not_paused;
@@ -130,7 +131,7 @@ pub fn burn(env: Env, from: Address, amount: i128) {
     env.storage()
         .instance()
         .set(&DataKey::TotalSupply, &new_supply);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
     events::burned(&env, &from, amount);
 }
 
@@ -178,7 +179,7 @@ pub fn burn_from(env: Env, spender: Address, from: Address, amount: i128) {
     env.storage()
         .instance()
         .set(&DataKey::TotalSupply, &new_supply);
-    bump_instance(&env);
+    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
     events::burned(&env, &from, amount);
 }
 

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -206,6 +206,91 @@ cargo fuzz run token_fuzz -- corpus/
 ```bash
 RUST_BACKTRACE=1 cargo fuzz run token_fuzz -- fuzz/artifacts/token_fuzz/crash-*
 ```
+## Debugging Macros
+
+Soroban contracts rely heavily on proc macros (`#[contract]`, `#[contractimpl]`, `#[contracttype]`, etc.). When macro-related errors are cryptic or the generated code behaves unexpectedly, `cargo-expand` lets you inspect the exact Rust code the macros emit.
+
+### Installing cargo-expand
+
+```bash
+cargo install cargo-expand
+```
+
+`cargo-expand` requires the nightly toolchain to pretty-print expanded output:
+
+```bash
+rustup toolchain install nightly
+```
+
+### Example Commands
+
+**Expand an entire contract file:**
+
+```bash
+# From the contract's crate directory (e.g. contracts/token)
+cargo +nightly expand
+```
+
+**Expand a specific module:**
+
+```bash
+cargo +nightly expand token
+```
+
+**Expand a specific item (struct, impl block, function):**
+
+```bash
+cargo +nightly expand --lib token::Token
+```
+
+**Expand and pipe to a file for easier inspection:**
+
+```bash
+cargo +nightly expand > expanded.rs
+```
+
+**Expand with all features enabled:**
+
+```bash
+cargo +nightly expand --all-features
+```
+
+**Expand for the wasm32 target (matches the actual build target):**
+
+```bash
+cargo +nightly expand --target wasm32-unknown-unknown
+```
+
+### Common Macro Expansion Issues
+
+**`#[contract]` / `#[contractimpl]` not generating expected trait impls**
+
+Run `cargo +nightly expand` and search for the `IntoVal` / `TryFromVal` implementations. If they are missing, check that:
+- The struct derives or is annotated correctly (`#[contract]` on the struct, `#[contractimpl]` on the `impl` block).
+- There is no conflicting manual `impl` of the same trait in the expanded output.
+
+**Mysterious "method not found" or "trait bound not satisfied" errors**
+
+These often mean a macro failed silently. Expand the file and look for `compile_error!` calls or incomplete `impl` blocks in the output — they indicate which macro panicked and why.
+
+**`#[contracttype]` enum/struct not serializing correctly**
+
+Expand the type and verify the generated `ScVal` conversion arms match your expected variants. A missing `#[contracttype]` on a nested type will produce a stub that falls back to a raw `ScVal::Void`.
+
+**Duplicate symbol errors when building for wasm32**
+
+Expand with `--target wasm32-unknown-unknown` to see if two macros are emitting the same symbol. The duplicated `fn __call` or `fn __spec` entry in the expansion points to the conflicting `#[contractimpl]` block.
+
+**Expanded output is unreadable**
+
+Use `rustfmt` to format the expanded output:
+
+```bash
+cargo +nightly expand | rustfmt --edition 2021 > expanded.rs
+```
+
+---
+
 ## Secrets Management
 
 ### Golden rules


### PR DESCRIPTION
## Summary

- Closes #547 — Added a **Debugging Macros** section to `docs/dev-environment.md` with `cargo expand` installation, example commands for expanding contract macros, and a guide to diagnosing common macro expansion issues.
- Closes #542 — Removed 11 unnecessary `#[allow(dead_code)]` suppressions from public functions in the `escrow` and `token` contracts. All suppressed items are `pub fn` in library crates where the lint does not trigger.
- Closes #541 — Added exhaustive `DataKey` discriminant stability tests to `contracts/token/src/storage.rs` and `contracts/escrow/src/storage.rs`, documented the variant stability rules in `CONTRIBUTING.md`, and added a dedicated `datakey-discriminants` CI job in `.github/workflows/ci.yml`.
- Closes #537 — Removed the local `bump_instance` and `bump_persistent` helper functions from the `token` and `escrow` contracts and replaced all call sites with `soroban_common::extend_ttl_instance` and `soroban_common::extend_ttl_persistent`.

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test -p soroban-token-template` passes (all feature combinations)
- [ ] `cargo test -p soroban-escrow-template` passes (all feature combinations)
- [ ] `cargo test -p soroban-token-template -- discriminant_tests` passes
- [ ] `cargo test -p soroban-escrow-template -- discriminant_tests` passes
- [ ] CI `datakey-discriminants` job passes