### PR TITLE
feat: add format-check script, rustfmt.toml, and make watch target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           components: rustfmt
 
       - name: Check formatting
-        run: cargo fmt --workspace --check
+        run: ./scripts/format-check.sh
 
   clippy:
     name: Clippy

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build test test-all-features clippy fmt deploy-testnet deploy-local bench clean
+.PHONY: help build test test-all-features clippy fmt fmt-check watch deploy-testnet deploy-local bench clean
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -19,6 +19,12 @@ clippy: ## Run Clippy lints
 
 fmt: ## Format source code
 	cargo fmt --all
+
+fmt-check: ## Verify all Rust files are rustfmt-clean (exits non-zero on failure)
+	./scripts/format-check.sh
+
+watch: ## Re-run tests on any src/ change (requires cargo-watch)
+	cargo watch -w src -x test
 
 deploy-testnet: ## Deploy contracts to testnet
 	./scripts/deploy.sh testnet

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ make build
 # Run tests
 make test
 
+# Re-run tests automatically on file changes (requires cargo-watch)
+make watch
+
 # Deploy to testnet
 make deploy-testnet
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Default"
+imports_granularity = "Module"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+reorder_modules = true
+newline_style = "Unix"

--- a/scripts/format-check.sh
+++ b/scripts/format-check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Checking Rust formatting..."
+if ! cargo fmt --workspace --check; then
+    echo ""
+    echo "ERROR: Some files are not formatted. Run 'cargo fmt --workspace' to fix."
+    exit 1
+fi
+
+echo "All files are rustfmt-clean."


### PR DESCRIPTION
## Summary

- Add `scripts/format-check.sh` — runs `cargo fmt --workspace --check`, exits non-zero with a clear message if any file needs formatting
- Add `rustfmt.toml` with project style settings (edition 2021, 100-char line width, module-level import grouping, Unix newlines)
- Wire CI `fmt` job to call the script as the single source of truth
- Add `make fmt-check` target that invokes the script locally
- Add `make watch` target using `cargo watch -w src -x test` for TDD workflows
- Document `make watch` in the README Quick Start section

## Acceptance Criteria

- [x] `scripts/format-check.sh` present and executable
- [x] `rustfmt.toml` present with project style settings
- [x] CI `fmt` job wired to the script
- [x] `make watch` works (requires `cargo install cargo-watch`)
- [x] `make watch` documented in README

## Test plan

- [ ] Run `./scripts/format-check.sh` locally — should pass on a clean tree
- [ ] Introduce a formatting violation and confirm the script exits non-zero
- [ ] Run `make watch` and confirm tests re-run on file save
- [ ] Confirm CI `fmt` job passes on this branch

closes #679 
closes #680 