### PR TITLE
fix: resolve issues #549 #550 #551 #552 and CI workflow bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,16 @@ jobs:
 
   security-audit:
     name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit --deny warnings
+
   machete:
     name: Unused dependencies (cargo-machete)
     runs-on: ubuntu-latest
@@ -247,11 +257,29 @@ jobs:
 
       - name: Check for unused dev-dependencies
         run: cargo +nightly udeps --workspace --all-targets
-      - name: Install cargo-audit
-        run: cargo install cargo-audit --locked
 
-      - name: Run cargo audit
-        run: cargo audit
+  semver:
+    name: Semver Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Install cargo-semver-checks
+        run: cargo install cargo-semver-checks --locked
+
+      - name: Check soroban-token-template for breaking changes
+        run: cargo semver-checks -p soroban-token-template
+
+      - name: Check soroban-escrow-template for breaking changes
+        run: cargo semver-checks -p soroban-escrow-template
 
   smoke-test:
     name: Smoke Test (local node)
@@ -308,4 +336,3 @@ jobs:
       - name: Stop local Stellar node
         if: always()
         run: docker compose -f docker/docker-compose.yml down -v
-        run: cargo audit --deny warnings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,20 @@ cargo install cargo-udeps --locked
 cargo +nightly udeps --workspace --all-targets
 ```
 
+### cargo-semver-checks (breaking API changes)
+
+The `semver` CI job runs `cargo semver-checks` on every PR to detect breaking public API changes in `soroban-token-template` and `soroban-escrow-template`.
+
+**Semver policy:** This repository follows [Semantic Versioning](https://semver.org/). Any change that removes, renames, or changes the signature of a public contract entry point, error type, or event is a **breaking change** and requires a major version bump. Adding new public items is backwards-compatible and requires only a minor bump. Bug fixes with no API change require a patch bump.
+
+Install locally:
+
+```bash
+cargo install cargo-semver-checks --locked
+cargo semver-checks -p soroban-token-template
+cargo semver-checks -p soroban-escrow-template
+```
+
 ---
 
 ## Code style

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/subscription", "tests", "fuzz"]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/timelock", "contracts/nft", "contracts/dao", "contracts/swap", "tests", "fuzz"]
+members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/subscription", "contracts/timelock", "contracts/nft", "contracts/dao", "contracts/swap", "tests", "fuzz"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -147,6 +147,28 @@ Each template includes:
 
 > **Zero-install option:** Open this repo in a pre-configured environment with all tools ready — see the [Dev Container & Codespaces Guide](docs/devcontainer.md).
 
+## 🔄 Compatibility Matrix
+
+This repository is pinned to `soroban-sdk = "=21.7.7"`. Each major SDK version is tightly coupled to a Stellar network protocol version. Use the table below to pick the right SDK for your target network.
+
+> ⚠️ **Always verify compatibility before deploying to Mainnet.** Contracts compiled against SDK v21 will not work on a node running Protocol 22 or later without recompilation against the matching SDK version.
+
+| soroban-sdk version | Stellar Protocol | Network status | Notes |
+|---------------------|-----------------|----------------|-------|
+| `21.x` (this repo: `21.7.7`) | Protocol 21 | Mainnet (Jun 2024) | secp256r1, separate TTL extension for instance/code |
+| `22.x` | Protocol 22 | Mainnet (Dec 2024) | Constructor support, BLS12-381 host functions |
+| `23.x` | Protocol 23 "Whisk" | Mainnet (Sep 2025) | Unified events (CAP-67), state archival (CAP-62/66) |
+| `25.x` | Protocol 25 "X-Ray" | Mainnet (Jan 2026) | BN254 elliptic curve ops, Poseidon hash functions |
+| `26.x` | Protocol 26 "Yardstick" | Mainnet (May 2026) | Freeze ledger entries, muxed address conversions, ZK BN254 |
+
+**To upgrade this repository to a newer SDK:**
+1. Update `soroban-sdk = "=<new-version>"` in `Cargo.toml`.
+2. Update `stellar-cli` to the matching version (`cargo install stellar-cli --version <new-version>`).
+3. Rebuild all contracts and run the full test suite.
+4. Update this matrix and `docs/gas-costs.md` with the new protocol version and fee schedule.
+
+For the authoritative version table, see [Stellar Software Versions](https://developers.stellar.org/docs/networks/software-versions).
+
 ## 📖 Usage
 
 ### Building Contracts

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -91,6 +91,24 @@ proptest! {
 
 **Use `prop_assert!` / `prop_assert_eq!`** instead of `assert!` inside `proptest!` blocks — they report the failing input rather than just panicking.
 
+### Proptest configuration
+
+The root `proptest.toml` configures proptest for all contracts in this workspace:
+
+```toml
+[proptest]
+cases = 256
+failure_persistence = "MapPath"
+```
+
+`failure_persistence = "MapPath"` tells proptest to write failing seeds to `proptest-regressions/<module_path>.txt` next to the test source. These files are listed in `.gitignore` so they are not committed — see the note below on how to share a failing seed.
+
+Override the number of cases for a single run:
+
+```bash
+PROPTEST_CASES=10000 cargo test -p soroban-token-template prop_
+```
+
 ### Reproducing a Failing Seed
 
 When proptest finds a failure it prints a line like:
@@ -101,21 +119,16 @@ PROPTEST_REGRESSIONS=contracts/token/proptest-regressions/prop_test.txt
 Failing input: amount = 9223372036854775807
 ```
 
-To reproduce it deterministically:
+The seed is saved to `proptest-regressions/prop_test.txt` inside the contract directory. To reproduce deterministically:
 
 ```bash
-# Re-run only that test with the saved seed file
-PROPTEST_REGRESSIONS=contracts/token/proptest-regressions/prop_test.txt \
-  cargo test -p soroban-token-template prop_mint_burn_roundtrip
+# Re-run only that test — proptest reads the saved regression file automatically
+cargo test -p soroban-token-template prop_mint_burn_roundtrip
 ```
 
-Proptest also writes a `proptest-regressions/` file next to the test file. Commit this file so CI always replays known failures.
+To share a failing seed with a colleague or in a bug report, copy the content of the regression file and paste it. They can place it at the same path and run the same command.
 
-To run more cases than the default (256):
-
-```bash
-PROPTEST_CASES=10000 cargo test -p soroban-token-template prop_
-```
+> **Gitignore choice:** `proptest-regressions/` directories are listed in `.gitignore` and are **not committed**. This keeps the repository clean. If you want CI to always replay a specific known failure, copy the regression file into a test fixture and add a dedicated `#[test]` that runs proptest with that seed using `ProptestConfig::with_cases(1)` and the `Just` strategy.
 
 ---
 

--- a/proptest.toml
+++ b/proptest.toml
@@ -1,0 +1,13 @@
+# proptest configuration
+# See https://proptest-rs.github.io/proptest/proptest/config.html
+
+[proptest]
+# Number of test cases to generate per property test (default: 256).
+# Override per-run with PROPTEST_CASES=<n> environment variable.
+cases = 256
+
+# Write failing seeds to a regression file so failures are reproducible.
+# The file is written to proptest-regressions/<module_path>.txt next to the
+# test source file.  These files are listed in .gitignore; see docs/testing-guide.md
+# for instructions on how to replay a failing seed.
+failure_persistence = "MapPath"


### PR DESCRIPTION
## Summary

This PR resolves issues #549, #550, #551, #552 and fixes two CI workflow bugs.

---

### CI Workflow Fixes

- **`security-audit` job was broken**: it was missing `runs-on` and `steps` — they had been inadvertently merged into the `machete` job. Restored as a proper standalone job.
- **`smoke-test` job had a dangling `run: cargo audit` key**: duplicate `run:` key removed.
- **`Cargo.toml` had duplicate `members=` line**: removed the old shorter list, kept the complete one.

---

### Closes #552 — deny.toml `[bans]` section

Verified `deny.toml` already contains a correct `[bans]` section:
- `multiple-versions = "deny"`
- `wildcards = "deny"`
- `skip` entries for the unavoidable `darling` dual-version (soroban-sdk-macros vs serde_with_macros)

No changes needed; the CI `deny` job passes.

---

### Closes #551 — `semver` CI job + CONTRIBUTING.md policy

- Added `semver` job to `.github/workflows/ci.yml` that installs `cargo-semver-checks` and runs it on `soroban-token-template` and `soroban-escrow-template`.
- Added a **Semver Policy** section to `CONTRIBUTING.md` explaining major/minor/patch bump rules and how to run the check locally.

---

### Closes #550 — proptest seed logging

- Created `proptest.toml` at workspace root with `failure_persistence = "MapPath"` so failing seeds are written to `proptest-regressions/<module>.txt` next to each test file.
- Updated `docs/testing-guide.md` with a **Proptest configuration** subsection explaining the config file, how to reproduce a failing seed, and documenting the gitignore choice (`proptest-regressions/` is listed in `.gitignore` and not committed).

---

### Closes #549 — soroban-sdk compatibility matrix

- Added a **Compatibility Matrix** table to `README.md` covering SDK `21.x` through `26.x`, each mapped to its Stellar protocol version, mainnet launch date, and key features.
- Added upgrade instructions and a link to the authoritative Stellar Software Versions page.

---

## Testing

- `cargo check --workspace` passes locally.
- All CI YAML changes validated by syntax review.

Closes #549
Closes #550
Closes #551
Closes #552