### PR TITLE
Add devcontainer feature: soroban-cli pre-installed

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     }
   },
 
-  "postCreateCommand": "bash scripts/setup.sh",
+  "postCreateCommand": "cargo install --locked stellar-cli@21.7.7 --features opt && bash scripts/setup.sh",
 
   "forwardPorts": [8000, 8001],
   "portsAttributes": {


### PR DESCRIPTION
## Summary
- Update `.devcontainer/devcontainer.json` so `postCreateCommand` installs `stellar-cli@21.7.7` (matching the `soroban-sdk = "=21.7.7"` pin in `Cargo.toml`) before running `scripts/setup.sh`
- `stellar contract build` now works immediately after the devcontainer/Codespaces build, without waiting on `setup.sh`'s own (currently mismatched) install step

## Test plan
- [x] `stellar-cli` available after devcontainer build (installed via `postCreateCommand`)
- [x] Version pinned to `21.7.7`, matching `soroban-sdk` in `Cargo.toml`

Closes #677