### PR TITLE
Add error snapshots and vesting release proptests

### DIFF
--- a/contracts/escrow/snapshots/error_codes.snap
+++ b/contracts/escrow/snapshots/error_codes.snap
@@ -1,0 +1,9 @@
+EscrowError::NotAuthorized = 1
+EscrowError::InvalidState = 2
+EscrowError::DeadlinePassed = 3
+EscrowError::DeadlineNotReached = 4
+EscrowError::AlreadyInitialized = 5
+EscrowError::NotInitialized = 6
+EscrowError::InsufficientFunds = 7
+EscrowError::InvalidAmount = 8
+EscrowError::InvalidParties = 9

--- a/contracts/escrow/src/errors.rs
+++ b/contracts/escrow/src/errors.rs
@@ -50,3 +50,44 @@ impl core::fmt::Display for EscrowError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::EscrowError;
+    use std::format;
+    use std::string::String;
+
+    fn render_error_code_snapshot() -> String {
+        format!(
+            "\
+EscrowError::NotAuthorized = {}\n\
+EscrowError::InvalidState = {}\n\
+EscrowError::DeadlinePassed = {}\n\
+EscrowError::DeadlineNotReached = {}\n\
+EscrowError::AlreadyInitialized = {}\n\
+EscrowError::NotInitialized = {}\n\
+EscrowError::InsufficientFunds = {}\n\
+EscrowError::InvalidAmount = {}\n\
+EscrowError::InvalidParties = {}\n",
+            EscrowError::NotAuthorized as u32,
+            EscrowError::InvalidState as u32,
+            EscrowError::DeadlinePassed as u32,
+            EscrowError::DeadlineNotReached as u32,
+            EscrowError::AlreadyInitialized as u32,
+            EscrowError::NotInitialized as u32,
+            EscrowError::InsufficientFunds as u32,
+            EscrowError::InvalidAmount as u32,
+            EscrowError::InvalidParties as u32,
+        )
+    }
+
+    #[test]
+    fn escrow_error_codes_match_snapshot() {
+        assert_eq!(
+            render_error_code_snapshot(),
+            include_str!("../snapshots/error_codes.snap")
+        );
+    }
+}

--- a/contracts/token/snapshots/error_codes.snap
+++ b/contracts/token/snapshots/error_codes.snap
@@ -1,0 +1,7 @@
+TokenError::InsufficientBalance = 1
+TokenError::InsufficientAllowance = 2
+TokenError::Unauthorized = 3
+TokenError::AlreadyInitialized = 4
+TokenError::NotInitialized = 5
+TokenError::InvalidAmount = 6
+TokenError::Overflow = 7

--- a/contracts/token/src/allowance.rs
+++ b/contracts/token/src/allowance.rs
@@ -4,10 +4,25 @@
 //! and `burn_from` share a single code path, eliminating the duplication that
 //! previously existed across `token_interface.rs`.
 
-use soroban_sdk::{Env, panic_with_error};
+use soroban_sdk::{panic_with_error, Env};
 
 use crate::errors::TokenError;
 use crate::storage::{AllowanceDataKey, AllowanceValue, DataKey};
+
+/// Soroban ledgers are expected roughly every 5 seconds on public networks.
+/// Allowance expiration is ledger-exact, so no additional wall-clock grace is
+/// applied beyond the caller-provided `expiration_ledger` (~0 seconds).
+const ALLOWANCE_EXPIRY_GRACE_LEDGERS: u32 = 0;
+
+/// Sentinel for an allowance that is already expired or absent.
+///
+/// Ledger 0 is genesis-time and therefore represents no future duration
+/// (~0 seconds) for active approvals.
+const EXPIRED_ALLOWANCE_LEDGER: u32 = 0;
+
+pub(crate) fn allowance_is_active(current_ledger: u32, expiration_ledger: u32) -> bool {
+    current_ledger <= expiration_ledger.saturating_add(ALLOWANCE_EXPIRY_GRACE_LEDGERS)
+}
 
 /// Returns the active allowance (amount) for `(from, spender)`, or `0` if the
 /// allowance is absent or expired.
@@ -15,7 +30,7 @@ pub fn get_allowance(env: &Env, from: soroban_sdk::Address, spender: soroban_sdk
     let key = DataKey::Allowance(AllowanceDataKey { from, spender });
     let val: Option<AllowanceValue> = env.storage().temporary().get(&key);
     match val {
-        Some(v) if env.ledger().sequence() <= v.expiration_ledger => v.amount,
+        Some(v) if allowance_is_active(env.ledger().sequence(), v.expiration_ledger) => v.amount,
         _ => 0,
     }
 }
@@ -60,10 +75,10 @@ pub fn deduct_allowance(
     });
     let val: Option<AllowanceValue> = env.storage().temporary().get(&key);
     let (current, expiration_ledger) = match val {
-        Some(v) if env.ledger().sequence() <= v.expiration_ledger => {
+        Some(v) if allowance_is_active(env.ledger().sequence(), v.expiration_ledger) => {
             (v.amount, v.expiration_ledger)
         }
-        _ => (0, 0),
+        _ => (0, EXPIRED_ALLOWANCE_LEDGER),
     };
     if current < amount {
         panic_with_error!(env, TokenError::InsufficientAllowance);

--- a/contracts/token/src/errors.rs
+++ b/contracts/token/src/errors.rs
@@ -25,3 +25,40 @@ impl core::fmt::Display for TokenError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::TokenError;
+    use std::format;
+    use std::string::String;
+
+    fn render_error_code_snapshot() -> String {
+        format!(
+            "\
+TokenError::InsufficientBalance = {}\n\
+TokenError::InsufficientAllowance = {}\n\
+TokenError::Unauthorized = {}\n\
+TokenError::AlreadyInitialized = {}\n\
+TokenError::NotInitialized = {}\n\
+TokenError::InvalidAmount = {}\n\
+TokenError::Overflow = {}\n",
+            TokenError::InsufficientBalance as u32,
+            TokenError::InsufficientAllowance as u32,
+            TokenError::Unauthorized as u32,
+            TokenError::AlreadyInitialized as u32,
+            TokenError::NotInitialized as u32,
+            TokenError::InvalidAmount as u32,
+            TokenError::Overflow as u32,
+        )
+    }
+
+    #[test]
+    fn token_error_codes_match_snapshot() {
+        assert_eq!(
+            render_error_code_snapshot(),
+            include_str!("../snapshots/error_codes.snap")
+        );
+    }
+}

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -16,7 +16,7 @@ mod token_interface;
 mod test;
 
 use admin::require_admin;
-use allowance::get_allowance;
+use allowance::{allowance_is_active, get_allowance};
 use errors::TokenError;
 use soroban_common::{extend_ttl_instance, extend_ttl_persistent, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 use storage::{AllowanceDataKey, AllowanceValue, DataKey, MetadataKey};
@@ -309,7 +309,9 @@ impl TokenContract {
         let key = DataKey::Allowance(AllowanceDataKey { from, spender });
         let val: Option<AllowanceValue> = env.storage().temporary().get(&key);
         match val {
-            Some(v) if env.ledger().sequence() <= v.expiration_ledger => Some(v.expiration_ledger),
+            Some(v) if allowance_is_active(env.ledger().sequence(), v.expiration_ledger) => {
+                Some(v.expiration_ledger)
+            }
             _ => None,
         }
     }
@@ -371,6 +373,8 @@ impl TokenContract {
 #[cfg(feature = "upgradeable")]
 #[contractimpl]
 impl TokenContract {
+    /// Delay before an upgrade can execute: 17,280 ledgers, approximately
+    /// 24 hours at the expected 5-second Soroban ledger cadence.
     const UPGRADE_DELAY_LEDGERS: u32 = 17_280;
 
     pub fn propose_upgrade(env: Env, wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), TokenError> {

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -8,6 +8,8 @@ mod storage;
 
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod prop_test;
 
 pub use errors::VestingError;
 pub use storage::{DataKey, VestingInfo};
@@ -19,7 +21,7 @@ fn bump(env: &Env) {
 }
 
 /// Returns the number of tokens vested as of `ledger`, ignoring already-claimed tokens.
-fn vested_amount(amount: i128, cliff_ledger: u32, end_ledger: u32, ledger: u32) -> i128 {
+pub(crate) fn vested_amount(amount: i128, cliff_ledger: u32, end_ledger: u32, ledger: u32) -> i128 {
     if ledger < cliff_ledger {
         return 0;
     }

--- a/contracts/vesting/src/prop_test.rs
+++ b/contracts/vesting/src/prop_test.rs
@@ -3,8 +3,8 @@
 use proptest::prelude::*;
 use soroban_sdk::{testutils::Ledger as _, Env};
 
-use crate::{VestingContract, VestingContractClient};
 use super::{make_token, setup_env};
+use crate::{vested_amount, VestingContract, VestingContractClient};
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::Address;
 
@@ -21,6 +21,61 @@ fn prop_setup(env: &Env, amount: i128) -> (VestingContractClient, Address, Addre
 }
 
 proptest! {
+    #[test]
+    fn prop_vested_amount_matches_schedule_checkpoints(
+        amount in 1i128..=1_000_000_000i128,
+        cliff_offset in 1u32..=10_000u32,
+        duration in 1u32..=100_000u32,
+        checkpoint_pct in 0u32..=100u32,
+    ) {
+        let env = setup_env();
+        let start = env.ledger().sequence();
+        let cliff = start + cliff_offset;
+        let end = cliff + duration;
+        let checkpoint = cliff + duration * checkpoint_pct / 100;
+        let expected = if checkpoint < cliff {
+            0
+        } else if checkpoint >= end {
+            amount
+        } else {
+            amount * i128::from(checkpoint - cliff) / i128::from(duration)
+        };
+
+        prop_assert_eq!(vested_amount(amount, cliff, end, checkpoint), expected);
+    }
+
+    #[test]
+    fn prop_vesting_claimable_matches_exact_release_formula(
+        amount in 1i128..=1_000_000_000i128,
+        cliff_offset in 1u32..=10_000u32,
+        duration in 1u32..=100_000u32,
+        checkpoint_pct in 0u32..=100u32,
+    ) {
+        let env = setup_env();
+        let admin = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+        let token = make_token(&env, &admin, amount);
+        let cliff = env.ledger().sequence() + cliff_offset;
+        let end = cliff + duration;
+        let addr = env.register_contract(None, VestingContract);
+        let client = VestingContractClient::new(&env, &addr);
+        client.initialize(&admin, &beneficiary, &token, &cliff, &end, &amount);
+
+        let before_cliff = cliff - 1;
+        env.ledger().with_mut(|l| l.sequence_number = before_cliff);
+        prop_assert_eq!(client.claimable(), 0);
+
+        let partial_checkpoint = cliff + duration * checkpoint_pct / 100;
+        env.ledger().with_mut(|l| l.sequence_number = partial_checkpoint);
+        prop_assert_eq!(
+            client.claimable(),
+            vested_amount(amount, cliff, end, partial_checkpoint)
+        );
+
+        env.ledger().with_mut(|l| l.sequence_number = end);
+        prop_assert_eq!(client.claimable(), amount);
+    }
+
     #[test]
     fn prop_initialize_stores_amount(amount in 1i128..=1_000_000i128) {
         let env = setup_env();

--- a/docs/security.md
+++ b/docs/security.md
@@ -19,6 +19,25 @@ The contract supports multi-sig arbiters. In this scenario, a dispute can only b
 ### State Machine Bypass
 
 The contract's state machine is designed to prevent invalid state transitions. For example, a refund can only be requested when the contract is in the `Funded` or `Delivered` state. The state machine is enforced by the `require_state` function, which is called by all state-changing functions. There are no known ways to bypass the state machine.
+
+## Re-Entrancy Analysis
+
+Soroban contract execution is protected from EVM-style re-entrancy by the host execution model. A contract invocation runs in a single call stack managed by the Soroban host, and authorization is captured for the invocation tree rather than allowing an external contract to asynchronously re-enter the same in-flight frame. The relevant host behavior is documented in the Soroban host repository and Stellar developer docs for contract invocation, host functions, and authorization.
+
+The escrow contract still follows a conservative checks-effects-interactions shape for clarity. Lifecycle methods validate authorization and state first, write the new escrow state before or alongside token movement, and rely on explicit state transitions such as `Created`, `Funded`, `Delivered`, `Completed`, `Refunded`, `Cancelled`, and `Disputed` to reject repeated settlement paths.
+
+Escrow invariants that depend on this model:
+
+- Funds can only move out through a state-specific path after the current state has been checked.
+- Terminal states prevent a second release, refund, or cancellation from being accepted.
+- Partial release reduces the stored escrow amount before the remaining balance can be released later.
+- Dispute resolution requires the configured arbiter policy and then transitions back to a state that preserves the normal release/refund checks.
+
+References:
+
+- Soroban host repository: https://github.com/stellar/rs-soroban-env
+- Stellar Soroban authorization docs: https://developers.stellar.org/docs/build/smart-contracts/authorization
+- Stellar Soroban contract invocation docs: https://developers.stellar.org/docs/build/smart-contracts/example-contracts/cross-contract-calls
 ## Authorization
 
 | Contract | Function | Authorization |


### PR DESCRIPTION
## Summary
- Replaced token allowance expiry magic comparisons with named constants/helpers documented with approximate ledger-to-time behavior.
- Added snapshot-backed tests for `TokenError` and `EscrowError` numeric mappings, with one snapshot file per contract.
- Added vesting proptest coverage for randomized cliff, duration, amount, and checkpoint release calculations, including before-cliff, partial, and fully vested cases.
- Added `docs/security.md` re-entrancy analysis covering Soroban’s single-call-stack execution model and escrow invariants.

## Security Notes
- Documented why Soroban avoids EVM-style re-entrancy.
- Added references to:
  - https://github.com/stellar/rs-soroban-env
  - https://developers.stellar.org/docs/build/smart-contracts/authorization
  - https://developers.stellar.org/docs/build/smart-contracts/example-contracts/cross-contract-calls

## Verification
- `git diff --check` passed.
- `cargo test` / `cargo fmt` could not complete because the pinned Rust `1.82.0` toolchain requires unavailable target `wasm32v1-none`.
- Retrying with installed Rust `1.88` was blocked by an existing `Cargo.lock` parse error: duplicate `name` key at line 

closes #645 
closes #647 
closes #639 
closes #650