### PR TITLE
refactor: escrow get_required, extend_ttl, staking pure calc, vesting schedule helper

### DIFF
--- a/contracts/escrow/src/dispute.rs
+++ b/contracts/escrow/src/dispute.rs
@@ -1,9 +1,8 @@
 use soroban_sdk::{Address, Env, Symbol};
 
 use crate::errors::EscrowError;
-use crate::lifecycle::{get_required, refund_to_buyer, release_to_seller};
+use crate::lifecycle::{extend_ttl, get_required, refund_to_buyer, release_to_seller};
 use crate::storage::{DataKey, EscrowState};
-use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
 use DataKey::*;
 
@@ -25,7 +24,7 @@ pub fn raise_dispute(env: Env, caller: Address) -> Result<(), EscrowError> {
     }
 
     env.storage().instance().set(&State, &EscrowState::Disputed);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     env.events()
         .publish((Symbol::new(&env, "dispute_raised"), caller), ());
@@ -93,11 +92,7 @@ pub fn resolve_dispute(env: Env, release_to_seller_flag: bool) -> Result<(), Esc
             Ok(())
         }
     } else {
-        let arbiter: Address = env
-            .storage()
-            .instance()
-            .get(&Arbiter)
-            .ok_or(EscrowError::NotInitialized)?;
+        let arbiter: Address = get_required(&env, &Arbiter)?;
         arbiter.require_auth();
 
         if release_to_seller_flag {

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env};
-use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
 mod admin;
 mod dispute;
@@ -127,7 +126,7 @@ impl EscrowContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &true);
-        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+        lifecycle::extend_ttl(&env);
         events::paused(&env, &admin);
         Ok(())
     }
@@ -136,7 +135,7 @@ impl EscrowContract {
         let admin = require_admin(&env)?;
         admin.require_auth();
         env.storage().instance().set(&DataKey::Paused, &false);
-        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+        lifecycle::extend_ttl(&env);
         events::unpaused(&env, &admin);
         Ok(())
     }
@@ -153,7 +152,7 @@ impl EscrowContract {
         env.storage()
             .instance()
             .set(&DataKey::PendingUpgrade, &(wasm_hash.clone(), ready_after));
-        extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+        lifecycle::extend_ttl(&env);
         env.events().publish(
             (soroban_sdk::Symbol::new(&env, "upgrade_proposed"), admin),
             (wasm_hash, ready_after),

--- a/contracts/escrow/src/lifecycle.rs
+++ b/contracts/escrow/src/lifecycle.rs
@@ -44,6 +44,10 @@ fn validate_parties_multi(buyer: &Address, seller: &Address, arbiters: &Vec<Addr
     Ok(())
 }
 
+pub(crate) fn extend_ttl(env: &Env) {
+    extend_ttl_instance(env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+}
+
 fn store_escrow_data(
     env: &Env,
     buyer: &Address,
@@ -86,7 +90,7 @@ pub fn initialize(
     validate_deadline(&env, deadline_ledger).map_err(|_| EscrowError::DeadlinePassed)?;
     token::Client::new(&env, &token_contract).decimals();
     store_escrow_data(&env, &buyer, &seller, &arbiter, &token_contract, amount, deadline_ledger, 1u32);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
     emit_init_events(&env, &buyer, &seller, &arbiter, amount);
     Ok(())
 }
@@ -111,34 +115,26 @@ pub fn initialize_with_arbiters(
     let primary_arbiter = arbiters.get(0).unwrap();
     store_escrow_data(&env, &buyer, &seller, &primary_arbiter, &token_contract, amount, deadline_ledger, required_signatures);
     env.storage().instance().set(&Arbiters, &arbiters);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
     emit_init_events(&env, &buyer, &seller, &primary_arbiter, amount);
     Ok(())
 }
 
 pub fn update_amount(env: Env, new_amount: i128) -> Result<(), EscrowError> {
-    let buyer: Address = env
-        .storage()
-        .instance()
-        .get(&Buyer)
-        .ok_or(EscrowError::NotInitialized)?;
+    let buyer: Address = get_required(&env, &Buyer)?;
     buyer.require_auth();
 
     if new_amount <= 0 {
         return Err(EscrowError::InvalidAmount);
     }
 
-    let state: EscrowState = env
-        .storage()
-        .instance()
-        .get(&State)
-        .ok_or(EscrowError::NotInitialized)?;
+    let state: EscrowState = get_required(&env, &State)?;
     if state != EscrowState::Created {
         return Err(EscrowError::InvalidState);
     }
 
     env.storage().instance().set(&Amount, &new_amount);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     env.events()
         .publish((Symbol::new(&env, "amount_updated"), buyer), new_amount);
@@ -168,7 +164,7 @@ pub fn fund(env: Env) -> Result<(), EscrowError> {
     token_client.transfer(&buyer, &env.current_contract_address(), &amount);
 
     env.storage().instance().set(&State, &EscrowState::Funded);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     env.events()
         .publish((Symbol::new(&env, "funded"), buyer), amount);
@@ -189,7 +185,7 @@ pub fn mark_delivered(env: Env) -> Result<(), EscrowError> {
     }
 
     env.storage().instance().set(&State, &EscrowState::Delivered);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     env.events()
         .publish((Symbol::new(&env, "marked_delivered"), seller), ());
@@ -211,18 +207,10 @@ pub fn release_partial(env: Env, amount: i128) -> Result<(), EscrowError> {
     #[cfg(feature = "pausable")]
     crate::EscrowContract::require_not_paused(&env)?;
 
-    let buyer: Address = env
-        .storage()
-        .instance()
-        .get(&Buyer)
-        .ok_or(EscrowError::NotInitialized)?;
+    let buyer: Address = get_required(&env, &Buyer)?;
     buyer.require_auth();
 
-    let state: EscrowState = env
-        .storage()
-        .instance()
-        .get(&State)
-        .ok_or(EscrowError::NotInitialized)?;
+    let state: EscrowState = get_required(&env, &State)?;
     if state != EscrowState::Funded {
         return Err(EscrowError::InvalidState);
     }
@@ -231,15 +219,15 @@ pub fn release_partial(env: Env, amount: i128) -> Result<(), EscrowError> {
         return Err(EscrowError::InvalidAmount);
     }
 
-    let stored_amount: i128 = env.storage().instance().get(&Amount).unwrap();
+    let stored_amount: i128 = get_required(&env, &Amount)?;
     if amount > stored_amount {
         return Err(EscrowError::InsufficientFunds);
     }
 
-    let seller: Address = env.storage().instance().get(&Seller).unwrap();
+    let seller: Address = get_required(&env, &Seller)?;
     let new_amount = stored_amount - amount;
     env.storage().instance().set(&Amount, &new_amount);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     admin::transfer_token(&env, &env.current_contract_address(), &seller, amount);
     events::partial_release(&env, &seller, amount);
@@ -276,7 +264,7 @@ pub fn cancel(env: Env) -> Result<(), EscrowError> {
     }
 
     env.storage().instance().set(&State, &EscrowState::Cancelled);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     env.events()
         .publish((Symbol::new(&env, "escrow_cancelled"), buyer), ());
@@ -285,41 +273,25 @@ pub fn cancel(env: Env) -> Result<(), EscrowError> {
 }
 
 pub fn extend_deadline(env: Env, new_deadline: u32) -> Result<(), EscrowError> {
-    let buyer: Address = env
-        .storage()
-        .instance()
-        .get(&Buyer)
-        .ok_or(EscrowError::NotInitialized)?;
-    let seller: Address = env
-        .storage()
-        .instance()
-        .get(&Seller)
-        .ok_or(EscrowError::NotInitialized)?;
+    let buyer: Address = get_required(&env, &Buyer)?;
+    let seller: Address = get_required(&env, &Seller)?;
 
     buyer.require_auth();
     seller.require_auth();
 
-    let current_deadline: u32 = env
-        .storage()
-        .instance()
-        .get(&Deadline)
-        .ok_or(EscrowError::NotInitialized)?;
+    let current_deadline: u32 = get_required(&env, &Deadline)?;
 
     if new_deadline <= current_deadline {
         return Err(EscrowError::DeadlinePassed);
     }
 
-    let state: EscrowState = env
-        .storage()
-        .instance()
-        .get(&State)
-        .ok_or(EscrowError::NotInitialized)?;
+    let state: EscrowState = get_required(&env, &State)?;
     if !matches!(state, EscrowState::Funded | EscrowState::Delivered) {
         return Err(EscrowError::InvalidState);
     }
 
     env.storage().instance().set(&Deadline, &new_deadline);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     env.events()
         .publish((Symbol::new(&env, "deadline_extended"), buyer), new_deadline);
@@ -334,7 +306,7 @@ pub fn release_to_seller(env: Env) -> Result<(), EscrowError> {
     let amount: i128 = get_required(&env, &Amount)?;
 
     env.storage().instance().set(&State, &EscrowState::Completed);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     admin::transfer_token(&env, &env.current_contract_address(), &seller, amount);
 
@@ -351,7 +323,7 @@ pub fn refund_to_buyer(env: Env) -> Result<(), EscrowError> {
     let amount: i128 = get_required(&env, &Amount)?;
 
     env.storage().instance().set(&State, &EscrowState::Refunded);
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
 
     admin::transfer_token(&env, &env.current_contract_address(), &buyer, amount);
 

--- a/contracts/escrow/src/queries.rs
+++ b/contracts/escrow/src/queries.rs
@@ -1,9 +1,8 @@
 use soroban_sdk::Env;
 
 use crate::errors::EscrowError;
-use crate::lifecycle::get_required;
+use crate::lifecycle::{extend_ttl, get_required};
 use crate::storage::{DataKey, EscrowInfo, EscrowState};
-use soroban_common::{extend_ttl_instance, LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
 use DataKey::*;
 
@@ -38,6 +37,6 @@ pub fn bump(env: Env) -> Result<(), EscrowError> {
     if !env.storage().instance().has(&State) {
         return Err(EscrowError::NotInitialized);
     }
-    extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+    extend_ttl(&env);
     Ok(())
 }

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -66,6 +66,11 @@ fn get_total_rewards_internal(env: &Env) -> Result<i128, StakingError> {
         .ok_or(StakingError::NotInitialized)
 }
 
+/// Pure reward calculation — isolated from storage for testability.
+pub(crate) fn calculate_earned(stake: i128, rpt: i128, paid: i128, accrued: i128) -> i128 {
+    accrued + stake * (rpt - paid) / REWARD_SCALE
+}
+
 /// Computes how many reward tokens `staker` has earned since their last update.
 fn earned(env: &Env, staker: &Address) -> i128 {
     let stake: i128 = env
@@ -84,7 +89,7 @@ fn earned(env: &Env, staker: &Address) -> i128 {
         .persistent()
         .get(&DataKey::Rewards(staker.clone()))
         .unwrap_or(0i128);
-    accrued + stake * (rpt - paid) / REWARD_SCALE
+    calculate_earned(stake, rpt, paid, accrued)
 }
 
 /// Snapshots the staker's earned rewards and updates their paid-up-to pointer.

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -34,6 +34,13 @@ pub(crate) fn vested_amount(amount: i128, cliff_ledger: u32, end_ledger: u32, le
     amount * elapsed / total
 }
 
+fn validate_schedule(cliff_ledger: u32, end_ledger: u32, now: u32) -> Result<(), VestingError> {
+    if cliff_ledger >= end_ledger || end_ledger <= now {
+        return Err(VestingError::InvalidSchedule);
+    }
+    Ok(())
+}
+
 /// Token vesting contract with cliff + linear release schedule.
 ///
 /// Flow:
@@ -67,10 +74,7 @@ impl VestingContract {
         if amount <= 0 {
             return Err(VestingError::InvalidAmount);
         }
-        let now = env.ledger().sequence();
-        if cliff_ledger >= end_ledger || end_ledger <= now {
-            return Err(VestingError::InvalidSchedule);
-        }
+        validate_schedule(cliff_ledger, end_ledger, env.ledger().sequence())?;
 
         admin.require_auth();
 


### PR DESCRIPTION
## Summary

- **Closes #687** — Replace all remaining inline `.ok_or(EscrowError::NotInitialized)` patterns in `lifecycle.rs` (`update_amount`, `release_partial`, `extend_deadline`) and `dispute.rs` (`resolve_dispute`) with the existing `get_required` helper, eliminating inconsistency.
- **Closes #690** — Extract `pub(crate) fn extend_ttl(env: &Env)` into `lifecycle.rs` wrapping `extend_ttl_instance`; replace every inline `extend_ttl_instance(…)` call-site across `lifecycle`, `dispute`, `queries`, and `lib` (pausable) with it. Public API (`EscrowContract::bump`) is unchanged.
- **Closes #688** — Extract `pub(crate) fn calculate_earned(stake, rpt, paid, accrued) -> i128` from the staking `earned()` function so the core reward arithmetic is a pure, storage-free function. `earned()` now delegates to it.
- **Closes #689** — Extract `fn validate_schedule(cliff_ledger, end_ledger, now) -> Result<(), VestingError>` from vesting `initialize()` and delegate to it, separating schedule validation from init logic.

## Test plan
- [ ] `cargo check` passes for escrow, staking, and vesting crates
- [ ] All existing test suites continue to pass without modification

