### PR TITLE
Add fuzz targets, escrow lifecycle test, and batch_mint cap coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,31 @@ jobs:
           path: lcov.info
           retention-days: 30
 
+  fuzz:
+    name: Fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [token_fuzz, escrow_initialize, token_mint_burn]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install nightly Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          toolchain: nightly
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Run fuzz target (10 000 iterations)
+        working-directory: fuzz
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -runs=10000 -max_total_time=120
+
   deny:
     name: License and Duplicate Check
     runs-on: ubuntu-latest

--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -583,6 +583,47 @@ mod capped_supply_tests {
         client.mint(&user, &large);
         assert_eq!(client.total_supply(), large);
     }
+
+    #[test]
+    fn test_batch_mint_exactly_at_cap_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+        let cap = 1_000i128;
+        let client = init_capped(&env, &admin, cap);
+
+        let recipients = soroban_sdk::vec![
+            &env,
+            (user1.clone(), 400i128),
+            (user2.clone(), 600i128),
+        ];
+        client.batch_mint(&recipients);
+
+        assert_eq!(client.balance(&user1), 400i128);
+        assert_eq!(client.balance(&user2), 600i128);
+        assert_eq!(client.total_supply(), cap);
+    }
+
+    #[test]
+    fn test_batch_mint_exceeds_cap_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
+        let cap = 1_000i128;
+        let client = init_capped(&env, &admin, cap);
+
+        let recipients = soroban_sdk::vec![
+            &env,
+            (user1.clone(), 600i128),
+            (user2.clone(), 500i128),
+        ];
+        assert!(client.try_batch_mint(&recipients).is_err());
+        assert_eq!(client.total_supply(), 0);
+    }
 }
 
 #[test]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -9,11 +9,24 @@ publish = false
 [dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 soroban-token-template = { path = "../contracts/token" }
+soroban-escrow-template = { path = "../contracts/escrow" }
 libfuzzer-sys = "0.4"
 
 [[bin]]
 name = "token_fuzz"
 path = "fuzz_targets/token_fuzz.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "escrow_initialize"
+path = "fuzz_targets/escrow_initialize.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "token_mint_burn"
+path = "fuzz_targets/token_mint_burn.rs"
 test = false
 doc = false
 

--- a/fuzz/fuzz_targets/escrow_initialize.rs
+++ b/fuzz/fuzz_targets/escrow_initialize.rs
@@ -1,0 +1,81 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_escrow_template::EscrowContract;
+use soroban_token_template::TokenContract;
+
+fn bytes_to_i128(data: &[u8], offset: usize) -> i128 {
+    i128::from_le_bytes([
+        data.get(offset).copied().unwrap_or(0),
+        data.get(offset + 1).copied().unwrap_or(0),
+        data.get(offset + 2).copied().unwrap_or(0),
+        data.get(offset + 3).copied().unwrap_or(0),
+        data.get(offset + 4).copied().unwrap_or(0),
+        data.get(offset + 5).copied().unwrap_or(0),
+        data.get(offset + 6).copied().unwrap_or(0),
+        data.get(offset + 7).copied().unwrap_or(0),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ])
+}
+
+fn bytes_to_u32(data: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes([
+        data.get(offset).copied().unwrap_or(0),
+        data.get(offset + 1).copied().unwrap_or(0),
+        data.get(offset + 2).copied().unwrap_or(0),
+        data.get(offset + 3).copied().unwrap_or(0),
+    ])
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 13 {
+        return;
+    }
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Valid token so initialize's decimals() probe never panics on a bad address.
+    let token_admin = Address::generate(&env);
+    let token_addr = env.register_contract(None, TokenContract);
+    let token_client = soroban_token_template::TokenContractClient::new(&env, &token_addr);
+    let _ = token_client.try_initialize(
+        &token_admin,
+        &String::from_str(&env, "Fuzz Token"),
+        &String::from_str(&env, "FZZ"),
+        &18u32,
+        &None,
+    );
+
+    let escrow_addr = env.register_contract(None, EscrowContract);
+    let escrow = soroban_escrow_template::EscrowContractClient::new(&env, &escrow_addr);
+
+    let pool = [
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+    ];
+    let buyer = pool[(data[0] as usize) % pool.len()].clone();
+    let seller = pool[(data[1] as usize) % pool.len()].clone();
+    let arbiter = pool[(data[2] as usize) % pool.len()].clone();
+
+    let amount = bytes_to_i128(data, 3);
+    let deadline = bytes_to_u32(data, 11);
+
+    let _ = escrow.try_initialize(
+        &buyer,
+        &seller,
+        &arbiter,
+        &token_addr,
+        &amount,
+        &deadline,
+    );
+});

--- a/fuzz/fuzz_targets/token_mint_burn.rs
+++ b/fuzz/fuzz_targets/token_mint_burn.rs
@@ -1,0 +1,56 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use soroban_token_template::TokenContract;
+
+fn bytes_to_i128(data: &[u8], offset: usize) -> i128 {
+    i128::from_le_bytes([
+        data.get(offset).copied().unwrap_or(0),
+        data.get(offset + 1).copied().unwrap_or(0),
+        data.get(offset + 2).copied().unwrap_or(0),
+        data.get(offset + 3).copied().unwrap_or(0),
+        data.get(offset + 4).copied().unwrap_or(0),
+        data.get(offset + 5).copied().unwrap_or(0),
+        data.get(offset + 6).copied().unwrap_or(0),
+        data.get(offset + 7).copied().unwrap_or(0),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ])
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() < 25 {
+        return;
+    }
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let recipient = Address::generate(&env);
+
+    let token_addr = env.register_contract(None, TokenContract);
+    let client = soroban_token_template::TokenContractClient::new(&env, &token_addr);
+    let _ = client.try_initialize(
+        &admin,
+        &String::from_str(&env, "Fuzz Token"),
+        &String::from_str(&env, "FZZ"),
+        &18u32,
+        &None,
+    );
+
+    let mint_amount = bytes_to_i128(data, 0);
+    let transfer_amount = bytes_to_i128(data, 8);
+    let burn_amount = bytes_to_i128(data, 16);
+
+    let _ = client.try_mint(&holder, &mint_amount);
+    let _ = client.try_transfer(&holder, &recipient, &transfer_amount);
+    let _ = client.try_burn(&recipient, &burn_amount);
+});

--- a/tests/src/escrow_lifecycle.rs
+++ b/tests/src/escrow_lifecycle.rs
@@ -1,0 +1,70 @@
+//! End-to-end escrow lifecycle with a real token contract deployed in the same Env.
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env, String,
+};
+
+use soroban_escrow_template::{EscrowContract, EscrowContractClient, EscrowState};
+use soroban_token_template::{TokenContract, TokenContractClient};
+
+fn deploy_token<'a>(env: &'a Env, admin: &Address) -> (TokenContractClient<'a>, Address) {
+    let addr = env.register_contract(None, TokenContract);
+    let client = TokenContractClient::new(env, &addr);
+    client.initialize(
+        admin,
+        &String::from_str(env, "Test Token"),
+        &String::from_str(env, "TEST"),
+        &18u32,
+        &None,
+    );
+    (client, addr)
+}
+
+fn deploy_escrow<'a>(env: &'a Env) -> (EscrowContractClient<'a>, Address) {
+    let addr = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(env, &addr);
+    (client, addr)
+}
+
+/// initialize → fund → mark_delivered → approve_delivery with real token balances.
+#[test]
+fn test_full_escrow_lifecycle_with_real_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let token_admin = Address::generate(&env);
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let amount = 2_500i128;
+    let deadline = env.ledger().sequence() + 200;
+
+    let (token, token_addr) = deploy_token(&env, &token_admin);
+
+    assert_eq!(token.balance(&buyer), 0);
+    assert_eq!(token.balance(&seller), 0);
+    assert_eq!(token.total_supply(), 0);
+
+    token.mint(&buyer, &amount);
+    assert_eq!(token.balance(&buyer), amount);
+    assert_eq!(token.total_supply(), amount);
+
+    let (escrow, escrow_addr) = deploy_escrow(&env);
+    escrow.initialize(&buyer, &seller, &arbiter, &token_addr, &amount, &deadline);
+
+    escrow.fund();
+    assert_eq!(token.balance(&buyer), 0);
+    assert_eq!(token.balance(&escrow_addr), amount);
+    assert_eq!(token.balance(&seller), 0);
+
+    escrow.mark_delivered();
+    assert_eq!(escrow.get_state(), Some(EscrowState::Delivered));
+
+    escrow.approve_delivery();
+    assert_eq!(escrow.get_state(), Some(EscrowState::Completed));
+    assert_eq!(token.balance(&escrow_addr), 0);
+    assert_eq!(token.balance(&seller), amount);
+    assert_eq!(token.balance(&buyer), 0);
+    assert_eq!(token.total_supply(), amount);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,2 +1,4 @@
 // Placeholder so the crate compiles as a library.
-// All integration tests live in tests/tests/integration.rs.
+// Integration test binaries live in tests/tests/; lifecycle coverage in src/.
+#[cfg(test)]
+mod escrow_lifecycle;


### PR DESCRIPTION
PR description:

Summary
Adds fuzz coverage for escrow initialization and token mint/transfer/burn sequences, an end-to-end escrow lifecycle integration test with a real token contract, and capped-supply batch_mint unit tests. Fuzz targets run in CI for 10,000 iterations each.

Changes
Task 1 — Escrow initialize input validation fuzz target
File: fuzz/fuzz_targets/escrow_initialize.rs
Feeds random byte input into EscrowContract::initialize via try_initialize
Party selection uses a 4-address pool indexed by fuzz bytes (covers duplicate-party InvalidParties paths)
Amount and deadline parsed from fuzz bytes as i128 / u32
A valid TokenContract is always registered so the decimals() probe does not panic on an invalid token address
Acceptance: target compiles; CI runs 10,000 iterations; failures only via Err, not panic
Task 2 — Token mint/burn sequence fuzz target
File: fuzz/fuzz_targets/token_mint_burn.rs
Exercises mint → transfer → burn with three independent i128 amounts from fuzz input
Uses try_mint, try_transfer, try_burn so overflow/underflow edge cases surface as errors, not panics
Acceptance: target at fuzz/fuzz_targets/token_mint_burn.rs; runs in CI
Task 3 — Full escrow lifecycle integration test
File: tests/src/escrow_lifecycle.rs
Deploys TokenContract and EscrowContract in the same Env
Mints tokens to buyer, then runs: initialize → fund → mark_delivered → approve_delivery
Asserts buyer, seller, and escrow token balances at each stage, plus total_supply at the end
Wired through tests/src/lib.rs as #[cfg(test)] mod escrow_lifecycle
Task 4 — batch_mint capped-supply tests
File: contracts/token/src/test.rs (capped_supply_tests module, capped-supply feature)
test_batch_mint_exactly_at_cap_succeeds: batch totaling exactly the cap (400 + 600 = 1000) succeeds; total_supply equals cap
test_batch_mint_exceeds_cap_fails: batch totaling above cap (600 + 500 = 1100) returns Err via try_batch_mint; supply stays 0

closes #641 
closes #642 
closes #643 
closes #649