### PR TITLE
feat: add contracts/oracle and contracts/lottery templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -109,9 +103,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -123,10 +117,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes-lit"
@@ -142,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -160,9 +163,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -346,7 +349,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -425,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -471,9 +473,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fastrand"
@@ -510,10 +512,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
+name = "futures-core"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -553,15 +573,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -589,24 +607,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hex"
@@ -657,12 +660,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,12 +678,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -724,11 +721,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -760,22 +758,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
 dependencies = [
  "arbitrary",
  "cc",
@@ -795,15 +787,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -826,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -891,6 +883,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -973,9 +971,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -994,9 +992,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1053,9 +1051,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
@@ -1152,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1188,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1201,15 +1199,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -1220,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1243,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest",
  "keccak",
@@ -1253,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -1268,10 +1267,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
+name = "slab"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
@@ -1316,7 +1321,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1359,7 +1364,7 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1410,6 +1415,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-lottery-template"
+version = "0.1.0"
+dependencies = [
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-multisig-template"
 version = "0.1.0"
 dependencies = [
@@ -1423,6 +1436,14 @@ name = "soroban-nft-template"
 version = "0.1.0"
 dependencies = [
  "proptest",
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
+name = "soroban-oracle-template"
+version = "0.1.0"
+dependencies = [
  "soroban-common",
  "soroban-sdk",
 ]
@@ -1478,7 +1499,7 @@ dependencies = [
  "base64 0.13.1",
  "stellar-xdr",
  "thiserror",
- "wasmparser 0.116.1",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1508,6 +1529,13 @@ dependencies = [
 
 [[package]]
 name = "soroban-subscription-template"
+version = "0.1.0"
+dependencies = [
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-swap-template"
 version = "0.1.0"
 dependencies = [
@@ -1626,9 +1654,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1670,12 +1698,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1685,25 +1712,40 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -1716,12 +1758,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "version_check"
@@ -1746,27 +1782,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1777,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1787,9 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1800,33 +1827,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -1853,19 +1858,7 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.13.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -1948,112 +1941,24 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.13.0",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.13.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2062,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/subscription", "tests", "fuzz"]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/timelock", "contracts/nft", "contracts/dao", "contracts/swap", "tests", "fuzz"]
+members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/subscription", "contracts/timelock", "contracts/nft", "contracts/dao", "contracts/swap", "contracts/oracle", "contracts/lottery", "tests", "fuzz"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ just --list
 | **NFT** | Non-fungible token with admin minting and optional supply cap | Digital collectibles, on-chain ownership, access tokens | ✅ Complete |
 | **DAO** | On-chain governance with token-weighted voting | Protocol upgrades, treasury management, community decisions | ✅ Complete |
 | **Swap** | Atomic two-party token swap with deadline | P2P token exchange, OTC trades, trustless DeFi swaps | ✅ Complete |
+| **Oracle** | Price oracle consumer with staleness validation | DeFi price feeds, on-chain data consumption, freshness checks | ✅ Complete |
+| **Lottery** | Verifiable on-chain lottery with commit-reveal randomness | Raffles, fair draws, decentralised prize distribution | ✅ Complete |
 
 ### Token Contract Features
 - **Standard Interface**: Full Soroban token compatibility
@@ -132,6 +134,22 @@ just --list
 - **Multi-Swap Support**: Multiple concurrent swaps tracked by auto-incrementing IDs
 - **Token Agnostic**: Works with any pair of Soroban-compatible tokens
 - **Event Emission**: `swap_proposed`, `swap_accepted`, and `swap_cancelled` events
+
+### Oracle Contract Features
+- **Price Feed Consumer**: Admin pushes price updates; consumers read via `get_price`
+- **Staleness Validation**: `get_price` rejects prices older than the configured ledger threshold
+- **Admin-Controlled Updates**: Only the admin may push new prices
+- **Configurable Threshold**: Staleness threshold set at initialization
+- **Event Emission**: `initialized` and `price_updated` events
+- **TTL Management**: Instance storage TTL is extended on every interaction
+
+### Lottery Contract Features
+- **Commit-Reveal Randomness**: Admin commits `hash(secret ++ salt)` before the draw, then reveals to prove fairness
+- **Ticket Purchase**: Any address buys tickets before the admin commits
+- **Verifiable Winner Selection**: Winner index derived from SHA-256 of revealed secret, salt, and ledger sequence
+- **Prize Pool Distribution**: Full ticket pool transferred to winner atomically
+- **State Machine**: Open → Committed → Drawn — each transition is irreversible
+- **Event Emission**: `initialized`, `ticket_purchased`, `committed`, and `winner_drawn` events
 
 Each template includes:
 - ✅ Complete contract implementation

--- a/contracts/lottery/Cargo.toml
+++ b/contracts/lottery/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "soroban-lottery-template"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+description = "A production-ready Soroban lottery contract template"
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[lints]
+workspace = true

--- a/contracts/lottery/build.rs
+++ b/contracts/lottery/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/contracts/lottery/src/errors.rs
+++ b/contracts/lottery/src/errors.rs
@@ -1,0 +1,16 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Copy, Debug)]
+pub enum LotteryError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    LotteryClosed = 4,
+    DrawAlreadyDone = 5,
+    DrawNotDone = 6,
+    InvalidTicketPrice = 7,
+    CommitAlreadySubmitted = 8,
+    RevealMismatch = 9,
+    NoTickets = 10,
+}

--- a/contracts/lottery/src/events.rs
+++ b/contracts/lottery/src/events.rs
@@ -1,0 +1,25 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+pub fn initialized(env: &Env, admin: &Address, ticket_price: i128) {
+    env.events().publish(
+        (Symbol::new(env, "initialized"), admin.clone()),
+        ticket_price,
+    );
+}
+
+pub fn ticket_purchased(env: &Env, buyer: &Address) {
+    env.events()
+        .publish((Symbol::new(env, "ticket_purchased"), buyer.clone()), ());
+}
+
+pub fn committed(env: &Env, admin: &Address) {
+    env.events()
+        .publish((Symbol::new(env, "committed"), admin.clone()), ());
+}
+
+pub fn winner_drawn(env: &Env, winner: &Address, prize: i128) {
+    env.events().publish(
+        (Symbol::new(env, "winner_drawn"), winner.clone()),
+        prize,
+    );
+}

--- a/contracts/lottery/src/lib.rs
+++ b/contracts/lottery/src/lib.rs
@@ -1,0 +1,245 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, crypto::Hash, token, Address, Bytes, BytesN, Env, Vec};
+
+mod errors;
+mod events;
+mod storage;
+
+pub use errors::LotteryError;
+pub use storage::{Commit, DataKey, LotteryInfo, LotteryState};
+
+use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+use storage::DataKey::*;
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+fn get_required<T: soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>(
+    env: &Env,
+    key: &DataKey,
+) -> Result<T, LotteryError> {
+    env.storage()
+        .instance()
+        .get(key)
+        .ok_or(LotteryError::NotInitialized)
+}
+
+/// Lottery contract using a commit-reveal scheme for verifiable randomness.
+///
+/// Lifecycle:
+/// 1. Admin calls `initialize` (→ Open).
+/// 2. Anyone calls `buy_ticket` (while Open).
+/// 3. Admin calls `commit` with hash(secret ++ salt) (→ Committed).
+/// 4. Admin calls `draw` revealing secret and salt (→ Drawn); winner receives the prize pool.
+#[contract]
+pub struct LotteryContract;
+
+#[contractimpl]
+impl LotteryContract {
+    /// Initialise the lottery.
+    ///
+    /// # Errors
+    /// - [`LotteryError::AlreadyInitialized`]
+    /// - [`LotteryError::InvalidTicketPrice`] if ticket_price <= 0
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        token: Address,
+        ticket_price: i128,
+    ) -> Result<(), LotteryError> {
+        if env.storage().instance().has(&State) {
+            return Err(LotteryError::AlreadyInitialized);
+        }
+        if ticket_price <= 0 {
+            return Err(LotteryError::InvalidTicketPrice);
+        }
+        admin.require_auth();
+
+        env.storage().instance().set(&Admin, &admin);
+        env.storage().instance().set(&Token, &token);
+        env.storage().instance().set(&TicketPrice, &ticket_price);
+        env.storage()
+            .instance()
+            .set(&Participants, &Vec::<Address>::new(&env));
+        env.storage().instance().set(&State, &LotteryState::Open);
+
+        bump_instance(&env);
+        events::initialized(&env, &admin, ticket_price);
+        Ok(())
+    }
+
+    /// Purchase one ticket. Transfers `ticket_price` tokens from caller to contract.
+    ///
+    /// # Errors
+    /// - [`LotteryError::NotInitialized`]
+    /// - [`LotteryError::LotteryClosed`] if lottery is no longer Open
+    pub fn buy_ticket(env: Env, buyer: Address) -> Result<(), LotteryError> {
+        let state: LotteryState = get_required(&env, &State)?;
+        if state != LotteryState::Open {
+            return Err(LotteryError::LotteryClosed);
+        }
+
+        buyer.require_auth();
+
+        let ticket_price: i128 = get_required(&env, &TicketPrice)?;
+        let token_addr: Address = get_required(&env, &Token)?;
+        token::Client::new(&env, &token_addr).transfer(
+            &buyer,
+            &env.current_contract_address(),
+            &ticket_price,
+        );
+
+        let mut participants: Vec<Address> = get_required(&env, &Participants)?;
+        participants.push_back(buyer.clone());
+        env.storage().instance().set(&Participants, &participants);
+
+        bump_instance(&env);
+        events::ticket_purchased(&env, &buyer);
+        Ok(())
+    }
+
+    /// Admin submits hash(secret ++ salt) to lock in randomness commitment.
+    /// Transitions lottery to Committed state, closing ticket sales.
+    ///
+    /// # Errors
+    /// - [`LotteryError::NotInitialized`]
+    /// - [`LotteryError::Unauthorized`]
+    /// - [`LotteryError::LotteryClosed`] if not Open
+    /// - [`LotteryError::CommitAlreadySubmitted`]
+    /// - [`LotteryError::NoTickets`] if no participants
+    pub fn commit(env: Env, hash: BytesN<32>) -> Result<(), LotteryError> {
+        let admin: Address = get_required(&env, &Admin)?;
+        admin.require_auth();
+
+        let state: LotteryState = get_required(&env, &State)?;
+        if state != LotteryState::Open {
+            return Err(if state == LotteryState::Committed {
+                LotteryError::CommitAlreadySubmitted
+            } else {
+                LotteryError::DrawAlreadyDone
+            });
+        }
+
+        let participants: Vec<Address> = get_required(&env, &Participants)?;
+        if participants.is_empty() {
+            return Err(LotteryError::NoTickets);
+        }
+
+        env.storage().instance().set(&Commit, &Commit { hash });
+        env.storage()
+            .instance()
+            .set(&State, &LotteryState::Committed);
+
+        bump_instance(&env);
+        events::committed(&env, &admin);
+        Ok(())
+    }
+
+    /// Admin reveals secret and salt. The contract verifies the preimage matches
+    /// the stored commitment, then uses hash(secret ++ salt ++ participants_count)
+    /// to pick a winner and transfer the entire prize pool.
+    ///
+    /// # Errors
+    /// - [`LotteryError::NotInitialized`]
+    /// - [`LotteryError::Unauthorized`]
+    /// - [`LotteryError::DrawNotDone`] if not yet Committed
+    /// - [`LotteryError::DrawAlreadyDone`] if already Drawn
+    /// - [`LotteryError::RevealMismatch`] if preimage does not match commitment
+    pub fn draw(env: Env, secret: BytesN<32>, salt: BytesN<32>) -> Result<Address, LotteryError> {
+        let admin: Address = get_required(&env, &Admin)?;
+        admin.require_auth();
+
+        let state: LotteryState = get_required(&env, &State)?;
+        match state {
+            LotteryState::Open => return Err(LotteryError::DrawNotDone),
+            LotteryState::Drawn => return Err(LotteryError::DrawAlreadyDone),
+            LotteryState::Committed => {}
+        }
+
+        // Verify commitment: SHA-256(secret ++ salt) must match stored hash.
+        let mut preimage = Bytes::new(&env);
+        preimage.extend_from_array(&secret.to_array());
+        preimage.extend_from_array(&salt.to_array());
+        let computed: BytesN<32> = env.crypto().sha256(&preimage).into();
+
+        let stored_commit: Commit = get_required(&env, &Commit)?;
+        if computed != stored_commit.hash {
+            return Err(LotteryError::RevealMismatch);
+        }
+
+        // Derive winner index from hash(secret ++ salt ++ ledger).
+        let ledger_bytes = env.ledger().sequence().to_be_bytes();
+        let mut entropy_input = Bytes::new(&env);
+        entropy_input.extend_from_array(&secret.to_array());
+        entropy_input.extend_from_array(&salt.to_array());
+        entropy_input.extend_from_array(&ledger_bytes);
+        let entropy: Hash<32> = env.crypto().sha256(&entropy_input);
+        let entropy_bytes = entropy.to_array();
+        // Use last 8 bytes as u64 for modulo.
+        let idx_raw = u64::from_be_bytes([
+            entropy_bytes[24],
+            entropy_bytes[25],
+            entropy_bytes[26],
+            entropy_bytes[27],
+            entropy_bytes[28],
+            entropy_bytes[29],
+            entropy_bytes[30],
+            entropy_bytes[31],
+        ]);
+
+        let participants: Vec<Address> = get_required(&env, &Participants)?;
+        let count = participants.len() as u64;
+        let winner_idx = (idx_raw % count) as u32;
+        let winner = participants.get(winner_idx).unwrap();
+
+        // Transfer full prize pool to winner.
+        let ticket_price: i128 = get_required(&env, &TicketPrice)?;
+        let prize = ticket_price * count as i128;
+        let token_addr: Address = get_required(&env, &Token)?;
+        token::Client::new(&env, &token_addr).transfer(
+            &env.current_contract_address(),
+            &winner,
+            &prize,
+        );
+
+        env.storage().instance().set(&State, &LotteryState::Drawn);
+        env.storage().instance().set(&Winner, &winner);
+
+        bump_instance(&env);
+        events::winner_drawn(&env, &winner, prize);
+        Ok(winner)
+    }
+
+    /// Return lottery details.
+    ///
+    /// # Errors
+    /// - [`LotteryError::NotInitialized`]
+    pub fn get_info(env: Env) -> Result<LotteryInfo, LotteryError> {
+        Ok(LotteryInfo {
+            admin: get_required(&env, &Admin)?,
+            token: get_required(&env, &Token)?,
+            ticket_price: get_required(&env, &TicketPrice)?,
+            state: get_required(&env, &State)?,
+            participants: get_required(&env, &Participants)?,
+        })
+    }
+
+    /// Return the winner address (only available after draw).
+    ///
+    /// # Errors
+    /// - [`LotteryError::NotInitialized`]
+    /// - [`LotteryError::DrawNotDone`] if draw hasn't happened yet
+    pub fn get_winner(env: Env) -> Result<Address, LotteryError> {
+        let state: LotteryState = get_required(&env, &State)?;
+        if state != LotteryState::Drawn {
+            return Err(LotteryError::DrawNotDone);
+        }
+        get_required(&env, &Winner)
+    }
+}
+
+mod test;

--- a/contracts/lottery/src/storage.rs
+++ b/contracts/lottery/src/storage.rs
@@ -1,0 +1,38 @@
+use soroban_sdk::{contracttype, Address, BytesN, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Token,
+    TicketPrice,
+    Participants,
+    State,
+    Commit,
+    Winner,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LotteryState {
+    Open = 0,
+    Committed = 1,
+    Drawn = 2,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct LotteryInfo {
+    pub admin: Address,
+    pub token: Address,
+    pub ticket_price: i128,
+    pub state: LotteryState,
+    pub participants: Vec<Address>,
+}
+
+/// Commit stored on-chain: hash(secret || salt) where both are 32-byte values.
+#[contracttype]
+#[derive(Clone)]
+pub struct Commit {
+    pub hash: BytesN<32>,
+}

--- a/contracts/lottery/src/test.rs
+++ b/contracts/lottery/src/test.rs
@@ -1,0 +1,198 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::Address as _,
+    token::TokenInterface,
+    Address, Bytes, BytesN, Env, String,
+};
+
+// ---------------------------------------------------------------------------
+// MockToken
+// ---------------------------------------------------------------------------
+
+#[contract]
+pub struct MockToken;
+
+#[contractimpl]
+impl TokenInterface for MockToken {
+    fn allowance(_env: Env, _from: Address, _spender: Address) -> i128 { 0 }
+    fn approve(_env: Env, _from: Address, _spender: Address, _amount: i128, _exp: u32) {}
+    fn balance(_env: Env, _id: Address) -> i128 { i128::MAX }
+    fn transfer(_env: Env, _from: Address, _to: Address, _amount: i128) {}
+    fn transfer_from(_env: Env, _spender: Address, _from: Address, _to: Address, _amount: i128) {}
+    fn burn(_env: Env, _from: Address, _amount: i128) {}
+    fn burn_from(_env: Env, _spender: Address, _from: Address, _amount: i128) {}
+    fn decimals(_env: Env) -> u32 { 7 }
+    fn name(env: Env) -> String { String::from_str(&env, "Mock") }
+    fn symbol(env: Env) -> String { String::from_str(&env, "MCK") }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_commit(env: &Env, secret: &[u8; 32], salt: &[u8; 32]) -> BytesN<32> {
+    let mut preimage = Bytes::new(env);
+    preimage.extend_from_array(secret);
+    preimage.extend_from_array(salt);
+    env.crypto().sha256(&preimage).into()
+}
+
+fn setup(env: &Env) -> (LotteryContractClient, Address, Address) {
+    let admin = Address::generate(env);
+    let token = env.register_contract(None, MockToken);
+    let addr = env.register_contract(None, LotteryContract);
+    let client = LotteryContractClient::new(env, &addr);
+    client.initialize(&admin, &token, &100);
+    (client, admin, token)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token) = setup(&env);
+    let info = client.get_info();
+    assert_eq!(info.admin, admin);
+    assert_eq!(info.token, token);
+    assert_eq!(info.ticket_price, 100);
+    assert_eq!(info.state, LotteryState::Open);
+    assert!(info.participants.is_empty());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_initialize_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token) = setup(&env);
+    client.initialize(&admin, &token, &100);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_initialize_zero_price_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let token = env.register_contract(None, MockToken);
+    let addr = env.register_contract(None, LotteryContract);
+    let client = LotteryContractClient::new(&env, &addr);
+    client.initialize(&admin, &token, &0);
+}
+
+#[test]
+fn test_buy_ticket() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup(&env);
+    let buyer = Address::generate(&env);
+    client.buy_ticket(&buyer);
+    assert_eq!(client.get_info().participants.len(), 1);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_commit_with_no_tickets_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup(&env);
+    let secret = [1u8; 32];
+    let salt = [2u8; 32];
+    let hash = make_commit(&env, &secret, &salt);
+    client.commit(&hash);
+}
+
+#[test]
+fn test_full_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup(&env);
+
+    let buyer1 = Address::generate(&env);
+    let buyer2 = Address::generate(&env);
+    client.buy_ticket(&buyer1);
+    client.buy_ticket(&buyer2);
+
+    let secret = [42u8; 32];
+    let salt = [99u8; 32];
+    let hash = make_commit(&env, &secret, &salt);
+    client.commit(&hash);
+    assert_eq!(client.get_info().state, LotteryState::Committed);
+
+    let secret_bytes: BytesN<32> = BytesN::from_array(&env, &secret);
+    let salt_bytes: BytesN<32> = BytesN::from_array(&env, &salt);
+    let winner = client.draw(&secret_bytes, &salt_bytes);
+
+    assert!(winner == buyer1 || winner == buyer2);
+    assert_eq!(client.get_info().state, LotteryState::Drawn);
+    assert_eq!(client.get_winner(), winner);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #9)")]
+fn test_draw_wrong_preimage_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup(&env);
+
+    let buyer = Address::generate(&env);
+    client.buy_ticket(&buyer);
+
+    let secret = [1u8; 32];
+    let salt = [2u8; 32];
+    let hash = make_commit(&env, &secret, &salt);
+    client.commit(&hash);
+
+    // Reveal wrong secret.
+    let bad_secret: BytesN<32> = BytesN::from_array(&env, &[9u8; 32]);
+    let salt_bytes: BytesN<32> = BytesN::from_array(&env, &salt);
+    client.draw(&bad_secret, &salt_bytes);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_buy_ticket_after_commit_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup(&env);
+
+    let buyer = Address::generate(&env);
+    client.buy_ticket(&buyer);
+
+    let secret = [1u8; 32];
+    let salt = [2u8; 32];
+    let hash = make_commit(&env, &secret, &salt);
+    client.commit(&hash);
+
+    // Should fail — lottery is no longer Open.
+    let another = Address::generate(&env);
+    client.buy_ticket(&another);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_draw_after_draw_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _) = setup(&env);
+
+    let buyer = Address::generate(&env);
+    client.buy_ticket(&buyer);
+
+    let secret = [1u8; 32];
+    let salt = [2u8; 32];
+    let hash = make_commit(&env, &secret, &salt);
+    client.commit(&hash);
+
+    let secret_bytes: BytesN<32> = BytesN::from_array(&env, &secret);
+    let salt_bytes: BytesN<32> = BytesN::from_array(&env, &salt);
+    client.draw(&secret_bytes, &salt_bytes);
+    // Second draw should fail.
+    client.draw(&secret_bytes, &salt_bytes);
+}

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "soroban-oracle-template"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+description = "A production-ready Soroban price oracle consumer contract template"
+license.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[lints]
+workspace = true

--- a/contracts/oracle/build.rs
+++ b/contracts/oracle/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+}

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -1,0 +1,11 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Copy, Debug)]
+pub enum OracleError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    StalePrice = 4,
+    InvalidStalenessThreshold = 5,
+}

--- a/contracts/oracle/src/events.rs
+++ b/contracts/oracle/src/events.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::{Address, Env, Symbol};
+
+pub fn initialized(env: &Env, admin: &Address, staleness_threshold: u32) {
+    env.events().publish(
+        (Symbol::new(env, "initialized"), admin.clone()),
+        staleness_threshold,
+    );
+}
+
+pub fn price_updated(env: &Env, admin: &Address, price: i128, ledger: u32) {
+    env.events().publish(
+        (Symbol::new(env, "price_updated"), admin.clone()),
+        (price, ledger),
+    );
+}

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -1,0 +1,121 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+mod errors;
+mod events;
+mod storage;
+
+pub use errors::OracleError;
+pub use storage::{DataKey, PriceData};
+
+use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+use storage::DataKey::*;
+
+fn bump_instance(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
+fn get_required<T: soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>(
+    env: &Env,
+    key: &DataKey,
+) -> Result<T, OracleError> {
+    env.storage()
+        .instance()
+        .get(key)
+        .ok_or(OracleError::NotInitialized)
+}
+
+/// Price oracle consumer contract.
+///
+/// The admin pushes price updates; consumers call `get_price` which validates
+/// that the price is not stale before returning it.
+#[contract]
+pub struct OracleContract;
+
+#[contractimpl]
+impl OracleContract {
+    /// Initialize with an admin and a staleness threshold (in ledgers).
+    ///
+    /// # Errors
+    /// - [`OracleError::AlreadyInitialized`] if already set up.
+    /// - [`OracleError::InvalidStalenessThreshold`] if threshold is zero.
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        staleness_threshold: u32,
+    ) -> Result<(), OracleError> {
+        if env.storage().instance().has(&Admin) {
+            return Err(OracleError::AlreadyInitialized);
+        }
+        if staleness_threshold == 0 {
+            return Err(OracleError::InvalidStalenessThreshold);
+        }
+        admin.require_auth();
+
+        env.storage().instance().set(&Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&StalenessThreshold, &staleness_threshold);
+
+        bump_instance(&env);
+        events::initialized(&env, &admin, staleness_threshold);
+        Ok(())
+    }
+
+    /// Push a new price. Admin only.
+    ///
+    /// # Errors
+    /// - [`OracleError::NotInitialized`] if not yet set up.
+    /// - [`OracleError::Unauthorized`] if caller is not the admin.
+    pub fn update_price(env: Env, price: i128) -> Result<(), OracleError> {
+        let admin: Address = get_required(&env, &Admin)?;
+        admin.require_auth();
+
+        let ledger = env.ledger().sequence();
+        env.storage().instance().set(&Price, &price);
+        env.storage().instance().set(&UpdatedAt, &ledger);
+
+        bump_instance(&env);
+        events::price_updated(&env, &admin, price, ledger);
+        Ok(())
+    }
+
+    /// Return the current price, rejecting it if it is stale.
+    ///
+    /// A price is stale when `current_ledger - updated_at > staleness_threshold`.
+    ///
+    /// # Errors
+    /// - [`OracleError::NotInitialized`] if no price has been pushed yet.
+    /// - [`OracleError::StalePrice`] if the price is older than the threshold.
+    pub fn get_price(env: Env) -> Result<i128, OracleError> {
+        let price: i128 = get_required(&env, &Price)?;
+        let updated_at: u32 = get_required(&env, &UpdatedAt)?;
+        let threshold: u32 = get_required(&env, &StalenessThreshold)?;
+
+        let age = env.ledger().sequence().saturating_sub(updated_at);
+        if age > threshold {
+            return Err(OracleError::StalePrice);
+        }
+
+        bump_instance(&env);
+        Ok(price)
+    }
+
+    /// Return the raw price data (price, updated_at, admin, staleness_threshold).
+    ///
+    /// # Errors
+    /// - [`OracleError::NotInitialized`] if not yet set up.
+    pub fn get_price_data(env: Env) -> Result<PriceData, OracleError> {
+        Ok(PriceData {
+            price: get_required(&env, &Price)?,
+            updated_at: get_required(&env, &UpdatedAt)?,
+            admin: get_required(&env, &Admin)?,
+            staleness_threshold: get_required(&env, &StalenessThreshold)?,
+        })
+    }
+}
+
+mod test;

--- a/contracts/oracle/src/storage.rs
+++ b/contracts/oracle/src/storage.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::{contracttype, Address};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    Price,
+    UpdatedAt,
+    StalenessThreshold,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PriceData {
+    pub price: i128,
+    pub updated_at: u32,
+    pub admin: Address,
+    pub staleness_threshold: u32,
+}

--- a/contracts/oracle/src/test.rs
+++ b/contracts/oracle/src/test.rs
@@ -1,0 +1,98 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
+
+fn setup(env: &Env) -> (OracleContractClient, Address) {
+    let admin = Address::generate(env);
+    let addr = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(env, &addr);
+    client.initialize(&admin, &100);
+    (client, admin)
+}
+
+#[test]
+fn test_initialize() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    // Push a price so get_price_data works.
+    client.update_price(&1_000_000);
+    let data = client.get_price_data();
+    assert_eq!(data.admin, admin);
+    assert_eq!(data.staleness_threshold, 100);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_initialize_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    client.initialize(&admin, &100);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_initialize_zero_threshold_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let addr = env.register_contract(None, OracleContract);
+    let client = OracleContractClient::new(&env, &addr);
+    client.initialize(&admin, &0);
+}
+
+#[test]
+fn test_update_and_get_price() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    client.update_price(&5_000_000);
+    assert_eq!(client.get_price(), 5_000_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_get_price_before_any_update_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    client.get_price();
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_stale_price_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    client.update_price(&1_000_000);
+    // Advance ledger past threshold (100).
+    env.ledger().with_mut(|l| l.sequence_number += 101);
+    client.get_price();
+}
+
+#[test]
+fn test_price_at_threshold_boundary_is_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    client.update_price(&2_000_000);
+    // Advance exactly to threshold — still valid.
+    env.ledger().with_mut(|l| l.sequence_number += 100);
+    assert_eq!(client.get_price(), 2_000_000);
+}
+
+#[test]
+fn test_price_update_overwrites_previous() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+    client.update_price(&1_000);
+    client.update_price(&9_999);
+    assert_eq!(client.get_price(), 9_999);
+}


### PR DESCRIPTION
## Summary

Adds two new production-ready Soroban contract templates.

---

### contracts/oracle (closes #620)

Price oracle consumer: admin pushes prices, consumers call `get_price` which validates staleness against a configurable ledger threshold.

**8 unit tests** — happy path, stale price, boundary, guard cases.

---

### contracts/lottery (closes #621)

Verifiable on-chain lottery using commit-reveal randomness.
- Admin commits `hash(secret ++ salt)`, closing ticket sales
- `draw` verifies preimage and derives winner from `SHA-256(secret ++ salt ++ ledger)`
- Full prize pool transferred to winner atomically
- State machine: Open → Committed → Drawn

**9 unit tests** — full lifecycle, reveal mismatch, state guards.

---

## Checklist
- [x] Both contracts compile
- [x] All tests pass (8 oracle, 9 lottery)
- [x] README updated
- [x] Workspace Cargo.toml updated

Closes #620
Closes #621