### PR TITLE
Add scripts/reset-localnet.sh — one-command local network teardown and restart

### DIFF
--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -73,6 +73,17 @@ docker compose -f docker/docker-compose.yml up stellar-node
 ./scripts/local-net.sh logs     # tail logs
 ```
 
+### Full teardown and restart
+
+If the node gets stuck or you need a totally clean slate, use `scripts/reset-localnet.sh`. It stops, removes, and restarts the `stellar-node` container, then blocks until Docker reports the container healthy:
+
+```bash
+./scripts/reset-localnet.sh          # default 180s timeout
+./scripts/reset-localnet.sh 300      # custom timeout in seconds
+```
+
+The script exits 0 once the node is healthy and 1 if it times out.
+
 ### Waiting for readiness
 
 The node takes ~30 seconds to initialize. Use `scripts/wait-for-node.sh` to block until the Soroban RPC endpoint is accepting requests:

--- a/scripts/reset-localnet.sh
+++ b/scripts/reset-localnet.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# reset-localnet.sh — one-command local network teardown and restart
+# Stops, removes, and restarts the local Stellar/Soroban node container,
+# then waits for it to report healthy before returning.
+# Usage: ./scripts/reset-localnet.sh [max-wait-seconds]
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="docker compose -f $ROOT/docker/docker-compose.yml"
+SERVICE="stellar-node"
+MAX_WAIT="${1:-180}"
+INTERVAL=3
+
+echo "Stopping local Stellar node..."
+$COMPOSE stop "$SERVICE"
+
+echo "Removing local Stellar node container (chain data will be lost)..."
+$COMPOSE rm -f "$SERVICE"
+
+echo "Starting local Stellar node..."
+$COMPOSE up -d "$SERVICE"
+
+CONTAINER_ID="$($COMPOSE ps -q "$SERVICE")"
+if [[ -z "$CONTAINER_ID" ]]; then
+  echo "ERROR: could not find container for service '$SERVICE'" >&2
+  exit 1
+fi
+
+echo "Waiting for node health check (timeout: ${MAX_WAIT}s) ..."
+elapsed=0
+while true; do
+  status="$(docker inspect --format='{{.State.Health.Status}}' "$CONTAINER_ID" 2>/dev/null || echo "unknown")"
+  if [[ "$status" == "healthy" ]]; then
+    echo "Local node ready (${elapsed}s)."
+    echo "  RPC:     http://localhost:${LOCAL_RPC_PORT:-8000}"
+    echo "  Horizon: http://localhost:${LOCAL_HORIZON_PORT:-8001}"
+    exit 0
+  fi
+  if (( elapsed >= MAX_WAIT )); then
+    echo "ERROR: node did not become healthy within ${MAX_WAIT}s (last status: ${status})" >&2
+    echo "  - Inspect logs: ./scripts/local-net.sh logs" >&2
+    exit 1
+  fi
+  echo "  Not healthy yet (${elapsed}s elapsed, status: ${status}), retrying in ${INTERVAL}s ..."
+  sleep "$INTERVAL"
+  elapsed=$(( elapsed + INTERVAL ))
+done


### PR DESCRIPTION
## Summary
- Add `scripts/reset-localnet.sh`, which stops, removes, and restarts the `stellar-node` Docker container and blocks until Docker's health check reports `healthy`
- Document the new script in `docs/dev-environment.md`

## Test plan
- [x] `chmod +x scripts/reset-localnet.sh` confirmed executable
- [x] Script waits on `docker inspect --format='{{.State.Health.Status}}'` until healthy or timeout
- [x] Usage documented in docs/dev-environment.md

Closes #678