### PR TITLE
refactor: separate multisig phases, consolidate token impls, centralize escrow events, add LEDGER_SECONDS constant

### DIFF
--- a/contracts/common/src/lib.rs
+++ b/contracts/common/src/lib.rs
@@ -159,11 +159,15 @@ where
         .extend_ttl(key, threshold, extend_to);
 }
 
-/// Ledger threshold for TTL extension (~14 days at 5 seconds per ledger).
+/// Expected wall-clock seconds between consecutive Soroban ledgers.
+/// Used to convert ledger counts to approximate durations in doc comments.
+pub const LEDGER_SECONDS: u32 = 5;
+
+/// Ledger threshold for TTL extension (~14 days at `LEDGER_SECONDS` seconds per ledger).
 /// When remaining TTL falls below this, storage is extended to `LEDGER_BUMP_AMOUNT`.
 pub const LEDGER_LIFETIME_THRESHOLD: u32 = 120_960;
 
-/// Target TTL (in ledgers) after each extension (~60 days at 5 seconds per ledger).
+/// Target TTL (in ledgers) after each extension (~60 days at `LEDGER_SECONDS` seconds per ledger).
 pub const LEDGER_BUMP_AMOUNT: u32 = 518_400;
 
 /// Validates that a deadline is sufficiently far in the future.

--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -1,6 +1,7 @@
-use soroban_sdk::{Address, Env, Symbol};
+use soroban_sdk::{Address, Env};
 
 use crate::errors::EscrowError;
+use crate::events;
 use crate::lifecycle::{get_required, refund_to_buyer, release_to_seller};
 use crate::storage::{DataKey, EscrowState};
 use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
@@ -27,8 +28,7 @@ pub fn raise_dispute(env: Env, caller: Address) -> Result<(), EscrowError> {
     env.storage().instance().set(&State, &EscrowState::Disputed);
     extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
-    env.events()
-        .publish((Symbol::new(&env, "dispute_raised"), caller), ());
+    events::dispute_raised(&env, &caller);
 
     Ok(())
 }

--- a/contracts/escrow/src/events.rs
+++ b/contracts/escrow/src/events.rs
@@ -43,6 +43,30 @@ pub fn funds_refunded(env: &Env, buyer: &Address, amount: i128) {
     env.events().publish((Symbol::new(env, "refunded"), buyer.clone()), amount);
 }
 
+/// Emitted when the escrow amount is updated.
+/// Topics: (Symbol, Address) — event name, buyer
+pub fn amount_updated(env: &Env, buyer: &Address, new_amount: i128) {
+    env.events().publish((Symbol::new(env, "amount_updated"), buyer.clone()), new_amount);
+}
+
+/// Emitted when the escrow is cancelled.
+/// Topics: (Symbol, Address) — event name, buyer
+pub fn escrow_cancelled(env: &Env, buyer: &Address) {
+    env.events().publish((Symbol::new(env, "escrow_cancelled"), buyer.clone()), ());
+}
+
+/// Emitted when the deadline is extended.
+/// Topics: (Symbol, Address) — event name, buyer
+pub fn deadline_extended(env: &Env, buyer: &Address, new_deadline: u32) {
+    env.events().publish((Symbol::new(env, "deadline_extended"), buyer.clone()), new_deadline);
+}
+
+/// Emitted when a dispute is raised.
+/// Topics: (Symbol, Address) — event name, caller
+pub fn dispute_raised(env: &Env, caller: &Address) {
+    env.events().publish((Symbol::new(env, "dispute_raised"), caller.clone()), ());
+}
+
 /// Emitted when the contract is paused.
 /// Topics: (Symbol, Address) — event name, admin
 pub fn paused(env: &Env, admin: &Address) {

--- a/contracts/escrow/src/lifecycle.rs
+++ b/contracts/escrow/src/lifecycle.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{token, Address, Env, Symbol, Vec};
+use soroban_sdk::{token, Address, Env, Vec};
 
 use crate::admin;
 use crate::errors::EscrowError;
@@ -140,8 +140,7 @@ pub fn update_amount(env: Env, new_amount: i128) -> Result<(), EscrowError> {
     env.storage().instance().set(&Amount, &new_amount);
     extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
-    env.events()
-        .publish((Symbol::new(&env, "amount_updated"), buyer), new_amount);
+    events::amount_updated(&env, &buyer, new_amount);
 
     Ok(())
 }
@@ -170,8 +169,7 @@ pub fn fund(env: Env) -> Result<(), EscrowError> {
     env.storage().instance().set(&State, &EscrowState::Funded);
     extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
-    env.events()
-        .publish((Symbol::new(&env, "funded"), buyer), amount);
+    events::escrow_funded(&env, &buyer, amount);
 
     Ok(())
 }
@@ -191,8 +189,7 @@ pub fn mark_delivered(env: Env) -> Result<(), EscrowError> {
     env.storage().instance().set(&State, &EscrowState::Delivered);
     extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
-    env.events()
-        .publish((Symbol::new(&env, "marked_delivered"), seller), ());
+    events::delivery_marked(&env, &seller);
 
     Ok(())
 }
@@ -278,8 +275,7 @@ pub fn cancel(env: Env) -> Result<(), EscrowError> {
     env.storage().instance().set(&State, &EscrowState::Cancelled);
     extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
-    env.events()
-        .publish((Symbol::new(&env, "escrow_cancelled"), buyer), ());
+    events::escrow_cancelled(&env, &buyer);
 
     Ok(())
 }
@@ -321,8 +317,7 @@ pub fn extend_deadline(env: Env, new_deadline: u32) -> Result<(), EscrowError> {
     env.storage().instance().set(&Deadline, &new_deadline);
     extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
 
-    env.events()
-        .publish((Symbol::new(&env, "deadline_extended"), buyer), new_deadline);
+    events::deadline_extended(&env, &buyer, new_deadline);
 
     Ok(())
 }
@@ -338,8 +333,7 @@ pub fn release_to_seller(env: Env) -> Result<(), EscrowError> {
 
     admin::transfer_token(&env, &env.current_contract_address(), &seller, amount);
 
-    env.events()
-        .publish((Symbol::new(&env, "released"), seller), amount);
+    events::funds_released(&env, &seller, amount);
 
     Ok(())
 }

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -177,33 +177,7 @@ impl MultisigContract {
         Self::require_signer(&env, &proposer)?;
         proposer.require_auth();
 
-        let tx_id: u64 = env
-            .storage()
-            .instance()
-            .get(&DataKey::NextTransactionId)
-            .ok_or(MultisigError::NotInitialized)?;
-        let mut signatures = Vec::new(&env);
-        signatures.push_back(proposer.clone());
-
-        let transaction = Transaction {
-            id: tx_id,
-            proposer: proposer.clone(),
-            target,
-            function,
-            args,
-            signatures,
-            executed: false,
-        };
-
-        env.storage()
-            .persistent()
-            .set(&DataKey::Transaction(tx_id), &transaction);
-        env.storage()
-            .instance()
-            .set(&DataKey::NextTransactionId, &(tx_id + 1));
-        bump_instance(&env);
-        bump_transaction(&env, tx_id);
-
+        let tx_id = Self::propose_phase(&env, &proposer, target, function, args)?;
         events::transaction_proposed(&env, tx_id, &proposer);
         Ok(tx_id)
     }
@@ -213,51 +187,14 @@ impl MultisigContract {
         Self::require_signer(&env, &signer)?;
         signer.require_auth();
 
-        let mut transaction = Self::get_required_transaction(&env, tx_id)?;
-        if transaction.executed {
-            return Err(MultisigError::AlreadyExecuted);
-        }
-        if contains(&transaction.signatures, &signer) {
-            return Err(MultisigError::AlreadySigned);
-        }
-
-        transaction.signatures.push_back(signer.clone());
-        let signature_count = transaction.signatures.len();
-        env.storage()
-            .persistent()
-            .set(&DataKey::Transaction(tx_id), &transaction);
-        bump_transaction(&env, tx_id);
-
+        let signature_count = Self::vote_phase(&env, &signer, tx_id)?;
         events::transaction_signed(&env, tx_id, &signer, signature_count);
         Ok(())
     }
 
     /// Execute a transaction once it has enough signatures.
     pub fn execute_transaction(env: Env, tx_id: u64) -> Result<Val, MultisigError> {
-        let mut transaction = Self::get_required_transaction(&env, tx_id)?;
-        if transaction.executed {
-            return Err(MultisigError::AlreadyExecuted);
-        }
-
-        let threshold: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::Threshold)
-            .ok_or(MultisigError::NotInitialized)?;
-        if transaction.signatures.len() < threshold {
-            return Err(MultisigError::ThresholdNotMet);
-        }
-
-        transaction.executed = true;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Transaction(tx_id), &transaction);
-        bump_transaction(&env, tx_id);
-        events::transaction_executed(&env, tx_id);
-
-        let result: Val =
-            env.invoke_contract(&transaction.target, &transaction.function, transaction.args);
-        Ok(result)
+        Self::execute_phase(&env, tx_id)
     }
 
     pub fn get_signers(env: Env) -> Vec<Address> {
@@ -289,6 +226,97 @@ impl MultisigContract {
     pub fn signature_count(env: Env, tx_id: u64) -> Option<u32> {
         Self::get_transaction(env, tx_id).map(|tx| tx.signatures.len())
     }
+
+    // ── Phase helpers ────────────────────────────────────────────────────────
+
+    /// Phase 1 — create a new proposal and record the proposer's implicit vote.
+    #[inline]
+    fn propose_phase(
+        env: &Env,
+        proposer: &Address,
+        target: Address,
+        function: Symbol,
+        args: Vec<Val>,
+    ) -> Result<u64, MultisigError> {
+        let tx_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextTransactionId)
+            .ok_or(MultisigError::NotInitialized)?;
+        let mut signatures = Vec::new(env);
+        signatures.push_back(proposer.clone());
+
+        let transaction = Transaction {
+            id: tx_id,
+            proposer: proposer.clone(),
+            target,
+            function,
+            args,
+            signatures,
+            executed: false,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transaction(tx_id), &transaction);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextTransactionId, &(tx_id + 1));
+        bump_instance(env);
+        bump_transaction(env, tx_id);
+        Ok(tx_id)
+    }
+
+    /// Phase 2 — record a signer's vote on an existing proposal.
+    #[inline]
+    fn vote_phase(env: &Env, signer: &Address, tx_id: u64) -> Result<u32, MultisigError> {
+        let mut transaction = Self::get_required_transaction(env, tx_id)?;
+        if transaction.executed {
+            return Err(MultisigError::AlreadyExecuted);
+        }
+        if contains(&transaction.signatures, signer) {
+            return Err(MultisigError::AlreadySigned);
+        }
+
+        transaction.signatures.push_back(signer.clone());
+        let signature_count = transaction.signatures.len();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transaction(tx_id), &transaction);
+        bump_transaction(env, tx_id);
+        Ok(signature_count)
+    }
+
+    /// Phase 3 — verify threshold and execute the approved proposal.
+    #[inline]
+    fn execute_phase(env: &Env, tx_id: u64) -> Result<Val, MultisigError> {
+        let mut transaction = Self::get_required_transaction(env, tx_id)?;
+        if transaction.executed {
+            return Err(MultisigError::AlreadyExecuted);
+        }
+
+        let threshold: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::Threshold)
+            .ok_or(MultisigError::NotInitialized)?;
+        if transaction.signatures.len() < threshold {
+            return Err(MultisigError::ThresholdNotMet);
+        }
+
+        transaction.executed = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Transaction(tx_id), &transaction);
+        bump_transaction(env, tx_id);
+        events::transaction_executed(env, tx_id);
+
+        let result: Val =
+            env.invoke_contract(&transaction.target, &transaction.function, transaction.args);
+        Ok(result)
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────────────
 
     #[inline]
     fn get_required_signers(env: &Env) -> Result<Vec<Address>, MultisigError> {

--- a/contracts/token/src/allowance.rs
+++ b/contracts/token/src/allowance.rs
@@ -9,7 +9,7 @@ use soroban_sdk::{panic_with_error, Env};
 use crate::errors::TokenError;
 use crate::storage::{AllowanceDataKey, AllowanceValue, DataKey};
 
-/// Soroban ledgers are expected roughly every 5 seconds on public networks.
+/// Soroban ledgers are expected roughly every `soroban_common::LEDGER_SECONDS` seconds on public networks.
 /// Allowance expiration is ledger-exact, so no additional wall-clock grace is
 /// applied beyond the caller-provided `expiration_ledger` (~0 seconds).
 const ALLOWANCE_EXPIRY_GRACE_LEDGERS: u32 = 0;

--- a/contracts/token/src/events.rs
+++ b/contracts/token/src/events.rs
@@ -54,6 +54,18 @@ pub fn transferred(env: &Env, from: &Address, to: &Address, amount: i128) {
     env.events().publish((Symbol::new(env, "transfer"), from.clone(), to.clone()), amount);
 }
 
+/// Emitted when an account is frozen.
+/// Topics: (Symbol, Address) — event name, account
+pub fn account_frozen(env: &Env, account: &Address) {
+    env.events().publish((Symbol::new(env, "account_frozen"), account.clone()), ());
+}
+
+/// Emitted when an account is unfrozen.
+/// Topics: (Symbol, Address) — event name, account
+pub fn account_unfrozen(env: &Env, account: &Address) {
+    env.events().publish((Symbol::new(env, "account_unfrozen"), account.clone()), ());
+}
+
 /// Emitted when the contract is paused.
 /// Topics: (Symbol, Address) — event name, admin
 pub fn paused(env: &Env, admin: &Address) {

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![no_std]
 
 use soroban_sdk::{
     contract, contractimpl, token, token::TokenInterface, Address, Env, String,
@@ -349,10 +348,7 @@ impl TokenContract {
         admin.require_auth();
         env.storage().instance().set(&DataKey::Frozen(account.clone()), &true);
         extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
-        env.events().publish(
-            (soroban_sdk::Symbol::new(&env, "account_frozen"), account),
-            (),
-        );
+        events::account_frozen(&env, &account);
         Ok(())
     }
 
@@ -361,10 +357,7 @@ impl TokenContract {
         admin.require_auth();
         env.storage().instance().set(&DataKey::Frozen(account.clone()), &false);
         extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
-        env.events().publish(
-            (soroban_sdk::Symbol::new(&env, "account_unfrozen"), account),
-            (),
-        );
+        events::account_unfrozen(&env, &account);
         Ok(())
     }
 }
@@ -374,7 +367,7 @@ impl TokenContract {
 #[contractimpl]
 impl TokenContract {
     /// Delay before an upgrade can execute: 17,280 ledgers, approximately
-    /// 24 hours at the expected 5-second Soroban ledger cadence.
+    /// 24 hours at `soroban_common::LEDGER_SECONDS` seconds per ledger.
     const UPGRADE_DELAY_LEDGERS: u32 = 17_280;
 
     pub fn propose_upgrade(env: Env, wasm_hash: soroban_sdk::BytesN<32>) -> Result<(), TokenError> {


### PR DESCRIPTION
## Summary

Closes #691 
closes #692 
closes  #693 
closes  #694 

- **#691** — Extracted `propose_phase`, `vote_phase`, and `execute_phase` private helpers in the multisig contract so each lifecycle phase has a named, dedicated function. Public API (`propose_transaction`, `sign_transaction`, `execute_transaction`) is unchanged.
- **#692** — Removed duplicate `#![no_std]`, added `account_frozen`/`account_unfrozen` to the token `events` module, replaced the inline `env.events().publish()` calls in the freeze impl block with `events::` calls, and added clarifying section comments to all feature-gated impl blocks.
- **#693** — Added `amount_updated`, `escrow_cancelled`, `deadline_extended`, and `dispute_raised` emit functions to the escrow `events` module. Replaced all inline `env.events().publish()` calls in `lifecycle.rs` and `dispute.rs` with `events::` calls (upgrade sections excluded per spec). Also unified the already-existing `escrow_funded`, `delivery_marked`, and `funds_released` paths to go through the module consistently.
- **#694** — Added `pub const LEDGER_SECONDS: u32 = 5` to `soroban-common`. Updated all time-estimation comments in `common/src/lib.rs`, `token/src/allowance.rs`, and `token/src/lib.rs` to reference this shared constant instead of repeating the literal `5`.

## Test plan

- [ ] Existing test suites pass (no logic changed, only structure)
- [ ] `cargo check` clean on all affected crates
- [ ] No inline `env.events().publish` calls outside upgrade sections in escrow
- [ ] Freeze events in token go through `events::account_frozen` / `events::account_unfrozen`

