### PR TITLE
refactor/build/ci/docs: escrow init helpers, cargo-criterion, wasm-op…

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,13 +29,23 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run benchmarks (save baseline)
-        # --save-baseline stores results under target/criterion so we can
-        # compare on subsequent runs.  On PRs we compare against the stored
-        # main baseline; on pushes to main we update it.
+      - name: Install cargo-criterion
+        run: cargo install cargo-criterion --locked
+
+      - name: Run benchmarks with cargo-criterion
+        # cargo-criterion saves machine-readable JSON and HTML reports under
+        # target/criterion/. On PRs we compare against the stored main baseline;
+        # on pushes to main we update it.
         run: |
-          cargo bench --package contract-benchmarks -- \
-            --save-baseline ci_baseline 2>&1 | tee bench_output.txt
+          cargo criterion --package contract-benchmarks \
+            --message-format json 2>&1 | tee bench_output.txt
+
+      - name: Upload HTML benchmark reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: criterion-html-reports-${{ github.sha }}
+          path: target/criterion/
+          retention-days: 30
 
       - name: Parse benchmark results to JSON
         shell: bash
@@ -174,7 +184,7 @@ jobs:
             }
 
       # ── Threshold check ────────────────────────────────────────────────────
-      # Criterion prints "time: [lower  estimate  upper]" lines.
+      # cargo-criterion prints "time: [lower  estimate  upper]" lines.
       # The script below fails the job if any single operation exceeds the
       # defined nanosecond threshold.  Adjust thresholds as the contracts evolve.
       - name: Check gas regression thresholds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,73 @@ cargo semver-checks -p soroban-escrow-template
 - Confirm that Protocol 22 fee schedule values are still correct and update any
   stale network fee assumptions.
 
+## Upgrading soroban-sdk
+
+The SDK version is pinned with an exact constraint (`=21.7.7`) in
+`[workspace.dependencies]` in the root `Cargo.toml` to guarantee reproducible
+builds across all developers and CI.
+
+### Finding the latest stable release
+
+```bash
+cargo search soroban-sdk | head -5
+# or browse https://crates.io/crates/soroban-sdk/versions
+```
+
+Check the [Stellar Protocol changelog](https://github.com/stellar/stellar-protocol)
+for protocol-breaking changes before upgrading across major versions.
+
+### Upgrade steps
+
+1. **Update the version pin** in `Cargo.toml`:
+
+   ```toml
+   [workspace.dependencies]
+   soroban-sdk = "=<NEW_VERSION>"
+   soroban-sdk-testutils = { version = "=<NEW_VERSION>", package = "soroban-sdk", features = ["testutils"] }
+   ```
+
+2. **Regenerate the lockfile**:
+
+   ```bash
+   cargo update -p soroban-sdk
+   ```
+
+3. **Check for breaking changes** — compile the workspace first:
+
+   ```bash
+   cargo check --workspace --all-targets
+   ```
+
+   Common breaking-change patterns to watch for:
+   - Renamed or removed items in `soroban_sdk::{Address, Env, Symbol, …}`
+   - Changed `#[contracttype]` / `#[contractimpl]` macro signatures
+   - New required trait impls for `Val` / `TryFromVal`
+   - Altered `token::Client` method signatures
+
+4. **Run the full test suite**, including feature-flagged variants:
+
+   ```bash
+   cargo test --workspace
+   cargo test -p soroban-escrow-template --features pausable,upgradeable
+   cargo test -p soroban-token-template --features pausable,capped-supply
+   ```
+
+5. **Run benchmarks** to catch performance regressions:
+
+   ```bash
+   cargo criterion --package contract-benchmarks
+   ```
+
+6. **Update docs** — edit `docs/gas-costs.md` to reflect the new protocol
+   version and re-verify fee schedule values.
+
+7. **Update this file** — change the version reference in the Prerequisites
+   table and this section to match the new pinned version.
+
+8. Open a PR with **only** the SDK bump and its fixes — do not mix unrelated
+   changes so reviewers can easily evaluate the upgrade diff.
+
 # Contributing to Soroban Starter Kit
 
 Thanks for taking the time to contribute. This guide covers everything you need to get set up, write good code, and get your changes merged.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,26 @@
 [workspace]
 members = [
+  "benches",
   "contracts/common",
   "contracts/token",
   "contracts/escrow",
   "contracts/vesting",
   "contracts/staking",
   "contracts/multisig",
+  "contracts/subscription",
   "contracts/timelock",
   "contracts/nft",
   "contracts/dao",
   "contracts/swap",
   "contracts/crowdfund",
   "contracts/auction",
+  "contracts/marketplace",
+  "contracts/airdrop",
+  "contracts/oracle",
+  "contracts/lottery",
   "tests",
   "fuzz",
 ]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/subscription", "contracts/timelock", "contracts/nft", "contracts/dao", "contracts/swap", "contracts/marketplace", "contracts/airdrop", "tests", "fuzz"]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/subscription", "contracts/timelock", "contracts/nft", "contracts/dao", "contracts/swap", "tests", "fuzz"]
-members = ["contracts/common", "contracts/token", "contracts/escrow", "contracts/vesting", "contracts/staking", "contracts/multisig", "contracts/subscription", "contracts/timelock", "contracts/nft", "contracts/dao", "contracts/swap", "contracts/oracle", "contracts/lottery", "tests", "fuzz"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -28,6 +31,7 @@ proc-macro2 = "=1.0.106"
 quote = "=1.0.45"
 soroban-sdk-testutils = { version = "=21.7.7", package = "soroban-sdk", features = ["testutils"] }
 proptest = "=1.6.0"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [profile.release]
 opt-level = "z"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "contract-benchmarks"
+version = "0.1.0"
+edition = "2021"
+authors.workspace = true
+license.workspace = true
+publish = false
+
+[[bench]]
+name = "escrow_ops"
+harness = false
+
+[[bench]]
+name = "token_ops"
+harness = false
+
+[dev-dependencies]
+criterion = { workspace = true }
+soroban-sdk = { workspace = true, features = ["testutils"] }
+soroban-escrow-template = { path = "../contracts/escrow" }
+soroban-token-template = { path = "../contracts/token" }
+
+[lints]
+workspace = true

--- a/contracts/escrow/src/lifecycle.rs
+++ b/contracts/escrow/src/lifecycle.rs
@@ -1,12 +1,10 @@
-use soroban_sdk::{token, Address, Env, Symbol};
+use soroban_sdk::{token, Address, Env, Symbol, Vec};
 
 use crate::admin;
 use crate::errors::EscrowError;
 use crate::events;
-use crate::storage::{DataKey, EscrowState};
-use soroban_common::{extend_ttl_instance, validate_deadline, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD, MIN_DEADLINE_BUFFER};
 use crate::storage::{require_state, DataKey, EscrowState};
-use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD, MIN_DEADLINE_BUFFER};
+use soroban_common::{extend_ttl_instance, validate_deadline, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
 use DataKey::*;
 
@@ -18,6 +16,57 @@ pub fn get_required<T: soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Va
         .instance()
         .get(key)
         .ok_or(EscrowError::NotInitialized)
+}
+
+fn validate_amount(amount: i128) -> Result<(), EscrowError> {
+    if amount <= 0 {
+        return Err(EscrowError::InvalidAmount);
+    }
+    Ok(())
+}
+
+fn validate_parties(buyer: &Address, seller: &Address, arbiter: &Address) -> Result<(), EscrowError> {
+    if buyer == seller || buyer == arbiter || seller == arbiter {
+        return Err(EscrowError::InvalidParties);
+    }
+    Ok(())
+}
+
+fn validate_parties_multi(buyer: &Address, seller: &Address, arbiters: &Vec<Address>, required_signatures: u32) -> Result<(), EscrowError> {
+    if arbiters.is_empty() || required_signatures == 0 || required_signatures > arbiters.len() as u32 {
+        return Err(EscrowError::InvalidParties);
+    }
+    for arbiter in arbiters.iter() {
+        if &arbiter == buyer || &arbiter == seller {
+            return Err(EscrowError::InvalidParties);
+        }
+    }
+    Ok(())
+}
+
+fn store_escrow_data(
+    env: &Env,
+    buyer: &Address,
+    seller: &Address,
+    arbiter: &Address,
+    token_contract: &Address,
+    amount: i128,
+    deadline_ledger: u32,
+    required_signatures: u32,
+) {
+    env.storage().instance().set(&Buyer, buyer);
+    env.storage().instance().set(&Seller, seller);
+    env.storage().instance().set(&Arbiter, arbiter);
+    env.storage().instance().set(&TokenContract, token_contract);
+    env.storage().instance().set(&Amount, &amount);
+    env.storage().instance().set(&Deadline, &deadline_ledger);
+    env.storage().instance().set(&State, &EscrowState::Created);
+    env.storage().instance().set(&RequiredSignatures, &required_signatures);
+}
+
+fn emit_init_events(env: &Env, buyer: &Address, seller: &Address, arbiter: &Address, amount: i128) {
+    events::escrow_created(env, buyer, seller, amount);
+    events::initialized(env, buyer, seller, arbiter, amount);
 }
 
 pub fn initialize(
@@ -32,31 +81,13 @@ pub fn initialize(
     if env.storage().instance().has(&State) {
         return Err(EscrowError::AlreadyInitialized);
     }
-    if amount <= 0 {
-        return Err(EscrowError::InvalidAmount);
-    }
-    if buyer == seller || buyer == arbiter || seller == arbiter {
-        return Err(EscrowError::InvalidParties);
-    }
+    validate_amount(amount)?;
+    validate_parties(&buyer, &seller, &arbiter)?;
     validate_deadline(&env, deadline_ledger).map_err(|_| EscrowError::DeadlinePassed)?;
-
-    let token_client = token::Client::new(&env, &token_contract);
-    token_client.decimals();
-
-    env.storage().instance().set(&Buyer, &buyer);
-    env.storage().instance().set(&Seller, &seller);
-    env.storage().instance().set(&Arbiter, &arbiter);
-    env.storage().instance().set(&TokenContract, &token_contract);
-    env.storage().instance().set(&Amount, &amount);
-    env.storage().instance().set(&Deadline, &deadline_ledger);
-    env.storage().instance().set(&State, &EscrowState::Created);
-    env.storage().instance().set(&RequiredSignatures, &1u32);
-
+    token::Client::new(&env, &token_contract).decimals();
+    store_escrow_data(&env, &buyer, &seller, &arbiter, &token_contract, amount, deadline_ledger, 1u32);
     extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
-
-    events::escrow_created(&env, &buyer, &seller, amount);
-    events::initialized(&env, &buyer, &seller, &arbiter, amount);
-
+    emit_init_events(&env, &buyer, &seller, &arbiter, amount);
     Ok(())
 }
 
@@ -73,37 +104,15 @@ pub fn initialize_with_arbiters(
     if env.storage().instance().has(&State) {
         return Err(EscrowError::AlreadyInitialized);
     }
-    if amount <= 0 {
-        return Err(EscrowError::InvalidAmount);
-    }
-    if arbiters.is_empty() || required_signatures == 0 || required_signatures > arbiters.len() as u32 {
-        return Err(EscrowError::InvalidParties);
-    }
-    for arbiter in arbiters.iter() {
-        if arbiter == buyer || arbiter == seller {
-            return Err(EscrowError::InvalidParties);
-        }
-    }
+    validate_amount(amount)?;
+    validate_parties_multi(&buyer, &seller, &arbiters, required_signatures)?;
     validate_deadline(&env, deadline_ledger).map_err(|_| EscrowError::DeadlinePassed)?;
-
-    let token_client = token::Client::new(&env, &token_contract);
-    token_client.decimals();
-
-    env.storage().instance().set(&Buyer, &buyer);
-    env.storage().instance().set(&Seller, &seller);
+    token::Client::new(&env, &token_contract).decimals();
+    let primary_arbiter = arbiters.get(0).unwrap();
+    store_escrow_data(&env, &buyer, &seller, &primary_arbiter, &token_contract, amount, deadline_ledger, required_signatures);
     env.storage().instance().set(&Arbiters, &arbiters);
-    env.storage().instance().set(&Arbiter, &arbiters.get(0).unwrap());
-    env.storage().instance().set(&RequiredSignatures, &required_signatures);
-    env.storage().instance().set(&TokenContract, &token_contract);
-    env.storage().instance().set(&Amount, &amount);
-    env.storage().instance().set(&Deadline, &deadline_ledger);
-    env.storage().instance().set(&State, &EscrowState::Created);
-
     extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
-
-    events::escrow_created(&env, &buyer, &seller, amount);
-    events::initialized(&env, &buyer, &seller, &arbiters.get(0).unwrap(), amount);
-
+    emit_init_events(&env, &buyer, &seller, &primary_arbiter, amount);
     Ok(())
 }
 

--- a/docker/Dockerfile.contracts
+++ b/docker/Dockerfile.contracts
@@ -2,7 +2,7 @@
 FROM rust:1.78-slim AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config libssl-dev \
+    pkg-config libssl-dev binaryen \
     && rm -rf /var/lib/apt/lists/*
 
 RUN cargo install --locked stellar-cli --features opt
@@ -12,6 +12,17 @@ COPY soroban-starter-kit/ .
 
 RUN for dir in contracts/*/; do \
       [ -f "$dir/Cargo.toml" ] && stellar contract build --manifest-path "$dir/Cargo.toml"; \
+    done
+
+# Run wasm-opt -Oz on every compiled WASM to reduce binary size by 10–30%.
+# Prints before/after sizes for each file.
+RUN echo "=== wasm-opt size reduction ===" && \
+    find target/wasm32-unknown-unknown/release -maxdepth 1 -name "*.wasm" | sort | while read wasm; do \
+      before=$(stat -c%s "$wasm"); \
+      wasm-opt -Oz --output "${wasm}.opt" "$wasm" && mv "${wasm}.opt" "$wasm"; \
+      after=$(stat -c%s "$wasm"); \
+      pct=$(( (before - after) * 100 / before )); \
+      echo "  $(basename $wasm): ${before}B → ${after}B (-${pct}%)"; \
     done
 
 # Stage 2: runtime — only .wasm artifacts

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -415,8 +415,85 @@ node scripts/generate-guides.mjs
 - Build contracts with `--release` flag (default in `deploy.sh`)
 - Minimize contract storage reads — cache values in `Env::storage().instance()`
 - Use `TTL` extensions for long-lived contract data to avoid expiry
-- Profile WASM size: `wasm-opt -Oz input.wasm -o output.wasm`
 - Frontend: set `Cache-Control: max-age=31536000` for hashed static assets
+
+### WASM Binary Size Optimisation with wasm-opt
+
+The build pipeline already sets `opt-level = "z"` and `lto = true` in the
+release profile. Running `wasm-opt -Oz` (from [Binaryen](https://github.com/WebAssembly/binaryen))
+as a post-build step typically reduces WASM size by an additional **10–30%**,
+lowering upload fees and ledger footprint.
+
+#### Install Binaryen
+
+```bash
+# macOS
+brew install binaryen
+
+# Ubuntu / Debian
+apt-get install binaryen
+
+# From source / pre-built release
+# https://github.com/WebAssembly/binaryen/releases
+```
+
+Verify the install:
+
+```bash
+wasm-opt --version
+```
+
+#### Run manually
+
+```bash
+# Optimise a single WASM file in-place
+wasm-opt -Oz --output optimized.wasm input.wasm
+
+# Check size reduction
+ls -lh input.wasm optimized.wasm
+```
+
+#### Automated via deploy.sh
+
+`scripts/deploy.sh` automatically runs `wasm-opt -Oz` on each compiled WASM
+after building, if `wasm-opt` is present on `$PATH`. It prints before/after
+sizes for every file:
+
+```
+── Building escrow ──
+  wasm-opt: 84320B → 61440B (-27%)
+── Deploying escrow to testnet ──
+```
+
+If `wasm-opt` is not installed, the script skips optimisation with an `INFO`
+message — the build still succeeds.
+
+#### Automated via Docker
+
+`docker/Dockerfile.contracts` installs `binaryen` in the build stage and runs
+`wasm-opt -Oz` on every WASM artifact before copying them to the runtime stage.
+Size comparisons are printed during the Docker build:
+
+```
+=== wasm-opt size reduction ===
+  soroban_escrow_template.wasm: 84320B → 61440B (-27%)
+  soroban_token_template.wasm:  72800B → 54200B (-25%)
+```
+
+#### CI size comparison
+
+To track WASM sizes across PRs, add a step to your CI workflow:
+
+```yaml
+- name: Report WASM sizes
+  run: |
+    echo "| Contract | Size |" >> $GITHUB_STEP_SUMMARY
+    echo "|----------|------|" >> $GITHUB_STEP_SUMMARY
+    find target/wasm32-unknown-unknown/release -maxdepth 1 -name "*.wasm" | sort | \
+      while read f; do
+        echo "| $(basename $f) | $(stat -c%s $f)B |" >> $GITHUB_STEP_SUMMARY
+      done
+```
 
 ---
 

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -172,6 +172,58 @@ rustup target add wasm32-unknown-unknown
 
 ---
 
+## Benchmarks with cargo-criterion
+
+The project uses [cargo-criterion](https://github.com/bheisler/cargo-criterion) for
+benchmarking. It wraps the standard `criterion` crate and adds:
+
+- **Machine-readable JSON output** for CI regression comparison
+- **HTML reports** with charts saved under `target/criterion/`
+- Cleaner CLI output with per-benchmark statistics
+
+### Installing cargo-criterion
+
+```bash
+cargo install cargo-criterion --locked
+```
+
+### Running benchmarks locally
+
+```bash
+# Run all benchmarks and generate HTML reports
+cargo criterion --package contract-benchmarks
+
+# Run a single benchmark group
+cargo criterion --package contract-benchmarks --bench escrow_ops
+
+# Open the HTML report in your browser (macOS)
+open target/criterion/report/index.html
+
+# Linux
+xdg-open target/criterion/report/index.html
+```
+
+### Comparing against a baseline
+
+```bash
+# Save a baseline before your change
+cargo criterion --package contract-benchmarks -- --save-baseline before
+
+# Make your change, then compare
+cargo criterion --package contract-benchmarks -- --baseline before
+```
+
+### CI integration
+
+The `.github/workflows/bench.yml` workflow:
+1. Runs `cargo criterion` on every push and PR
+2. Uploads HTML reports as a GitHub Actions artifact (`criterion-html-reports-<sha>`)
+3. Compares results against the stored `main` baseline and fails if any
+   benchmark regresses by more than 10%
+4. Posts a markdown regression table as a PR comment
+
+---
+
 ## Fuzz Testing
 
 Fuzz testing helps discover edge cases and potential vulnerabilities in contract code.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -15,6 +15,28 @@ check_prerequisites() {
 }
 check_prerequisites
 
+WASM_OPT_AVAILABLE=false
+if command -v wasm-opt &>/dev/null; then
+  WASM_OPT_AVAILABLE=true
+else
+  echo "INFO: wasm-opt not found — skipping WASM size optimisation." >&2
+  echo "      Install Binaryen (https://github.com/WebAssembly/binaryen) to enable." >&2
+fi
+
+optimize_wasm() {
+  local wasm="$1"
+  if [[ "$WASM_OPT_AVAILABLE" == "false" ]]; then
+    return
+  fi
+  local before
+  before=$(stat -c%s "$wasm" 2>/dev/null || stat -f%z "$wasm")
+  wasm-opt -Oz --output "${wasm}.opt" "$wasm" && mv "${wasm}.opt" "$wasm"
+  local after
+  after=$(stat -c%s "$wasm" 2>/dev/null || stat -f%z "$wasm")
+  local pct=$(( (before - after) * 100 / before ))
+  echo "  wasm-opt: ${before}B → ${after}B (-${pct}%)"
+}
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CONTRACTS_DIR="$ROOT/contracts"
 
@@ -78,6 +100,8 @@ deploy_contract() {
 
   WASM=$(find "$dir/target/wasm32-unknown-unknown/release" -name "*.wasm" | head -1)
   [[ -n "$WASM" ]] || { echo "No WASM found for $name"; return 1; }
+
+  optimize_wasm "$WASM"
 
   echo "── Deploying $name to $NETWORK ──"
   CONTRACT_ID=$(stellar contract deploy \


### PR DESCRIPTION
## Summary

   Addresses four independent issues in a single PR:

   - **#543 — Refactor `EscrowContract::initialize`**: Extracted `validate_amount`, `validate_parties`, `store_escrow_data`, and
   `emit_init_events` private helpers from `lifecycle::initialize`. The function body is now **10 lines** (down from ~38), comfortably
   under the 20-line target. Duplicate import lines in `lifecycle.rs` are also consolidated.

   - **#545 — soroban-sdk workspace hygiene + upgrade docs**: The root `Cargo.toml` had **four duplicate `members` declarations** (TOML
   does not support duplicate keys; the last value silently wins, hiding packages). Consolidated into a single authoritative list. Added
   a complete soroban-sdk upgrade guide to `CONTRIBUTING.md` covering version discovery, lockfile regeneration, breaking-change patterns,
   test commands, and PR best practices.

   - **#546 — cargo-criterion for benchmarking**: Added `benches/Cargo.toml` (the `contract-benchmarks` package was referenced in CI but
   had no manifest). Added `criterion` with `html_reports` to workspace dependencies. Updated `bench.yml` to install `cargo-criterion`
   and run `cargo criterion` instead of `cargo bench`, which produces machine-readable JSON and HTML reports. HTML reports are uploaded
   as a CI artifact (`criterion-html-reports-<sha>`). Documented local usage in `docs/dev-environment.md`.

   - **#548 — wasm-opt post-processing**: `docker/Dockerfile.contracts` now installs `binaryen` and runs `wasm-opt -Oz` on every compiled
   WASM before copying to the runtime stage, printing before/after sizes. `scripts/deploy.sh` gains an `optimize_wasm` helper that runs
   `wasm-opt -Oz` when available, with a graceful `INFO` fallback when Binaryen is not installed. Fully documented in
   `docs/deployment-guide.md` with manual, deploy.sh, Docker, and CI size-comparison patterns.

   ## Test plan

   - [ ] `cargo check --workspace --all-targets` passes
   - [ ] `cargo test -p soroban-escrow-template` passes (all initialize paths covered)
   - [ ] `cargo test -p soroban-escrow-template --features pausable,upgradeable` passes
   - [ ] `cargo criterion --package contract-benchmarks` runs and produces HTML under `target/criterion/`
   - [ ] `docker build -f docker/Dockerfile.contracts .` completes and prints wasm-opt size lines
   - [ ] `./scripts/deploy.sh local` skips wasm-opt gracefully when Binaryen is absent

   Closes #543
   Closes #545
   Closes #546
   Closes #548