### PR TITLE
feat: dev-experience and monitoring improvements (#696, #697, #699, #703)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,13 +260,17 @@ jobs:
         run: cargo machete --workspace
 
   udeps:
-    name: Unused dev-dependencies (cargo-udeps)
+    name: Unused dependencies (cargo-udeps)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@nightly
+      # Pin the nightly toolchain so unused-dependency results are reproducible
+      # across runs (cargo-udeps requires nightly).
+      - name: Install pinned nightly Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-06-15
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -274,8 +278,8 @@ jobs:
       - name: Install cargo-udeps
         run: cargo install cargo-udeps --locked
 
-      - name: Check for unused dev-dependencies
-        run: cargo +nightly udeps --workspace --all-targets
+      - name: Check for unused dependencies
+        run: cargo udeps --workspace --all-targets
 
   semver:
     name: Semver Checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error Reference section in README documenting all `TokenError` and `EscrowError` codes (#234)
 - This CHANGELOG file (#231)
 - Terraform provider version pinning and `.terraform` directory caching between plan and apply jobs (#242)
+- Structured JSON log lines (timestamp, network, contract, contractId, txHash, status) emitted by the deploy scripts so deployments can be piped to log aggregators (#696)
+- Prometheus alert definitions and a sample importable Grafana dashboard JSON in `docs/monitoring.md`, linked from the deployment guide (#697)
+
+### Changed
+- Migrated all workspace crates to the Rust 2024 edition and bumped the pinned toolchain to 1.85.0 (#703)
+- Pinned the nightly toolchain used by the `cargo-udeps` CI job for reproducible unused-dependency checks (#699)
 
 ## [0.1.0] - 2026-04-24
 

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "contract-benchmarks"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 license.workspace = true
 publish = false

--- a/contracts/airdrop/Cargo.toml
+++ b/contracts/airdrop/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-airdrop-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban merkle-proof airdrop contract template"
 license.workspace = true

--- a/contracts/auction/Cargo.toml
+++ b/contracts/auction/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-auction-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban English auction contract template"
 license.workspace = true

--- a/contracts/ballot/Cargo.toml
+++ b/contracts/ballot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ballot"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/contracts/bonding-curve/Cargo.toml
+++ b/contracts/bonding-curve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bonding-curve"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/contracts/common/Cargo.toml
+++ b/contracts/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-common"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [lib]

--- a/contracts/crowdfund/Cargo.toml
+++ b/contracts/crowdfund/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-crowdfund-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban all-or-nothing crowdfunding contract template"
 license.workspace = true

--- a/contracts/dao/Cargo.toml
+++ b/contracts/dao/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-dao-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban DAO governance contract template"
 license.workspace = true

--- a/contracts/escrow/Cargo.toml
+++ b/contracts/escrow/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-escrow-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban escrow contract template"
 license.workspace = true

--- a/contracts/lottery/Cargo.toml
+++ b/contracts/lottery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-lottery-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban lottery contract template"
 license.workspace = true

--- a/contracts/marketplace/Cargo.toml
+++ b/contracts/marketplace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-marketplace-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban NFT marketplace contract template"
 license.workspace = true

--- a/contracts/multisig/Cargo.toml
+++ b/contracts/multisig/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-multisig-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban N-of-M multisig wallet contract template"
 license.workspace = true

--- a/contracts/nft/Cargo.toml
+++ b/contracts/nft/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-nft-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban NFT contract template"
 license.workspace = true

--- a/contracts/oracle/Cargo.toml
+++ b/contracts/oracle/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-oracle-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban price oracle consumer contract template"
 license.workspace = true

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-staking-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban token staking contract template"
 license.workspace = true

--- a/contracts/subscription/Cargo.toml
+++ b/contracts/subscription/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-subscription-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban recurring payment subscription contract template"
 license.workspace = true

--- a/contracts/swap/Cargo.toml
+++ b/contracts/swap/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-swap-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban atomic token swap contract template"
 license.workspace = true

--- a/contracts/timelock/Cargo.toml
+++ b/contracts/timelock/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-timelock-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban timelock contract template"
 license.workspace = true

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-token-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban token contract template"
 license.workspace = true

--- a/contracts/vesting/Cargo.toml
+++ b/contracts/vesting/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-vesting-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 description = "A production-ready Soroban token vesting contract template"
 license.workspace = true

--- a/contracts/wrapped-token/Cargo.toml
+++ b/contracts/wrapped-token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wrapped-token"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [lib]

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -353,6 +353,31 @@ To add automated deployment, extend `.github/workflows/ci.yml`:
     STELLAR_SECRET_KEY: ${{ secrets.STELLAR_SECRET_KEY }}
 ```
 
+### Structured deployment logs (JSON)
+
+`deploy.sh`, `deploy_staking.sh`, and `deploy_vesting.sh` emit one structured
+JSON log line per deploy event on **stdout**, while all human-readable progress
+goes to **stderr**. Each line has the shape:
+
+```json
+{"timestamp":"2026-06-28T12:00:00Z","network":"testnet","contract":"escrow","contractId":"C...","txHash":"","status":"deployed"}
+```
+
+`status` is one of `building`, `deployed`, or `failed`. Because stdout is a clean
+NDJSON stream, you can pipe it straight into a log aggregator or filter it with
+`jq`:
+
+```bash
+# Pretty-print only successful deployments
+./scripts/deploy.sh testnet 2>/dev/null | jq -c 'select(.status == "deployed")'
+
+# Persist a deploy ledger and ship lines to a collector at the same time
+./scripts/deploy.sh testnet 2>deploy.stderr.log \
+  | tee -a deploys.ndjson \
+  | curl -s -H 'Content-Type: application/x-ndjson' --data-binary @- \
+      https://logs.example.com/ingest
+```
+
 ---
 
 ## 8. Automated Guide Generation
@@ -654,6 +679,7 @@ The script also prints a warning when the deadline has passed and funds are stil
 - [Stellar Friendbot (testnet funding)](https://friendbot.stellar.org)
 - [Stellar Laboratory](https://laboratory.stellar.org/)
 - [cargo-audit](https://crates.io/crates/cargo-audit)
+- [Contract Monitoring Guide](./monitoring.md) — event indexing, anomaly detection, Prometheus alerts, and a sample Grafana dashboard for deployed contracts
 
 ---
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -278,7 +278,228 @@ See [`scripts/monitor-escrow.sh`](../scripts/monitor-escrow.sh) for details.
 
 ---
 
-## 10. Resources
+## 10. Prometheus Alert Definitions
+
+The thresholds in §8 translate directly into Prometheus alerting rules. These
+assume an exporter (e.g. the custom indexer from §5) publishes the following
+metrics, labelled by `contract_id`:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `soroban_events_processed_total` | counter | Events ingested by the indexer |
+| `soroban_escrow_disputes_total` | counter | `dispute_raised` events observed |
+| `soroban_escrow_funded_total` | counter | `escrow_funded` events observed |
+| `soroban_transfer_amount` | histogram/gauge | Per-transfer value (base units) |
+| `soroban_upgrade_events_total` | counter | `upgrade_proposed` / `upgrade_executed` events |
+| `soroban_subscription_charge_failed_total` | counter | Failed `charged` attempts |
+| `soroban_subscription_charge_total` | counter | Total `charged` attempts |
+
+Save as `monitoring/alerts.yml` and load it from your Prometheus config
+(`rule_files: [ "alerts.yml" ]`):
+
+```yaml
+groups:
+  - name: soroban-contracts
+    rules:
+      # Indexer has stopped ingesting events entirely.
+      - alert: SorobanIndexerDown
+        expr: rate(soroban_events_processed_total[5m]) == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No contract events processed for {{ $labels.contract_id }}"
+          description: "The indexer has ingested 0 events in the last 5 minutes."
+
+      # Event-processing lag: throughput dropped well below normal.
+      - alert: SorobanEventProcessingLag
+        expr: rate(soroban_events_processed_total[5m]) * 60 < 10
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Event processing lag for {{ $labels.contract_id }}"
+          description: "Fewer than 10 events/min processed over the last 10 minutes."
+
+      # Repeated disputes: dispute rate exceeds 10% of funded escrows.
+      - alert: SorobanEscrowDisputeSpike
+        expr: |
+          (
+            increase(soroban_escrow_disputes_total[1h])
+            / clamp_min(increase(soroban_escrow_funded_total[1h]), 1)
+          ) > 0.10
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Escrow dispute spike on {{ $labels.contract_id }}"
+          description: ">10% of funded escrows raised a dispute in the last hour."
+
+      # Large escrow / transfer: a single transfer exceeds the high-value cap.
+      - alert: SorobanLargeTransfer
+        expr: max_over_time(soroban_transfer_amount[5m]) > 1e11
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Large transfer on {{ $labels.contract_id }}"
+          description: "A transfer above the high-value threshold was observed. Review immediately."
+
+      # Failed upgrades / upgrade activity: alert on every upgrade event.
+      - alert: SorobanUpgradeActivity
+        expr: increase(soroban_upgrade_events_total[10m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Upgrade activity on {{ $labels.contract_id }}"
+          description: "An upgrade was proposed or executed. Verify the WASM hash and timelock."
+
+      # Subscription charge failures above 20% of attempts.
+      - alert: SorobanChargeFailureRate
+        expr: |
+          (
+            increase(soroban_subscription_charge_failed_total[1h])
+            / clamp_min(increase(soroban_subscription_charge_total[1h]), 1)
+          ) > 0.20
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High subscription charge-failure rate on {{ $labels.contract_id }}"
+          description: ">20% of charge attempts failed in the last hour."
+```
+
+Tune the numeric thresholds (`1e11` base units, `0.10`, `0.20`, …) to match the
+decimals and risk profile of your specific deployment — see the tables in §8.
+
+---
+
+## 11. Grafana Dashboard
+
+Import the JSON below via **Dashboards → New → Import** in Grafana. It expects a
+Prometheus datasource and the metrics described in §10. Replace the
+`${DS_PROMETHEUS}` datasource variable when prompted.
+
+```json
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "schemaVersion": 39,
+  "title": "Soroban Contract Monitoring",
+  "tags": ["soroban", "stellar", "contracts"],
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "contract_id",
+        "type": "query",
+        "datasource": "${DS_PROMETHEUS}",
+        "query": "label_values(soroban_events_processed_total, contract_id)",
+        "includeAll": true,
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Events processed / min",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "rate(soroban_events_processed_total{contract_id=~\"$contract_id\"}[5m]) * 60",
+          "legendFormat": "{{contract_id}}"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Dispute rate (1h)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.02 },
+              { "color": "red", "value": 0.1 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "increase(soroban_escrow_disputes_total{contract_id=~\"$contract_id\"}[1h]) / clamp_min(increase(soroban_escrow_funded_total{contract_id=~\"$contract_id\"}[1h]), 1)",
+          "legendFormat": "{{contract_id}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Max transfer value (5m)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "max_over_time(soroban_transfer_amount{contract_id=~\"$contract_id\"}[5m])",
+          "legendFormat": "{{contract_id}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Upgrade events (10m)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": "${DS_PROMETHEUS}",
+      "targets": [
+        {
+          "expr": "increase(soroban_upgrade_events_total{contract_id=~\"$contract_id\"}[10m])",
+          "legendFormat": "{{contract_id}}"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Subscription charge-failure rate (1h)",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.05 },
+              { "color": "red", "value": 0.2 }
+            ]
+          }
+        }
+      },
+      "targets": [
+        {
+          "expr": "increase(soroban_subscription_charge_failed_total{contract_id=~\"$contract_id\"}[1h]) / clamp_min(increase(soroban_subscription_charge_total{contract_id=~\"$contract_id\"}[1h]), 1)",
+          "legendFormat": "{{contract_id}}"
+        }
+      ]
+    }
+  ]
+}
+```
+
+> Tip: keep this JSON under version control (e.g. `monitoring/dashboard.json`)
+> and provision it automatically with the Grafana
+> [dashboard provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards)
+> config so it is recreated on every environment.
+
+---
+
+## 12. Resources
 
 - [Horizon Events API](https://developers.stellar.org/docs/data/horizon/api-reference/resources/get-events-by-contract-id)
 - [Stellar CLI contract events](https://developers.stellar.org/docs/tools/stellar-cli)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-token-fuzz"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 license.workspace = true
 publish = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel    = "1.82.0"
+channel    = "1.85.0"
 targets    = ["wasm32v1-none"]
 components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,18 @@
 # Usage: ./scripts/deploy.sh [testnet|mainnet|local] [contract] [--identity <name>]
 set -euo pipefail
 
+# log_json — emit one structured JSON log line per deploy event on stdout.
+# Fields: timestamp (UTC ISO-8601), network, contract, contractId, txHash, status.
+# Human-readable progress is written to stderr so stdout stays a clean NDJSON
+# stream that can be piped straight to a log aggregator (jq, Loki, CloudWatch).
+# Usage: log_json <status> <contract> [contractId] [txHash]
+log_json() {
+  local status="$1" contract="${2:-}" contract_id="${3:-}" tx_hash="${4:-}" ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '{"timestamp":"%s","network":"%s","contract":"%s","contractId":"%s","txHash":"%s","status":"%s"}\n' \
+    "$ts" "${NETWORK:-}" "$contract" "$contract_id" "$tx_hash" "$status"
+}
+
 check_prerequisites() {
   local missing=()
   for cmd in stellar cargo; do
@@ -34,7 +46,7 @@ optimize_wasm() {
   local after
   after=$(stat -c%s "$wasm" 2>/dev/null || stat -f%z "$wasm")
   local pct=$(( (before - after) * 100 / before ))
-  echo "  wasm-opt: ${before}B → ${after}B (-${pct}%)"
+  echo "  wasm-opt: ${before}B → ${after}B (-${pct}%)" >&2
 }
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -93,17 +105,18 @@ esac
 deploy_contract() {
   local name="$1"
   local dir="$CONTRACTS_DIR/$name"
-  [[ -d "$dir" ]] || { echo "Contract not found: $name"; return 1; }
+  [[ -d "$dir" ]] || { echo "Contract not found: $name" >&2; log_json failed "$name"; return 1; }
 
-  echo "── Building $name ──"
-  (cd "$dir" && stellar contract build)
+  echo "── Building $name ──" >&2
+  log_json building "$name"
+  (cd "$dir" && stellar contract build) >&2
 
   WASM=$(find "$dir/target/wasm32-unknown-unknown/release" -name "*.wasm" | head -1)
-  [[ -n "$WASM" ]] || { echo "No WASM found for $name"; return 1; }
+  [[ -n "$WASM" ]] || { echo "No WASM found for $name" >&2; log_json failed "$name"; return 1; }
 
   optimize_wasm "$WASM"
 
-  echo "── Deploying $name to $NETWORK ──"
+  echo "── Deploying $name to $NETWORK ──" >&2
   CONTRACT_ID=$(stellar contract deploy \
     --wasm "$WASM" \
     --rpc-url "$RPC_URL" \
@@ -111,7 +124,8 @@ deploy_contract() {
     --source-account "$IDENTITY" \
     --network "$NETWORK")
   echo "$name: $CONTRACT_ID" >> "$ROOT/.contract-ids"
-  echo "Contract ID: $CONTRACT_ID"
+  echo "Contract ID: $CONTRACT_ID" >&2
+  log_json deployed "$name" "$CONTRACT_ID"
 }
 
 if [[ "$CONTRACT" == "all" ]]; then

--- a/scripts/deploy_staking.sh
+++ b/scripts/deploy_staking.sh
@@ -9,20 +9,33 @@ set -e
 NETWORK=${1:-testnet}
 CONTRACT_NAME="soroban-staking-template"
 
-echo "🚀 Deploying Staking Contract to $NETWORK..."
+# log_json — emit one structured JSON log line per deploy event on stdout.
+# Fields: timestamp (UTC ISO-8601), network, contract, contractId, txHash, status.
+# Human-readable progress goes to stderr so stdout stays clean NDJSON for log
+# aggregators. Usage: log_json <status> [contractId] [txHash]
+log_json() {
+  local status="$1" contract_id="${2:-}" tx_hash="${3:-}" ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '{"timestamp":"%s","network":"%s","contract":"staking","contractId":"%s","txHash":"%s","status":"%s"}\n' \
+    "$ts" "$NETWORK" "$contract_id" "$tx_hash" "$status"
+}
+
+echo "🚀 Deploying Staking Contract to $NETWORK..." >&2
 
 # Build the contract
-echo "📦 Building contract..."
-stellar contract build --manifest-path contracts/staking/Cargo.toml
+echo "📦 Building contract..." >&2
+log_json building
+stellar contract build --manifest-path contracts/staking/Cargo.toml >&2
 
 # Deploy the contract
-echo "🌐 Deploying to $NETWORK..."
+echo "🌐 Deploying to $NETWORK..." >&2
 CONTRACT_ID=$(stellar contract deploy \
     --wasm contracts/staking/target/wasm32-unknown-unknown/release/${CONTRACT_NAME}.wasm \
     --network "$NETWORK")
 
-echo "✅ Staking contract deployed!"
-echo "📋 Contract ID: $CONTRACT_ID"
+echo "✅ Staking contract deployed!" >&2
+echo "📋 Contract ID: $CONTRACT_ID" >&2
+log_json deployed "$CONTRACT_ID"
 
 # Save contract ID
 echo "staking: $CONTRACT_ID" >> .contract-ids
@@ -50,5 +63,5 @@ echo "staking: $CONTRACT_ID" >> .contract-ids
 #     -- add_rewards \
 #     --amount "$REWARD_AMOUNT"
 
-echo "🎉 Staking contract ready for use!"
-echo "📝 Save this Contract ID: $CONTRACT_ID"
+echo "🎉 Staking contract ready for use!" >&2
+echo "📝 Save this Contract ID: $CONTRACT_ID" >&2

--- a/scripts/deploy_vesting.sh
+++ b/scripts/deploy_vesting.sh
@@ -9,20 +9,33 @@ set -e
 NETWORK=${1:-testnet}
 CONTRACT_NAME="soroban-vesting-template"
 
-echo "🚀 Deploying Vesting Contract to $NETWORK..."
+# log_json — emit one structured JSON log line per deploy event on stdout.
+# Fields: timestamp (UTC ISO-8601), network, contract, contractId, txHash, status.
+# Human-readable progress goes to stderr so stdout stays clean NDJSON for log
+# aggregators. Usage: log_json <status> [contractId] [txHash]
+log_json() {
+  local status="$1" contract_id="${2:-}" tx_hash="${3:-}" ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '{"timestamp":"%s","network":"%s","contract":"vesting","contractId":"%s","txHash":"%s","status":"%s"}\n' \
+    "$ts" "$NETWORK" "$contract_id" "$tx_hash" "$status"
+}
+
+echo "🚀 Deploying Vesting Contract to $NETWORK..." >&2
 
 # Build the contract
-echo "📦 Building contract..."
-stellar contract build --manifest-path contracts/vesting/Cargo.toml
+echo "📦 Building contract..." >&2
+log_json building
+stellar contract build --manifest-path contracts/vesting/Cargo.toml >&2
 
 # Deploy the contract
-echo "🌐 Deploying to $NETWORK..."
+echo "🌐 Deploying to $NETWORK..." >&2
 CONTRACT_ID=$(stellar contract deploy \
     --wasm contracts/vesting/target/wasm32-unknown-unknown/release/${CONTRACT_NAME}.wasm \
     --network "$NETWORK")
 
-echo "✅ Vesting contract deployed!"
-echo "📋 Contract ID: $CONTRACT_ID"
+echo "✅ Vesting contract deployed!" >&2
+echo "📋 Contract ID: $CONTRACT_ID" >&2
+log_json deployed "$CONTRACT_ID"
 
 # Save contract ID
 echo "vesting: $CONTRACT_ID" >> .contract-ids
@@ -47,5 +60,5 @@ echo "vesting: $CONTRACT_ID" >> .contract-ids
 #     --end_ledger "$END_LEDGER" \
 #     --amount "$AMOUNT"
 
-echo "🎉 Vesting contract ready for use!"
-echo "📝 Save this Contract ID: $CONTRACT_ID"
+echo "🎉 Vesting contract ready for use!" >&2
+echo "📝 Save this Contract ID: $CONTRACT_ID" >&2

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "soroban-integration-tests"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors.workspace = true
 license.workspace = true
 publish = false


### PR DESCRIPTION
Implements four developer-experience and operations issues in a single PR.

## Changes

### Rust 2024 edition migration (#703)
- All 23 workspace crates (`contracts/*`, `benches`, `tests`, `fuzz`) now use `edition = "2024"`.
- Bumped the pinned toolchain in `rust-toolchain.toml` to `1.85.0` (minimum for the 2024 edition).
- CHANGELOG entry added.

### Structured JSON logging in deploy scripts (#696)
- `deploy.sh`, `deploy_staking.sh`, and `deploy_vesting.sh` emit one NDJSON line per deploy event on **stdout** with `timestamp`, `network`, `contract`, `contractId`, `txHash`, and `status` (`building` / `deployed` / `failed`).
- Human-readable progress is routed to **stderr** so stdout stays a clean JSON stream for log aggregators.
- Example pipeline command documented in `docs/deployment-guide.md`.

### Pinned nightly for cargo-udeps in CI (#699)
- The `udeps` job now pins the nightly toolchain (`nightly-2025-06-15`) for reproducible unused-dependency checks instead of a floating `@nightly`.
- `cargo machete` already guards unused deps; nothing additional was flagged.

### Monitoring: alerts + Grafana dashboard (#697)
- Added a **Prometheus Alert Definitions** section to `docs/monitoring.md` (indexer down, dispute spike, large transfer, upgrade activity, charge-failure rate).
- Added a complete, importable sample **Grafana dashboard JSON**.
- Linked the monitoring guide from `docs/deployment-guide.md`.

> Note: per request, no tests/builds were run as part of this change.

Closes #696
Closes #697
Closes #699
Closes #703
