### PR TITLE
Issues/635 636 637 638

### DIFF
--- a/contracts/escrow/src/storage.rs
+++ b/contracts/escrow/src/storage.rs
@@ -40,7 +40,7 @@ pub enum DataKey {
 /// `Created → Funded → Delivered → Completed`
 /// with side exits to `Refunded` or `Cancelled`.
 #[contracttype]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum EscrowState {
     /// Escrow has been initialized but not yet funded.
     Created = 0,
@@ -181,6 +181,15 @@ mod tests {
         assert_eq!(EscrowState::Completed.to_string(), "completed");
         assert_eq!(EscrowState::Refunded.to_string(), "refunded");
         assert_eq!(EscrowState::Cancelled.to_string(), "cancelled");
+    }
+
+    #[test]
+    fn test_escrow_state_ordering() {
+        assert!(EscrowState::Created < EscrowState::Funded);
+        assert!(EscrowState::Funded < EscrowState::Delivered);
+        assert!(EscrowState::Delivered < EscrowState::Disputed);
+        assert!(EscrowState::Funded >= EscrowState::Created);
+        assert_eq!(EscrowState::Created, EscrowState::Created);
     }
 }
 

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -22,12 +22,14 @@ use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 #[contract]
 pub struct MultisigContract;
 
+#[inline]
 fn bump_instance(env: &Env) {
     env.storage()
         .instance()
         .extend_ttl(LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 }
 
+#[inline]
 fn bump_transaction(env: &Env, tx_id: u64) {
     env.storage().persistent().extend_ttl(
         &DataKey::Transaction(tx_id),
@@ -36,6 +38,7 @@ fn bump_transaction(env: &Env, tx_id: u64) {
     );
 }
 
+#[inline]
 fn contains(list: &Vec<Address>, address: &Address) -> bool {
     for item in list.iter() {
         if item == *address {
@@ -45,6 +48,7 @@ fn contains(list: &Vec<Address>, address: &Address) -> bool {
     false
 }
 
+#[inline]
 fn validate_unique_signers(signers: &Vec<Address>) -> Result<(), MultisigError> {
     if signers.is_empty() {
         return Err(MultisigError::InvalidSigners);
@@ -60,6 +64,7 @@ fn validate_unique_signers(signers: &Vec<Address>) -> Result<(), MultisigError> 
     Ok(())
 }
 
+#[inline]
 fn validate_threshold(threshold: u32, signer_count: u32) -> Result<(), MultisigError> {
     if threshold == 0 || threshold > signer_count {
         return Err(MultisigError::InvalidThreshold);
@@ -285,6 +290,7 @@ impl MultisigContract {
         Self::get_transaction(env, tx_id).map(|tx| tx.signatures.len())
     }
 
+    #[inline]
     fn get_required_signers(env: &Env) -> Result<Vec<Address>, MultisigError> {
         env.storage()
             .instance()
@@ -292,6 +298,7 @@ impl MultisigContract {
             .ok_or(MultisigError::NotInitialized)
     }
 
+    #[inline]
     fn get_required_transaction(env: &Env, tx_id: u64) -> Result<Transaction, MultisigError> {
         env.storage()
             .persistent()
@@ -299,6 +306,7 @@ impl MultisigContract {
             .ok_or(MultisigError::TransactionNotFound)
     }
 
+    #[inline]
     fn require_signer(env: &Env, signer: &Address) -> Result<(), MultisigError> {
         let signers = Self::get_required_signers(env)?;
         if !contains(&signers, signer) {
@@ -307,6 +315,7 @@ impl MultisigContract {
         Ok(())
     }
 
+    #[inline]
     fn require_threshold_approvals(
         env: &Env,
         approvals: &Vec<Address>,


### PR DESCRIPTION
## Summary

This PR addresses four code quality and optimization issues across the Soroban contract suite, focusing on type enhancements, code verification, and WASM performance optimization.

## Changes

### 1. Issue #635: Add PartialOrd/Ord Derives to EscrowState

**File**: `contracts/escrow/src/storage.rs`

- Added `PartialOrd` and `Ord` derives to `EscrowState` enum for sorted state comparisons
- Implemented `test_escrow_state_ordering()` test to verify ordering semantics:
  - `Created < Funded < Delivered < Disputed`
  - Enables lifecycle state assertions like `state >= EscrowState::Funded`

**Benefits**: Simplifies lifecycle state validation in tests and reduces boilerplate comparison logic.

---

### 2. Issue #636: Verify Dead Code in Multisig Contract

**File**: `contracts/multisig/src/lib.rs`

- Comprehensive code review of all functions in the multisig contract
- Verified all helper functions are actively used:
  - `bump_instance()`: Called in initialize, add_signer, remove_signer, propose_transaction, sign_transaction, execute_transaction
  - `bump_transaction()`: Called in propose_transaction, sign_transaction, execute_transaction, get_transaction
  - `contains()`: Called in validation and signer checks
  - `validate_unique_signers()`: Called in initialize, add_signer, require_threshold_approvals
  - `validate_threshold()`: Called in initialize, add_signer, remove_signer
  - All public methods: Contract entry points or query functions
  - All private helpers: Used from public/impl methods

**Conclusion**: Zero dead code. All functions have callers. No changes required.

---

### 3. Issue #637: Normalize Storage Key Naming to PascalCase

**Files**: `contracts/escrow/src/storage.rs`, `contracts/token/src/storage.rs`, `contracts/staking/src/storage.rs`, `contracts/vesting/src/storage.rs`

- Verified all `DataKey` variants across four specified contracts
- **Escrow (13 variants)**: Buyer, Seller, Arbiter, TokenContract, Amount, Deadline, State, Paused, Version, PendingUpgrade, Arbiters, RequiredSignatures, ArbiterVotes
- **Token (11 variants)**: Admin, PendingAdmin, Balance, Allowance, Metadata, TotalSupply, Paused, MaxSupply, PendingUpgrade, Version, Frozen
- **Staking (9 variants)**: Admin, StakeToken, RewardToken, TotalStaked, TotalRewards, RewardPerTokenStored, Stake, RewardPerTokenPaid, Rewards
- **Vesting (8 variants)**: Beneficiary, Token, CliffLedger, EndLedger, Amount, Claimed, Revoked, Admin

**Conclusion**: All variants already normalized to PascalCase. No changes required. Requirement fully met.

---

### 4. Issue #638: Add #[inline] Hints to Hot-Path Storage Helpers

**File**: `contracts/multisig/src/lib.rs`

- Added `#[inline]` attribute to 9 hot-path helper functions for WASM optimization:

**Top-level helpers:**
- `bump_instance()` - Extends instance storage TTL
- `bump_transaction()` - Extends persistent storage TTL for transactions
- `contains()` - Linear search helper for address membership
- `validate_unique_signers()` - Validates signer set uniqueness
- `validate_threshold()` - Validates threshold constraints

**Private impl methods:**
- `get_required_signers()` - Retrieves signer set with error handling
- `get_required_transaction()` - Retrieves transaction with error handling
- `require_signer()` - Signer authorization check
- `require_threshold_approvals()` - Multi-signer approval validation

**Benefits**: Micro-optimization for WASM compilation. Guides the compiler to inline frequently called functions, reducing function call overhead in contract execution.

---

## Testing

- ✅ Existing test suite passes (escrow, token, staking, vesting, multisig)
- ✅ New test `test_escrow_state_ordering()` verifies PartialOrd/Ord implementation
- ✅ Code review verified all functions are actively used (no dead code)
- ✅ All DataKey variants verified as PascalCase

## Files Changed

- `contracts/escrow/src/storage.rs` (+10 lines)
- `contracts/multisig/src/lib.rs` (+9 lines)

## Closes

Closes #635
Closes #636
Closes #637
Closes #638