### PR TITLE
Docs/add guides

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,63 @@
+name: Stale Issue/PR Management
+
+on:
+  schedule:
+    # Run at 2 AM UTC every day
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issue configuration
+          days-before-issue-stale: 45
+          days-before-issue-close: 60
+          stale-issue-label: 'stale'
+          close-issue-label: 'closed-stale'
+          stale-issue-message: |
+            This issue has been inactive for 45 days. It will be closed in 15 days if no activity occurs.
+            
+            To keep it open:
+            - Comment with a status update or new information
+            - Link a PR that addresses this issue
+            - React to show continued interest
+            
+            Exempt labels (will not be marked stale): `Stellar Wave`, `pinned`, `security`
+          close-issue-message: 'Closed due to inactivity. Feel free to reopen if you\'d like to continue discussion.'
+          
+          # PR configuration
+          days-before-pr-stale: 45
+          days-before-pr-close: 60
+          stale-pr-label: 'stale'
+          close-pr-label: 'closed-stale'
+          stale-pr-message: |
+            This PR has been inactive for 45 days. It will be closed in 15 days if no activity occurs.
+            
+            To keep it open:
+            - Push new commits with updates
+            - Request re-review if changes are complete
+            - Comment with a status update
+            
+            Exempt labels (will not be marked stale): `Stellar Wave`, `pinned`, `do-not-close`
+          close-pr-message: 'Closed due to inactivity. Feel free to reopen if you\'d like to continue work on this PR.'
+          
+          # Common configuration
+          exempt-issue-labels: 'Stellar Wave,pinned,security,work-in-progress'
+          exempt-pr-labels: 'Stellar Wave,pinned,do-not-close,work-in-progress'
+          
+          # Don't mark as stale if assigned
+          exempt-all-assignees: false
+          
+          # Remove stale label when activity resumes
+          remove-stale-when-updated: true
+          
+          # Automation
+          operations-per-run: 30
+          delete-branch: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,6 +346,39 @@ The format is `type(scope): subject`, where `type` is one of: `feat`, `fix`, `do
 
 ---
 
+## Branch Protection Rules
+
+The `main` branch is protected with the following rules:
+
+| Rule | Enforcement |
+|------|------------|
+| Require PR reviews | Minimum **1 approval** required before merge |
+| Require status checks | All GitHub Actions workflows must pass: `ci`, `lint-pr-title`, `bench`, `pr-labeler` |
+| Require branches up to date | Branch must be up-to-date with `main` before merge |
+| Restrict who can push | Only authorized maintainers can merge PRs |
+| Allow force pushes | Disabled — prevents accidental history rewriting |
+| Allow deletions | Disabled — protects branch from accidents |
+| Require code owner review | Enabled — CODEOWNERS file is enforced |
+
+### Status Checks Required for Merge
+
+All of the following must pass **before review begins**:
+
+1. **`ci`** — Runs `cargo test --workspace`, `cargo clippy`, `cargo fmt --check`, `cargo machete`, and WASM size verification
+2. **`lint-pr-title`** — Validates PR title follows Conventional Commits format
+3. **`bench`** — Gas/time benchmarks for escrow and token operations (informational)
+4. **`pr-labeler`** — Auto-applies labels based on file changes (informational)
+
+### What Contributors Must Know
+
+- **Never force-push** to `main` or any branch with a PR open
+- **Wait for 1 approval** from a maintainer before merging (maintainers merge, not authors)
+- **Keep your branch up to date** — GitHub will prevent merge if `main` has new commits
+- **Rebase or merge** to sync with main before requesting final review
+- **CI failures block review** — fix all failed checks first, then re-request review
+
+---
+
 ## PR Review Process
 
 1. A maintainer will be assigned to review within **3 business days** of opening.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup, 
 ## 📚 Resources
 
 - [System Architecture](docs/architecture.md) — High-level design, contract relationships, storage tiers, event model, and admin framework
+- [Contract API Reference](docs/contract-api.md) — Full public API for all contracts (parameters, return types, errors)
+- [Upgrade Guide](docs/upgrade-guide.md) — Step-by-step on-chain WASM upgrade with timelock and key rotation
 - [Security Best Practices](docs/security.md)
 - [Integration Guide](docs/integration-guide.md)
 - [Deployment Guide](docs/deployment-guide.md)

--- a/docs/contract-api.md
+++ b/docs/contract-api.md
@@ -1,0 +1,181 @@
+# Contract API Reference
+
+Complete public API documentation for all Soroban starter kit contracts.
+
+## Token Contract
+
+**Location:** `contracts/token/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, name: String, symbol: String, decimals: u32, max_supply: Option<i128>` | `Result<(), TokenError>` | `AlreadyInitialized`, `InvalidAmount` |
+| `mint` | `env: Env, to: Address, amount: i128` | `Result<(), TokenError>` | `Unauthorized`, `Overflow`, `InvalidAmount` |
+| `burn` | `env: Env, from: Address, amount: i128` | `Result<(), TokenError>` | `InsufficientBalance`, `Unauthorized`, `InvalidAmount` |
+| `transfer` | `env: Env, from: Address, to: Address, amount: i128` | `Result<(), TokenError>` | `InsufficientBalance`, `InvalidAmount` |
+| `transfer_from` | `env: Env, spender: Address, from: Address, to: Address, amount: i128` | `Result<(), TokenError>` | `InsufficientAllowance`, `InsufficientBalance`, `InvalidAmount` |
+| `approve` | `env: Env, from: Address, spender: Address, amount: i128, expiration_ledger: u32` | `Result<(), TokenError>` | `InvalidAmount` |
+| `allowance` | `env: Env, from: Address, spender: Address` | `i128` | None |
+| `balance` | `env: Env, id: Address` | `i128` | None |
+| `total_supply` | `env: Env` | `i128` | None |
+| `name` | `env: Env` | `String` | None |
+| `symbol` | `env: Env` | `String` | None |
+| `decimals` | `env: Env` | `u32` | None |
+
+**Errors:**
+- `InsufficientBalance` (1) — Caller's balance too low
+- `InsufficientAllowance` (2) — Allowance too low for transfer_from
+- `Unauthorized` (3) — Caller not admin
+- `AlreadyInitialized` (4) — initialize called twice
+- `NotInitialized` (5) — Operation before initialize
+- `InvalidAmount` (6) — Amount zero, negative, or exceeds cap
+- `Overflow` (7) — Arithmetic overflow
+
+---
+
+## Escrow Contract
+
+**Location:** `contracts/escrow/src/lib.rs`
+
+### Core Operations
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, buyer: Address, seller: Address, arbiter: Address, token_contract: Address, amount: i128, deadline_ledger: u32` | `Result<(), EscrowError>` | `AlreadyInitialized`, `InvalidAmount`, `InvalidParties` |
+| `initialize_with_arbiters` | `env: Env, buyer: Address, seller: Address, arbiters: Vec<Address>, token_contract: Address, amount: i128, deadline_ledger: u32, required_signatures: u32` | `Result<(), EscrowError>` | Same + validation |
+| `fund` | `env: Env` | `Result<(), EscrowError>` | `InvalidState`, `InsufficientFunds` |
+| `mark_delivered` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `approve_delivery` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `release_partial` | `env: Env, amount: i128` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState`, `InvalidAmount` |
+| `request_refund` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `raise_dispute` | `env: Env, caller: Address` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `resolve_dispute` | `env: Env, release_to_seller: bool` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `cancel` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `extend_deadline` | `env: Env, new_deadline: u32` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+
+### Query Functions
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `get_escrow_info` | `env: Env` | `Result<EscrowInfo, EscrowError>` | `NotInitialized` |
+| `get_state` | `env: Env` | `Option<EscrowState>` | None |
+| `is_deadline_passed` | `env: Env` | `bool` | None |
+| `get_remaining_ledgers` | `env: Env` | `i64` | None |
+
+**Errors:**
+- `NotAuthorized` (1) — Caller not permitted
+- `InvalidState` (2) — Escrow not in required state
+- `DeadlinePassed` (3) — Deadline already elapsed
+- `DeadlineNotReached` (4) — Deadline not yet passed
+- `AlreadyInitialized` (5) — initialize called twice
+- `NotInitialized` (6) — Operation before initialize
+- `InsufficientFunds` (7) — Buyer balance too low
+- `InvalidAmount` (8) — Amount zero or invalid
+- `InvalidParties` (9) — Invalid addresses or conflicts
+
+---
+
+## Staking Contract
+
+**Location:** `contracts/staking/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, stake_token: Address, reward_token: Address` | `Result<(), StakingError>` | `AlreadyInitialized` |
+| `stake` | `env: Env, staker: Address, amount: i128` | `Result<(), StakingError>` | `NotInitialized`, `InvalidAmount` |
+| `unstake` | `env: Env, staker: Address, amount: i128` | `Result<(), StakingError>` | `NotInitialized`, `InvalidAmount`, `InsufficientStake`, `NoStake` |
+| `add_rewards` | `env: Env, amount: i128` | `Result<(), StakingError>` | `Unauthorized`, `NotInitialized`, `InvalidAmount` |
+| `claim_rewards` | `env: Env, staker: Address` | `Result<(), StakingError>` | `NotInitialized`, `NoRewards` |
+| `total_staked` | `env: Env` | `i128` | None |
+| `total_rewards` | `env: Env` | `i128` | None |
+| `user_stake` | `env: Env, staker: Address` | `i128` | None |
+| `user_rewards` | `env: Env, staker: Address` | `i128` | None |
+
+**Errors:**
+- `AlreadyInitialized` (1) — initialize called twice
+- `NotInitialized` (2) — Operation before initialize
+- `Unauthorized` (3) — Caller not admin
+- `InvalidAmount` (4) — Amount zero or negative
+- `NoStake` (5) — No stake to unstake/claim
+- `InsufficientStake` (6) — Unstake amount exceeds stake
+- `NoRewards` (7) — No rewards available
+
+---
+
+## Vesting Contract
+
+**Location:** `contracts/vesting/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, beneficiary: Address, token: Address, amount: i128, cliff_ledger: u32, end_ledger: u32` | `Result<(), VestingError>` | `AlreadyInitialized`, `InvalidAmount`, `InvalidSchedule` |
+| `claim` | `env: Env` | `Result<(), VestingError>` | `NotInitialized`, `NothingToClaim` |
+| `revoke` | `env: Env` | `Result<(), VestingError>` | `NotInitialized`, `Unauthorized`, `AlreadyRevoked` |
+| `get_vested_amount` | `env: Env` | `i128` | None |
+| `get_claimed_amount` | `env: Env` | `i128` | None |
+| `get_unvested_amount` | `env: Env` | `i128` | None |
+| `is_revoked` | `env: Env` | `bool` | None |
+
+**Errors:**
+- `AlreadyInitialized` (1) — initialize called twice
+- `NotInitialized` (2) — Operation before initialize
+- `Unauthorized` (3) — Caller not admin
+- `InvalidAmount` (4) — Amount zero or negative
+- `InvalidSchedule` (5) — cliff_ledger >= end_ledger or end_ledger in past
+- `NothingToClaim` (6) — No tokens vested since last claim
+- `AlreadyRevoked` (7) — revoke called on revoked schedule
+
+---
+
+## Multisig Contract
+
+**Location:** `contracts/multisig/src/lib.rs`
+
+### Core Operations
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, signers: Vec<Address>, threshold: u32` | `Result<(), MultisigError>` | `AlreadyInitialized`, `InvalidThreshold`, `InvalidSigners` |
+| `add_signer` | `env: Env, approvals: Vec<Address>, signer: Address, new_threshold: u32` | `Result<(), MultisigError>` | `NotInitialized`, `NotSigner`, `InsufficientApprovals`, `InvalidThreshold` |
+| `remove_signer` | `env: Env, approvals: Vec<Address>, signer: Address, new_threshold: u32` | `Result<(), MultisigError>` | `NotInitialized`, `NotSigner`, `InsufficientApprovals`, `InvalidThreshold` |
+| `propose` | `env: Env, target: Address, func: Symbol, args: Vec<Val>` | `Result<u64, MultisigError>` | `NotInitialized` |
+| `approve` | `env: Env, tx_id: u64` | `Result<(), MultisigError>` | `TransactionNotFound`, `AlreadyExecuted`, `AlreadySigned`, `NotSigner` |
+| `execute` | `env: Env, tx_id: u64` | `Result<Val, MultisigError>` | `TransactionNotFound`, `AlreadyExecuted`, `ThresholdNotMet` |
+| `get_signers` | `env: Env` | `Vec<Address>` | None |
+| `get_threshold` | `env: Env` | `u32` | None |
+
+**Errors:**
+- `AlreadyInitialized` (1) — initialize called twice
+- `NotInitialized` (2) — Operation before initialize
+- `InvalidThreshold` (3) — Threshold zero or > signer count
+- `InvalidSigners` (4) — Signers empty, duplicate, or invalid
+- `NotSigner` (5) — Caller/approver not in signer set
+- `TransactionNotFound` (6) — TX ID does not exist
+- `AlreadyExecuted` (7) — Transaction already executed
+- `AlreadySigned` (8) — Signer already approved
+- `ThresholdNotMet` (9) — Not enough signatures
+- `InsufficientApprovals` (10) — Signer change lacks threshold approvals
+
+---
+
+## Cross-Contract Patterns
+
+### Token Interface
+All contracts that transfer tokens implement the standard Soroban token interface:
+- `transfer(from, to, amount)`
+- `transfer_from(spender, from, to, amount)`
+- `approve(from, spender, amount, expiration_ledger)`
+- `balance(id)`
+- `allowance(from, spender)`
+
+### Admin Pattern
+Contracts with admin controls require:
+1. Admin address set at initialization
+2. `require_auth()` on admin operations
+3. TTL bumping on state changes
+
+### Error Handling
+All contracts follow consistent error patterns:
+- `AlreadyInitialized` / `NotInitialized` gate operations
+- `Unauthorized` for permission failures
+- `InvalidAmount` for validation failures
+- Specific errors for state machine violations

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -1,0 +1,300 @@
+# Contract Upgrade Guide
+
+Step-by-step guide for upgrading a contract WASM on-chain using timelock proposals and safe key rotation.
+
+## Overview
+
+On-chain upgrades follow a timelock-protected flow:
+1. **Propose** — Admin creates upgrade proposal with new WASM hash
+2. **Wait** — Timelock delay passes (governance approval period)
+3. **Execute** — Deploy new WASM, verify, and resume operations
+4. **Verify** — Confirm new code is live
+
+This ensures security by preventing instant unauthorized upgrades.
+
+## Prerequisites
+
+- Stellar CLI installed and configured
+- Admin key (controlled privately)
+- New key for signing (for key rotation)
+- Testnet or Mainnet RPC endpoint
+- Current contract ID
+
+## Step 1: Build New WASM
+
+Build the upgraded contract:
+
+```bash
+cd contracts/escrow
+stellar contract build
+
+# Output: target/wasm32-unknown-unknown/release/soroban_escrow_contract.wasm
+```
+
+Get the WASM hash:
+
+```bash
+stellar contract install \
+  --network testnet \
+  --source admin-key \
+  target/wasm32-unknown-unknown/release/soroban_escrow_contract.wasm
+
+# Returns: WASM hash (xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx)
+# Save this for the proposal step
+WASM_HASH="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+## Step 2: Propose Upgrade (with Timelock)
+
+**Important:** Only call this if your contract includes timelock pause functionality (escrow with `pausable` feature).
+
+Propose the upgrade to activate after timelock delay:
+
+```bash
+CONTRACT_ID="CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+ADMIN_KEY="admin-key"
+TIMELOCK_DELAY_LEDGERS=300  # ~1.5 hours on mainnet (every 5 seconds)
+
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $ADMIN_KEY \
+  -- propose_upgrade --wasm_hash $WASM_HASH
+```
+
+**Response:** Proposal created. Current ledger: `12345`. Execution available at: `12645`.
+
+Record the target ledger for step 3.
+
+```bash
+TARGET_LEDGER=12645
+```
+
+## Step 3: Wait for Timelock (Optional Key Rotation)
+
+Wait until the target ledger is reached. During this window, you can rotate keys for security:
+
+### Key Rotation (Optional but Recommended)
+
+1. **Generate new key:**
+
+```bash
+stellar keys generate new-admin-key
+# Securely back up the secret key
+```
+
+2. **Export current admin from contract:**
+
+```bash
+CURRENT_ADMIN=$(stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $ADMIN_KEY \
+  -- get_admin)
+```
+
+3. **Update admin in new code** (if contract includes admin management):
+
+Edit contract code to hardcode new admin, or use a contract upgrade that changes admin permissions.
+
+4. **Fund new key** (testnet):
+
+```bash
+stellar account create new-admin-key --starting-balance 10 --network testnet
+```
+
+## Step 4: Execute Upgrade
+
+Check current ledger:
+
+```bash
+CURRENT_LEDGER=$(stellar ledger info --network testnet | grep "^Sequence" | awk '{print $2}')
+echo "Current ledger: $CURRENT_LEDGER, Target: $TARGET_LEDGER"
+```
+
+If `CURRENT_LEDGER >= TARGET_LEDGER`, execute:
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $ADMIN_KEY \
+  -- execute_upgrade
+```
+
+**Response:** Upgrade executed. New WASM deployed.
+
+## Step 5: Verify New Code
+
+Verify the upgrade:
+
+```bash
+# 1. Check new WASM hash matches:
+stellar contract info \
+  --id $CONTRACT_ID \
+  --network testnet | grep "WASM Hash"
+
+# Should match $WASM_HASH from step 1
+
+# 2. Call a query function to confirm contract is live:
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $ADMIN_KEY \
+  -- get_version
+
+# Should return new version string
+```
+
+## Step 6: Resume Operations
+
+Resume normal contract operations:
+
+```bash
+# Unpause (if contract was paused during upgrade)
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $ADMIN_KEY \
+  -- unpause
+```
+
+## Rollback Procedure
+
+If the upgrade fails:
+
+### 1. Immediate Actions (Before Timelock Expires)
+
+Cancel the proposal (if supported):
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $ADMIN_KEY \
+  -- cancel_upgrade  # If this function exists
+```
+
+### 2. Restore Previous WASM
+
+Redeploy the previous WASM:
+
+```bash
+# 1. Install old WASM
+PREV_HASH=$(stellar contract install \
+  --network testnet \
+  --source $ADMIN_KEY \
+  path/to/previous/wasm)
+
+# 2. Create new upgrade proposal
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $ADMIN_KEY \
+  -- propose_upgrade --wasm_hash $PREV_HASH
+
+# 3. Wait and execute as in steps 3-4
+```
+
+### 3. Key Rotation for Revoked Keys
+
+If keys were compromised:
+
+```bash
+# 1. Rotate to emergency key (pre-positioned)
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $EMERGENCY_KEY \
+  -- rotate_admin --new_admin $EMERGENCY_KEY
+
+# 2. Disable all other keys in your key management system
+```
+
+## Testing Upgrades (Local)
+
+Test locally before mainnet deployment:
+
+```bash
+# 1. Deploy contract to local node
+docker compose up stellar-node
+stellar contract deploy \
+  --network local \
+  --source local-admin \
+  target/wasm32-unknown-unknown/release/soroban_escrow_contract.wasm
+
+# 2. Propose upgrade
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network local \
+  --source local-admin \
+  -- propose_upgrade --wasm_hash $WASM_HASH
+
+# 3. Mine blocks until timelock passed (locally, instant)
+stellar ledger bump --network local
+
+# 4. Execute and verify
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network local \
+  --source local-admin \
+  -- execute_upgrade
+
+# 5. Confirm new code
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network local \
+  -- get_version
+```
+
+## Safety Checklist
+
+Before executing any upgrade:
+
+- [ ] New WASM built and tested locally
+- [ ] WASM hash verified matches `stellar contract install` output
+- [ ] All state migrations planned (if storage format changed)
+- [ ] Timelock delay respected (no shortcuts)
+- [ ] Emergency key prepared and funded
+- [ ] Rollback procedure tested locally
+- [ ] Team notified of upgrade window
+- [ ] Monitoring and alerts configured for post-upgrade
+- [ ] Backup of previous WASM and state taken
+- [ ] Admin key access reviewed and restricted
+
+## Common Issues
+
+### "Timelock not reached"
+```
+Error: Proposal not yet executable
+Solution: Current ledger < target ledger. Wait for more blocks.
+```
+
+### "WASM hash mismatch"
+```
+Error: Installed WASM hash does not match proposal
+Solution: Re-run stellar contract install with exact same binary
+```
+
+### "Admin not authorized"
+```
+Error: Caller not admin
+Solution: Sign with correct admin key, check contract has correct admin set
+```
+
+## Mainnet Considerations
+
+For mainnet deployments:
+
+1. **Extend timelock delay:** Use `UPGRADE_DELAY_LEDGERS = 17_280` (1 day @ 5-second blocks)
+2. **Governance approval:** Require multisig consensus before proposing
+3. **Public announcement:** Notify users of upgrade schedule
+4. **Parallel testing:** Deploy to testnet first, run for 24+ hours
+5. **Monitoring:** Set up alerts for success/failure
+6. **Post-upgrade audit:** Have third party verify new code
+
+## References
+
+- [Soroban Contract Upgrades](https://soroban.stellar.org/docs/learn/upgrading-contracts)
+- [Stellar CLI Docs](https://stellar.org/docs)
+- [Timelock Contract Reference](./contract-api.md#timelock-contract)


### PR DESCRIPTION
## Summary

Resolves #663, #664, #665, #666.

### Changes

**#663 — Stale issue/PR bot** (`.github/workflows/stale.yml`)
- Warns after 45 days of inactivity, closes after 60 days
- Applies `stale` warning label before close
- Exempts `Stellar Wave`, `pinned`, `security` labels from staleness

**#664 — Branch protection rules** (`CONTRIBUTING.md`)
- New "Branch Protection Rules" section documents all enforced rules on `main`
- Lists all required status checks by name: `ci`, `lint-pr-title`, `bench`, `pr-labeler`
- Documents no-force-push, 1-approval requirement, and CODEOWNERS enforcement

**#665 — Contract API reference** (`docs/contract-api.md`)
- Full public API tables for Token, Escrow, Staking, Vesting, and Multisig contracts
- Includes parameter types, return types, and all error variant names with codes
- Linked from README Resources section

**#666 — Upgrade guide** (`docs/upgrade-guide.md`)
- Step-by-step CLI commands: build → propose → wait → execute → verify
- Covers key rotation before/during upgrade window
- Covers rollback procedure and local testing workflow
- Linked from README Resources section

## Testing

All changes are documentation and CI config — no Rust code modified.

Closes #663 
Closes #664 
Closes #665 
Closes #666 