### PR TITLE
feat: vesting admin_release, token transfer-hook, multisig expiry, es…

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -50,6 +50,7 @@ mod contract {
             token_contract: Address,
             amount: i128,
             deadline_ledger: u32,
+            metadata_hash: Option<soroban_sdk::BytesN<32>>,
         ) -> Result<(), EscrowError> {
             lifecycle::initialize(
                 env,
@@ -59,6 +60,7 @@ mod contract {
                 token_contract,
                 amount,
                 deadline_ledger,
+                metadata_hash,
             )
         }
 
@@ -71,6 +73,7 @@ mod contract {
             amount: i128,
             deadline_ledger: u32,
             required_signatures: u32,
+            metadata_hash: Option<soroban_sdk::BytesN<32>>,
         ) -> Result<(), EscrowError> {
             lifecycle::initialize_with_arbiters(
                 env,
@@ -81,6 +84,7 @@ mod contract {
                 amount,
                 deadline_ledger,
                 required_signatures,
+                metadata_hash,
             )
         }
 

--- a/contracts/escrow/src/lifecycle.rs
+++ b/contracts/escrow/src/lifecycle.rs
@@ -38,9 +38,6 @@ fn validate_parties(
     Ok(())
 }
 
-fn validate_parties_multi(buyer: &Address, seller: &Address, arbiters: &Vec<Address>, required_signatures: u32) -> Result<(), EscrowError> {
-    #[allow(clippy::cast_possible_truncation, clippy::as_conversions)]
-    if arbiters.is_empty() || required_signatures == 0 || required_signatures > arbiters.len() as u32 {
 fn validate_parties_multi(
     buyer: &Address,
     seller: &Address,
@@ -100,6 +97,7 @@ pub fn initialize(
     token_contract: Address,
     amount: i128,
     deadline_ledger: u32,
+    metadata_hash: Option<soroban_sdk::BytesN<32>>,
 ) -> Result<(), EscrowError> {
     if env.storage().instance().has(&State) {
         return Err(EscrowError::AlreadyInitialized);
@@ -118,6 +116,9 @@ pub fn initialize(
         deadline_ledger,
         1u32,
     );
+    if let Some(hash) = metadata_hash {
+        env.storage().instance().set(&DataKey::MetadataHash, &hash);
+    }
     extend_ttl(&env);
     emit_init_events(&env, &buyer, &seller, &arbiter, amount);
     Ok(())
@@ -132,6 +133,7 @@ pub fn initialize_with_arbiters(
     amount: i128,
     deadline_ledger: u32,
     required_signatures: u32,
+    metadata_hash: Option<soroban_sdk::BytesN<32>>,
 ) -> Result<(), EscrowError> {
     if env.storage().instance().has(&State) {
         return Err(EscrowError::AlreadyInitialized);
@@ -153,6 +155,9 @@ pub fn initialize_with_arbiters(
         required_signatures,
     );
     env.storage().instance().set(&Arbiters, &arbiters);
+    if let Some(hash) = metadata_hash {
+        env.storage().instance().set(&DataKey::MetadataHash, &hash);
+    }
     extend_ttl(&env);
     emit_init_events(&env, &buyer, &seller, &primary_arbiter, amount);
     Ok(())

--- a/contracts/escrow/src/prop_test.rs
+++ b/contracts/escrow/src/prop_test.rs
@@ -30,7 +30,7 @@ fn setup_escrow<'a>(
     let escrow_addr = env.register_contract(None, EscrowContract);
     let client = EscrowContractClient::new(env, &escrow_addr);
     let deadline = env.ledger().sequence() + MIN_DEADLINE_BUFFER + 10;
-    client.initialize(&buyer, &seller, &arbiter, &token_addr, &amount, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token_addr, &amount, &deadline, &None);
 
     (client, buyer, seller, arbiter, token_addr)
 }
@@ -129,7 +129,7 @@ proptest! {
         let bad_deadline = env.ledger().sequence() + offset; // < MIN_DEADLINE_BUFFER
 
         let result = client.try_initialize(
-            &buyer, &seller, &arbiter, &token_addr, &1000i128, &bad_deadline,
+            &buyer, &seller, &arbiter, &token_addr, &1000i128, &bad_deadline, &None,
         );
         prop_assert!(result.is_err());
     }

--- a/contracts/escrow/src/queries.rs
+++ b/contracts/escrow/src/queries.rs
@@ -15,6 +15,7 @@ pub fn get_escrow_info(env: Env) -> Result<EscrowInfo, EscrowError> {
         amount: get_required(&env, &Amount)?,
         deadline: get_required(&env, &Deadline)?,
         state: get_required(&env, &State)?,
+        metadata_hash: env.storage().instance().get(&MetadataHash),
     })
 }
 

--- a/contracts/escrow/src/storage.rs
+++ b/contracts/escrow/src/storage.rs
@@ -35,6 +35,8 @@ pub enum DataKey {
     RequiredSignatures,
     /// Arbiter votes for dispute resolution (`Vec<Address>`).
     ArbiterVotes,
+    /// Optional off-chain deal reference hash (`BytesN<32>`).
+    MetadataHash,
 }
 
 /// Lifecycle states of an escrow.
@@ -130,6 +132,7 @@ mod tests {
             amount: 1_000i128,
             deadline: 500u32,
             state: EscrowState::Created,
+            metadata_hash: None,
         };
 
         // Round-trip: encode → decode must produce the same value.
@@ -167,6 +170,7 @@ mod tests {
                 "arbiter",
                 "buyer",
                 "deadline",
+                "metadata_hash",
                 "seller",
                 "state",
                 "token_contract"
@@ -226,6 +230,7 @@ mod discriminant_tests {
             DataKey::Arbiters => 10,
             DataKey::RequiredSignatures => 11,
             DataKey::ArbiterVotes => 12,
+            DataKey::MetadataHash => 13,
         }
     }
 
@@ -244,6 +249,7 @@ mod discriminant_tests {
         assert_eq!(escrow_data_key_index(&DataKey::Arbiters), 10);
         assert_eq!(escrow_data_key_index(&DataKey::RequiredSignatures), 11);
         assert_eq!(escrow_data_key_index(&DataKey::ArbiterVotes), 12);
+        assert_eq!(escrow_data_key_index(&DataKey::MetadataHash), 13);
     }
 }
 
@@ -255,7 +261,7 @@ mod discriminant_tests {
 /// `EscrowInfo` is serialised on-chain as an XDR map whose entries are keyed by
 /// field name and sorted alphabetically.  The stable key order is:
 ///
-/// `amount`, `arbiter`, `buyer`, `deadline`, `seller`, `state`, `token_contract`
+/// `amount`, `arbiter`, `buyer`, `deadline`, `metadata_hash`, `seller`, `state`, `token_contract`
 ///
 /// **Renaming, adding, or removing any field is a breaking on-chain ABI change.**
 /// Off-chain clients (SDKs, indexers, test harnesses) that decode this type from
@@ -279,4 +285,6 @@ pub struct EscrowInfo {
     pub deadline: u32,
     /// Current lifecycle state.
     pub state: EscrowState,
+    /// Optional off-chain deal reference hash (32 bytes).
+    pub metadata_hash: Option<soroban_sdk::BytesN<32>>,
 }

--- a/contracts/escrow/src/test.rs
+++ b/contracts/escrow/src/test.rs
@@ -93,7 +93,7 @@ fn setup_funded_escrow<'a>(
     let deadline = env.ledger().sequence() + 100;
 
     let (client, contract_address) = create_escrow_contract(env);
-    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline, &None);
     client.fund();
 
     (
@@ -132,6 +132,7 @@ fn test_initialize() {
         &token_contract,
         &amount,
         &deadline,
+        &None,
     );
 
     let info = client.get_escrow_info();
@@ -194,6 +195,7 @@ fn test_initialize_twice() {
         &token_contract,
         &amount,
         &deadline,
+        &None,
     );
     // Second call must fail with AlreadyInitialized (#5)
     client.initialize(
@@ -203,6 +205,7 @@ fn test_initialize_twice() {
         &token_contract,
         &amount,
         &deadline,
+        &None,
     );
 }
 
@@ -228,6 +231,7 @@ fn test_initialize_past_deadline() {
         &token_contract,
         &amount,
         &deadline,
+        &None,
     );
 }
 
@@ -241,7 +245,7 @@ fn test_initialize_buyer_equals_seller_fails() {
     let token = create_mock_token(&env);
     let deadline = env.ledger().sequence() + 100;
     let (client, _) = create_escrow_contract(&env);
-    client.initialize(&same, &same, &arbiter, &token, &1_000, &deadline);
+    client.initialize(&same, &same, &arbiter, &token, &1_000, &deadline, &None);
 }
 
 #[test]
@@ -254,7 +258,7 @@ fn test_initialize_buyer_equals_arbiter_fails() {
     let token = create_mock_token(&env);
     let deadline = env.ledger().sequence() + 100;
     let (client, _) = create_escrow_contract(&env);
-    client.initialize(&same, &seller, &same, &token, &1_000, &deadline);
+    client.initialize(&same, &seller, &same, &token, &1_000, &deadline, &None);
 }
 
 #[test]
@@ -267,7 +271,7 @@ fn test_initialize_seller_equals_arbiter_fails() {
     let token = create_mock_token(&env);
     let deadline = env.ledger().sequence() + 100;
     let (client, _) = create_escrow_contract(&env);
-    client.initialize(&buyer, &same, &same, &token, &1_000, &deadline);
+    client.initialize(&buyer, &same, &same, &token, &1_000, &deadline, &None);
 }
 
 #[test]
@@ -283,7 +287,7 @@ fn test_initialize_zero_amount_fails() {
     let deadline = env.ledger().sequence() + 100;
 
     let (client, _) = create_escrow_contract(&env);
-    client.initialize(&buyer, &seller, &arbiter, &token, &0, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token, &0, &deadline, &None);
 }
 
 #[test]
@@ -299,7 +303,7 @@ fn test_initialize_negative_amount_fails() {
     let deadline = env.ledger().sequence() + 100;
 
     let (client, _) = create_escrow_contract(&env);
-    client.initialize(&buyer, &seller, &arbiter, &token, &-1, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token, &-1, &deadline, &None);
 }
 
 #[test]
@@ -336,6 +340,7 @@ fn test_fund() {
         &token_contract,
         &amount,
         &deadline,
+        &None,
     );
     client.fund();
 
@@ -484,6 +489,7 @@ fn test_deadline_passed() {
         &token_contract,
         &amount,
         &deadline,
+        &None,
     );
 
     assert_eq!(client.is_deadline_passed(), false);
@@ -542,6 +548,7 @@ fn test_initialize_invalid_token_address() {
         &invalid_token,
         &amount,
         &deadline,
+        &None,
     );
 }
 
@@ -559,7 +566,7 @@ fn test_cancel_by_seller_fails() {
     let deadline = env.ledger().sequence() + 100;
 
     let (client, contract_address) = create_escrow_contract(&env);
-    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline, &None);
 
     // Only authorize the seller — buyer.require_auth() inside cancel() will fail.
     use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
@@ -605,7 +612,7 @@ fn test_fund_insufficient_funds() {
     });
 
     let (client, _) = create_escrow_contract(&env);
-    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline, &None);
     // buyer has balance 0 < amount 1000 → InsufficientFunds (#7)
     client.fund();
 }
@@ -751,7 +758,7 @@ fn test_release_partial_invalid_state() {
     let deadline = env.ledger().sequence() + 100;
 
     let (client, _) = create_escrow_contract(&env);
-    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline, &None);
 
     // Try to release_partial in Created state — should fail with InvalidState
     client.release_partial(&500i128);
@@ -815,7 +822,7 @@ mod pausable_tests {
         env.as_contract(&contract_address, || {
             env.storage().instance().set(&AdminKey::Admin, &admin);
         });
-        client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline);
+        client.initialize(&buyer, &seller, &arbiter, &token, &amount, &deadline, &None);
         (client, admin, buyer)
     }
 
@@ -933,7 +940,7 @@ fn test_update_amount() {
     let deadline = env.ledger().sequence() + 100;
     let (client, _) = create_escrow_contract(&env);
 
-    client.initialize(&buyer, &seller, &arbiter, &token, &1_000, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token, &1_000, &deadline, &None);
 
     // Update amount before funding
     client.update_amount(&2_000);
@@ -954,7 +961,7 @@ fn test_update_amount_zero_fails() {
     let deadline = env.ledger().sequence() + 100;
     let (client, _) = create_escrow_contract(&env);
 
-    client.initialize(&buyer, &seller, &arbiter, &token, &1_000, &deadline);
+    client.initialize(&buyer, &seller, &arbiter, &token, &1_000, &deadline, &None);
     client.update_amount(&0);
 }
 
@@ -983,8 +990,45 @@ fn test_initialize_with_arbiters() {
     let (client, _) = create_escrow_contract(&env);
 
     let arbiters = soroban_sdk::vec![&env, arbiter1.clone(), arbiter2.clone(), arbiter3.clone()];
-    client.initialize_with_arbiters(&buyer, &seller, &arbiters, &token, &1_000, &deadline, &2);
+    client.initialize_with_arbiters(&buyer, &seller, &arbiters, &token, &1_000, &deadline, &2, &None);
 
     let info = client.get_escrow_info();
     assert_eq!(info.amount, 1_000);
+}
+
+// ── #716 metadata_hash tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_initialize_with_metadata_hash_stores_it() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token = create_mock_token(&env);
+    let deadline = env.ledger().sequence() + 100;
+    let (client, _) = create_escrow_contract(&env);
+    let hash = soroban_sdk::BytesN::from_array(&env, &[0xabu8; 32]);
+
+    client.initialize(&buyer, &seller, &arbiter, &token, &1_000, &deadline, &Some(hash.clone()));
+
+    let info = client.get_escrow_info();
+    assert_eq!(info.metadata_hash, Some(hash));
+}
+
+#[test]
+fn test_initialize_without_metadata_hash_is_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let arbiter = Address::generate(&env);
+    let token = create_mock_token(&env);
+    let deadline = env.ledger().sequence() + 100;
+    let (client, _) = create_escrow_contract(&env);
+
+    client.initialize(&buyer, &seller, &arbiter, &token, &1_000, &deadline, &None);
+
+    let info = client.get_escrow_info();
+    assert_eq!(info.metadata_hash, None);
 }

--- a/contracts/multisig/src/errors.rs
+++ b/contracts/multisig/src/errors.rs
@@ -28,6 +28,8 @@ pub enum MultisigError {
     ThresholdNotMet = 9,
     /// Signer-management approval list does not satisfy the threshold.
     InsufficientApprovals = 10,
+    /// The proposal has expired and can no longer be signed or executed.
+    ProposalExpired = 11,
 }
 
 impl_display_error!(
@@ -42,4 +44,5 @@ impl_display_error!(
     AlreadySigned       => "already signed",
     ThresholdNotMet     => "threshold not met",
     InsufficientApprovals => "insufficient approvals",
+    ProposalExpired     => "proposal expired",
 );

--- a/contracts/multisig/src/events.rs
+++ b/contracts/multisig/src/events.rs
@@ -31,3 +31,8 @@ pub fn transaction_executed(env: &Env, tx_id: u64) {
     env.events()
         .publish((Symbol::new(env, "executed"), tx_id), ());
 }
+
+pub fn proposal_expired(env: &Env, tx_id: u64) {
+    env.events()
+        .publish((Symbol::new(env, "expired"), tx_id), ());
+}

--- a/contracts/multisig/src/lib.rs
+++ b/contracts/multisig/src/lib.rs
@@ -187,11 +187,12 @@ mod contract {
             target: Address,
             function: Symbol,
             args: Vec<Val>,
+            expiry_ledgers: u32,
         ) -> Result<u64, MultisigError> {
             Self::require_signer(&env, &proposer)?;
             proposer.require_auth();
 
-            let tx_id = Self::propose_phase(&env, &proposer, target, function, args)?;
+            let tx_id = Self::propose_phase(&env, &proposer, target, function, args, expiry_ledgers)?;
             events::transaction_proposed(&env, tx_id, &proposer);
             Ok(tx_id)
         }
@@ -245,6 +246,29 @@ mod contract {
             Self::get_transaction(env, tx_id).map(|tx| tx.signatures.len())
         }
 
+        /// Remove an expired proposal from storage. Anyone may call this.
+        ///
+        /// Returns `Ok(())` when the proposal was found and expired.
+        /// Returns `Err(TransactionNotFound)` if the proposal does not exist.
+        /// Returns `Err(AlreadyExecuted)` if the proposal was already executed.
+        /// Returns `Err(ProposalExpired)` — actually succeeds silently if not yet expired
+        ///   (to avoid griefing); callers should check `get_transaction` themselves.
+        pub fn cleanup_expired(env: Env, tx_id: u64) -> Result<(), MultisigError> {
+            let transaction = Self::get_required_transaction(&env, tx_id)?;
+            if transaction.executed {
+                return Err(MultisigError::AlreadyExecuted);
+            }
+            if env.ledger().sequence() <= transaction.expiry_ledger {
+                // Not yet expired — nothing to clean up.
+                return Err(MultisigError::ProposalExpired);
+            }
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Transaction(tx_id));
+            events::proposal_expired(&env, tx_id);
+            Ok(())
+        }
+
         // ── Phase helpers ────────────────────────────────────────────────────────
 
         /// Phase 1 — create a new proposal and record the proposer's implicit vote.
@@ -255,6 +279,7 @@ mod contract {
             target: Address,
             function: Symbol,
             args: Vec<Val>,
+            expiry_ledgers: u32,
         ) -> Result<u64, MultisigError> {
             let tx_id: u64 = env
                 .storage()
@@ -264,6 +289,8 @@ mod contract {
             let mut signatures = Vec::new(env);
             signatures.push_back(proposer.clone());
 
+            let expiry_ledger = env.ledger().sequence().saturating_add(expiry_ledgers);
+
             let transaction = Transaction {
                 id: tx_id,
                 proposer: proposer.clone(),
@@ -272,6 +299,7 @@ mod contract {
                 args,
                 signatures,
                 executed: false,
+                expiry_ledger,
             };
 
             env.storage()
@@ -292,6 +320,9 @@ mod contract {
             if transaction.executed {
                 return Err(MultisigError::AlreadyExecuted);
             }
+            if env.ledger().sequence() > transaction.expiry_ledger {
+                return Err(MultisigError::ProposalExpired);
+            }
             if contains(&transaction.signatures, signer) {
                 return Err(MultisigError::AlreadySigned);
             }
@@ -311,6 +342,9 @@ mod contract {
             let mut transaction = Self::get_required_transaction(env, tx_id)?;
             if transaction.executed {
                 return Err(MultisigError::AlreadyExecuted);
+            }
+            if env.ledger().sequence() > transaction.expiry_ledger {
+                return Err(MultisigError::ProposalExpired);
             }
 
             let threshold: u32 = env

--- a/contracts/multisig/src/storage.rs
+++ b/contracts/multisig/src/storage.rs
@@ -24,4 +24,6 @@ pub struct Transaction {
     pub args: Vec<Val>,
     pub signatures: Vec<Address>,
     pub executed: bool,
+    /// Ledger sequence after which this proposal is considered expired.
+    pub expiry_ledger: u32,
 }

--- a/contracts/multisig/src/test.rs
+++ b/contracts/multisig/src/test.rs
@@ -157,6 +157,7 @@ fn propose_transaction_stores_transaction_and_auto_signature() {
         &target,
         &Symbol::new(&env, "increment"),
         &vec![&env, 7u32.into_val(&env)],
+        &100u32,
     );
 
     let transaction = client.get_transaction(&tx_id).expect("transaction exists");
@@ -182,6 +183,7 @@ fn non_signer_cannot_propose_transaction() {
         &target,
         &Symbol::new(&env, "increment"),
         &vec![&env, 1u32.into_val(&env)],
+        &100u32,
     );
 }
 
@@ -197,6 +199,7 @@ fn signer_cannot_sign_same_transaction_twice() {
         &target,
         &Symbol::new(&env, "increment"),
         &vec![&env, 1u32.into_val(&env)],
+        &100u32,
     );
 
     client.sign_transaction(&alice, &tx_id);
@@ -214,6 +217,7 @@ fn execute_rejects_when_threshold_not_met() {
         &target,
         &Symbol::new(&env, "increment"),
         &vec![&env, 1u32.into_val(&env)],
+        &100u32,
     );
 
     client.execute_transaction(&tx_id);
@@ -231,6 +235,7 @@ fn execute_runs_target_call_once_when_threshold_met() {
         &target,
         &Symbol::new(&env, "increment"),
         &vec![&env, 5u32.into_val(&env)],
+        &100u32,
     );
 
     client.sign_transaction(&bob, &tx_id);
@@ -259,9 +264,123 @@ fn execute_rejects_second_execution() {
         &target,
         &Symbol::new(&env, "increment"),
         &vec![&env, 5u32.into_val(&env)],
+        &100u32,
     );
 
     client.sign_transaction(&bob, &tx_id);
     client.execute_transaction(&tx_id);
     client.execute_transaction(&tx_id);
+}
+
+// ── #715 proposal expiry tests ───────────────────────────────────────────────
+
+#[test]
+fn proposal_stores_expiry_ledger() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, _, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 1u32.into_val(&env)],
+        &50u32,
+    );
+
+    let tx = client.get_transaction(&tx_id).expect("transaction exists");
+    assert_eq!(tx.expiry_ledger, env.ledger().sequence() + 50);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn sign_after_expiry_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, bob, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 1u32.into_val(&env)],
+        &10u32,
+    );
+
+    // Advance ledger past expiry
+    env.ledger().with_mut(|l| l.sequence_number += 11);
+    client.sign_transaction(&bob, &tx_id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn execute_after_expiry_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, bob, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 1u32.into_val(&env)],
+        &10u32,
+    );
+    client.sign_transaction(&bob, &tx_id);
+
+    // Advance ledger past expiry
+    env.ledger().with_mut(|l| l.sequence_number += 11);
+    client.execute_transaction(&tx_id);
+}
+
+#[test]
+fn cleanup_expired_removes_proposal_and_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, _, _, contract_address) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 1u32.into_val(&env)],
+        &10u32,
+    );
+
+    // Advance past expiry
+    env.ledger().with_mut(|l| l.sequence_number += 11);
+    client.cleanup_expired(&tx_id);
+
+    // Proposal should be gone
+    assert_eq!(client.get_transaction(&tx_id), None);
+
+    // expired event emitted
+    let found = env.events().all().iter().any(|(_, topics, _)| {
+        topics == (Symbol::new(&env, "expired"), tx_id).into_val(&env)
+    });
+    assert!(found, "expired event not emitted");
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn cleanup_not_yet_expired_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, alice, _, _, _) = create_multisig(&env);
+    let target = env.register_contract(None, CounterContract);
+
+    let tx_id = client.propose_transaction(
+        &alice,
+        &target,
+        &Symbol::new(&env, "increment"),
+        &vec![&env, 1u32.into_val(&env)],
+        &100u32,
+    );
+
+    // Not yet expired — should fail
+    client.cleanup_expired(&tx_id);
 }

--- a/contracts/token/Cargo.toml
+++ b/contracts/token/Cargo.toml
@@ -11,6 +11,7 @@ pausable = []
 upgradeable = []
 capped-supply = []
 freeze = []
+transfer-hook = []
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/token/src/events.rs
+++ b/contracts/token/src/events.rs
@@ -114,3 +114,12 @@ pub fn upgraded(env: &Env, admin: &Address, new_wasm_hash: &soroban_sdk::BytesN<
         new_wasm_hash.clone(),
     );
 }
+
+/// Emitted when the transfer hook address is changed.
+/// Topics: (Symbol, Address) — event name, admin
+pub fn transfer_hook_set(env: &Env, admin: &Address, hook: Option<&Address>) {
+    env.events().publish(
+        (Symbol::new(env, "hook_set"), admin.clone()),
+        hook.cloned(),
+    );
+}

--- a/contracts/token/src/lib.rs
+++ b/contracts/token/src/lib.rs
@@ -460,6 +460,42 @@ mod contract {
         }
     }
 
+    /// Transfer hook — only compiled when the `transfer-hook` feature is enabled.
+    #[cfg(feature = "transfer-hook")]
+    #[contractimpl]
+    impl TokenContract {
+        /// Set (or clear) the optional transfer hook contract address. Admin only.
+        ///
+        /// Pass `None` to disable the hook. When set, every transfer will attempt
+        /// to call `on_transfer(from, to, amount)` on the hook contract. A failure
+        /// in the hook does NOT revert the transfer.
+        pub fn set_transfer_hook(
+            env: Env,
+            hook: Option<Address>,
+        ) -> Result<(), TokenError> {
+            let admin = require_admin(&env)?;
+            admin.require_auth();
+            match hook {
+                Some(ref addr) => {
+                    env.storage()
+                        .instance()
+                        .set(&DataKey::TransferHook, addr);
+                }
+                None => {
+                    env.storage().instance().remove(&DataKey::TransferHook);
+                }
+            }
+            extend_ttl_instance(&env, LEDGER_LIFETIME_THRESHOLD, LEDGER_BUMP_AMOUNT);
+            events::transfer_hook_set(&env, &admin, hook.as_ref());
+            Ok(())
+        }
+
+        /// Return the current transfer hook address, if any.
+        pub fn get_transfer_hook(env: Env) -> Option<Address> {
+            env.storage().instance().get(&DataKey::TransferHook)
+        }
+    }
+
     impl TokenContract {
         pub(crate) fn update_balance(
             env: &Env,
@@ -502,6 +538,30 @@ mod contract {
             Self::update_balance(env, &from, -amount)?;
             Self::update_balance(env, &to, amount)?;
             events::transferred(env, &from, &to, amount);
+
+            // Transfer hook: fire-and-forget, failure does NOT revert the transfer.
+            #[cfg(feature = "transfer-hook")]
+            {
+                if let Some(hook_addr) = env
+                    .storage()
+                    .instance()
+                    .get::<DataKey, Address>(&DataKey::TransferHook)
+                {
+                    let args = soroban_sdk::vec![
+                        env,
+                        soroban_sdk::IntoVal::<soroban_sdk::Env, soroban_sdk::Val>::into_val(&from, env),
+                        soroban_sdk::IntoVal::<soroban_sdk::Env, soroban_sdk::Val>::into_val(&to, env),
+                        soroban_sdk::IntoVal::<soroban_sdk::Env, soroban_sdk::Val>::into_val(&amount, env),
+                    ];
+                    // Ignore the return value and any error from the hook.
+                    let _ = env.try_invoke_contract::<soroban_sdk::Val, soroban_sdk::Error>(
+                        &hook_addr,
+                        &soroban_sdk::Symbol::new(env, "on_transfer"),
+                        args,
+                    );
+                }
+            }
+
             Ok(())
         }
     }

--- a/contracts/token/src/storage.rs
+++ b/contracts/token/src/storage.rs
@@ -21,6 +21,8 @@ pub enum DataKey {
     Version,
     /// Instance storage – frozen accounts set (`bool` per address).
     Frozen(Address),
+    /// Instance storage – optional transfer hook contract address (`Address`).
+    TransferHook,
 }
 
 #[contracttype]
@@ -69,6 +71,7 @@ mod discriminant_tests {
             DataKey::PendingUpgrade => 8,
             DataKey::Version => 9,
             DataKey::Frozen(_) => 10,
+            DataKey::TransferHook => 11,
         }
     }
 
@@ -103,6 +106,7 @@ mod discriminant_tests {
         assert_eq!(token_data_key_index(&DataKey::PendingUpgrade), 8);
         assert_eq!(token_data_key_index(&DataKey::Version), 9);
         assert_eq!(token_data_key_index(&DataKey::Frozen(addr)), 10);
+        assert_eq!(token_data_key_index(&DataKey::TransferHook), 11);
     }
 
     #[test]

--- a/contracts/token/src/test.rs
+++ b/contracts/token/src/test.rs
@@ -1019,3 +1019,93 @@ fn test_cancel_admin_proposal_by_non_admin_fails() {
     }]);
     client.cancel_admin_proposal();
 }
+
+// ── #714 transfer hook tests ─────────────────────────────────────────────────
+
+#[cfg(feature = "transfer-hook")]
+mod transfer_hook_tests {
+    use super::*;
+    use soroban_sdk::{contract, contractimpl, Symbol, IntoVal, testutils::Events as _};
+
+    /// Minimal mock hook contract that records calls via an event.
+    #[contract]
+    pub struct MockHook;
+
+    #[contractimpl]
+    impl MockHook {
+        pub fn on_transfer(env: Env, from: Address, to: Address, amount: i128) {
+            env.events().publish(
+                (Symbol::new(&env, "hook_called"), from, to),
+                amount,
+            );
+        }
+    }
+
+    #[test]
+    fn set_transfer_hook_stores_address() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let client = init_token(&env, &admin);
+        let hook_addr = env.register_contract(None, MockHook);
+
+        client.set_transfer_hook(&Some(hook_addr.clone()));
+        assert_eq!(client.get_transfer_hook(), Some(hook_addr));
+    }
+
+    #[test]
+    fn clear_transfer_hook_removes_address() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let client = init_token(&env, &admin);
+        let hook_addr = env.register_contract(None, MockHook);
+
+        client.set_transfer_hook(&Some(hook_addr));
+        client.set_transfer_hook(&None);
+        assert_eq!(client.get_transfer_hook(), None);
+    }
+
+    #[test]
+    fn transfer_calls_hook_and_does_not_revert() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let client = init_token(&env, &admin);
+        let hook_addr = env.register_contract(None, MockHook);
+
+        client.mint(&from, &1_000i128);
+        client.set_transfer_hook(&Some(hook_addr.clone()));
+        client.transfer(&from, &to, &500i128);
+
+        // Balances updated correctly
+        assert_eq!(client.balance(&from), 500);
+        assert_eq!(client.balance(&to), 500);
+
+        // Hook was called
+        let found = env.events().all().iter().any(|(addr, topics, _)| {
+            *addr == hook_addr
+                && topics
+                    == (Symbol::new(&env, "hook_called"), from.clone(), to.clone())
+                        .into_val(&env)
+        });
+        assert!(found, "hook_called event not emitted");
+    }
+
+    #[test]
+    fn transfer_without_hook_set_does_not_revert() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let from = Address::generate(&env);
+        let to = Address::generate(&env);
+        let client = init_token(&env, &admin);
+
+        client.mint(&from, &1_000i128);
+        // No hook set — transfer should still succeed
+        client.transfer(&from, &to, &300i128);
+        assert_eq!(client.balance(&to), 300);
+    }
+}

--- a/contracts/vesting/src/errors.rs
+++ b/contracts/vesting/src/errors.rs
@@ -20,4 +20,6 @@ pub enum VestingError {
     NothingToClaim = 6,
     /// The vesting schedule has already been revoked.
     AlreadyRevoked = 7,
+    /// admin_release was called after the cliff has already passed.
+    CliffAlreadyPassed = 8,
 }

--- a/contracts/vesting/src/events.rs
+++ b/contracts/vesting/src/events.rs
@@ -22,3 +22,8 @@ pub fn revoked(env: &Env, admin: &Address, returned: i128) {
     env.events()
         .publish((Symbol::new(env, "revoked"), admin.clone()), returned);
 }
+
+pub fn admin_released(env: &Env, admin: &Address, amount: i128) {
+    env.events()
+        .publish((Symbol::new(env, "admin_released"), admin.clone()), amount);
+}

--- a/contracts/vesting/src/lib.rs
+++ b/contracts/vesting/src/lib.rs
@@ -280,6 +280,105 @@ mod contract {
             Ok(returnable)
         }
 
+        /// Emergency unlock: admin releases all tokens to the beneficiary before the cliff.
+        ///
+        /// Only callable before the cliff ledger. Transfers the full unvested amount
+        /// to the beneficiary, emits an `admin_released` event, and records the
+        /// released amount in an on-chain audit-log entry.
+        ///
+        /// # Errors
+        /// - [`VestingError::NotInitialized`] if the contract has not been initialized.
+        /// - [`VestingError::Unauthorized`] if the caller is not the admin.
+        /// - [`VestingError::AlreadyRevoked`] if the schedule has already been revoked.
+        /// - [`VestingError::CliffAlreadyPassed`] if the cliff has already been reached.
+        /// - [`VestingError::NothingToClaim`] if there are no tokens left to release.
+        pub fn admin_release(env: Env) -> Result<i128, VestingError> {
+            if !env.storage().instance().has(&DataKey::Admin) {
+                return Err(VestingError::NotInitialized);
+            }
+
+            let revoked: bool = env
+                .storage()
+                .instance()
+                .get(&DataKey::Revoked)
+                .unwrap_or(false);
+            if revoked {
+                return Err(VestingError::AlreadyRevoked);
+            }
+
+            let admin: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .ok_or(VestingError::NotInitialized)?;
+            admin.require_auth();
+
+            let cliff_ledger: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::CliffLedger)
+                .ok_or(VestingError::NotInitialized)?;
+
+            // Only callable before the cliff.
+            if env.ledger().sequence() >= cliff_ledger {
+                return Err(VestingError::CliffAlreadyPassed);
+            }
+
+            let amount: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey::Amount)
+                .ok_or(VestingError::NotInitialized)?;
+            let claimed: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey::Claimed)
+                .ok_or(VestingError::NotInitialized)?;
+
+            let releasable = amount - claimed;
+            if releasable <= 0 {
+                return Err(VestingError::NothingToClaim);
+            }
+
+            let beneficiary: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Beneficiary)
+                .ok_or(VestingError::NotInitialized)?;
+            let token: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Token)
+                .ok_or(VestingError::NotInitialized)?;
+
+            // Mark as revoked, cap amount to zero (nothing more to claim).
+            env.storage().instance().set(&DataKey::Revoked, &true);
+            env.storage().instance().set(&DataKey::Amount, &releasable);
+            env.storage()
+                .instance()
+                .set(&DataKey::Claimed, &releasable);
+
+            // Audit log: accumulate total admin-released tokens.
+            let prev_released: i128 = env
+                .storage()
+                .instance()
+                .get(&DataKey::AdminReleased)
+                .unwrap_or(0);
+            env.storage()
+                .instance()
+                .set(&DataKey::AdminReleased, &(prev_released + releasable));
+
+            token::Client::new(&env, &token).transfer(
+                &env.current_contract_address(),
+                &beneficiary,
+                &releasable,
+            );
+
+            bump(&env);
+            events::admin_released(&env, &admin, releasable);
+            Ok(releasable)
+        }
+
         /// Returns a snapshot of the vesting schedule, or `None` if uninitialized.
         pub fn get_info(env: Env) -> Option<VestingInfo> {
             if !env.storage().instance().has(&DataKey::Admin) {

--- a/contracts/vesting/src/storage.rs
+++ b/contracts/vesting/src/storage.rs
@@ -22,6 +22,8 @@ pub enum DataKey {
     Revoked,
     /// Admin address.
     Admin,
+    /// Total tokens released early by admin (audit log).
+    AdminReleased,
 }
 
 /// Snapshot returned by `get_info`.

--- a/contracts/vesting/src/test.rs
+++ b/contracts/vesting/src/test.rs
@@ -320,3 +320,58 @@ proptest! {
         }
     }
 }
+
+// ── #712 admin_release tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_admin_release_before_cliff_sends_all_to_beneficiary() {
+    let env = setup_env();
+    let (client, _admin, beneficiary, token, _cliff, _end, amount) = setup(&env);
+    // Still before cliff (ledger = 100, cliff = 110)
+    let released = client.admin_release();
+    assert_eq!(released, amount);
+    let token_client = soroban_sdk::token::Client::new(&env, &token);
+    assert_eq!(token_client.balance(&beneficiary), amount);
+}
+
+#[test]
+fn test_admin_release_marks_revoked() {
+    let env = setup_env();
+    let (client, ..) = setup(&env);
+    client.admin_release();
+    let info = client.get_info().unwrap();
+    assert!(info.revoked);
+}
+
+#[test]
+fn test_admin_release_after_cliff_fails() {
+    let env = setup_env();
+    let (client, _admin, _beneficiary, _token, cliff, _end, _amount) = setup(&env);
+    // Advance past cliff
+    env.ledger().with_mut(|l| l.sequence_number = cliff);
+    let result = client.try_admin_release();
+    assert_eq!(result, Err(Ok(VestingError::CliffAlreadyPassed)));
+}
+
+#[test]
+fn test_admin_release_twice_fails() {
+    let env = setup_env();
+    let (client, ..) = setup(&env);
+    client.admin_release();
+    let result = client.try_admin_release();
+    assert_eq!(result, Err(Ok(VestingError::AlreadyRevoked)));
+}
+
+#[test]
+fn test_admin_release_emits_event() {
+    let env = setup_env();
+    let (client, admin, _beneficiary, _token, _cliff, _end, amount) = setup(&env);
+    client.admin_release();
+    use soroban_sdk::{IntoVal, Symbol, testutils::Events as _};
+    let all = env.events().all();
+    let found = all.iter().any(|(_, topics, data)| {
+        topics == (Symbol::new(&env, "admin_released"), admin.clone()).into_val(&env)
+            && data == amount.into_val(&env)
+    });
+    assert!(found, "admin_released event not emitted");
+}


### PR DESCRIPTION
Here's the full PR description — ready to paste into GitHub:

---

**Title:** `feat: vesting admin_release, token transfer-hook, multisig proposal expiry, escrow metadata_hash`

---

## Summary

This PR implements four independent features across four contracts, each tracked by its own issue. All changes are additive and backward-compatible where possible, with breaking signature changes (escrow `initialize`, multisig `propose_transaction`) fully reflected in tests.

---

## Changes

### Closes #712 — Vesting: Admin Emergency Release Before Cliff

**Contract:** `contracts/vesting`

The admin can now call `admin_release()` to immediately unlock and transfer all unvested tokens to the beneficiary before the cliff, covering emergency situations.

**What changed:**
- New `admin_release() -> Result<i128, VestingError>` function on `VestingContract`
- Only callable before `cliff_ledger` — reverts with `CliffAlreadyPassed` if the cliff has passed
- Transfers the full remaining balance to the beneficiary in a single call
- Marks the schedule as revoked so no further claims or releases are possible
- Accumulates the released amount in a new `AdminReleased` instance storage key as an on-chain audit log
- Emits `admin_released` event with `(admin_address, amount)` as topics/data
- New error variant: `CliffAlreadyPassed = 8`
- New storage key: `AdminReleased`
- New event: `admin_released`

**Tests added:**
- Happy path: tokens land in beneficiary wallet
- Revoked flag is set after release
- Call after cliff reverts with `CliffAlreadyPassed`
- Second call reverts with `AlreadyRevoked`
- Event emission verified

---

### Closes #714 — Token: Optional Transfer Hook (`transfer-hook` feature)

**Contract:** `contracts/token`

An optional `transfer_hook` contract address can be registered. After every successful transfer, the hook's `on_transfer(from, to, amount)` is called. Inspired by ERC-777. Hook failure never reverts the transfer (fire-and-forget).

**What changed:**
- New Cargo feature: `transfer-hook`
- New storage key: `TransferHook` (appended at index 11, discriminant-stable)
- New admin function: `set_transfer_hook(hook: Option<Address>)` — pass `None` to clear
- New query: `get_transfer_hook() -> Option<Address>`
- `transfer_impl` calls `env.try_invoke_contract(hook, "on_transfer", [from, to, amount])` when a hook is set, ignoring any returned error
- Emits `hook_set` event on change
- All hook logic is gated behind `#[cfg(feature = "transfer-hook")]`

**Tests added** (in `#[cfg(feature = "transfer-hook")]` module):
- Set hook stores address
- Clear hook removes address
- Transfer invokes hook and emits `hook_called` event
- Transfer without hook set succeeds normally

---

### Closes #715 — Multisig: Proposal Expiry After N Ledgers

**Contract:** `contracts/multisig`

Proposals that fail to gather enough signatures within a configurable window now expire automatically rather than remaining open indefinitely.

**What changed:**
- `propose_transaction` gains a new required parameter: `expiry_ledgers: u32`
- `Transaction` struct gains `expiry_ledger: u32` (stored as `current_ledger + expiry_ledgers`)
- `sign_transaction` and `execute_transaction` both check expiry and revert with `ProposalExpired` if the ledger has passed
- New public function: `cleanup_expired(tx_id: u64) -> Result<(), MultisigError>` — removes the expired proposal from persistent storage and emits `expired` event. Returns `ProposalExpired` if the proposal has not yet expired (to prevent premature cleanup)
- New error variant: `ProposalExpired = 11`
- New event: `expired`
- All existing tests updated to pass `&100u32` for `expiry_ledgers`

**Tests added:**
- `proposal_stores_expiry_ledger` — verifies `expiry_ledger = sequence + N`
- `sign_after_expiry_fails` — reverts with `#11`
- `execute_after_expiry_fails` — reverts with `#11`
- `cleanup_expired_removes_proposal_and_emits_event` — storage cleared, event emitted
- `cleanup_not_yet_expired_fails` — reverts with `#11`

---

### Closes #716 — Escrow: Optional Off-Chain Deal Reference Hash

**Contract:** `contracts/escrow`

An optional `metadata_hash: Option<BytesN<32>>` can be passed at init time, linking the on-chain escrow to an off-chain deal document (e.g. a hash of a PDF contract or IPFS CID).

**What changed:**
- New storage key: `MetadataHash` (appended at index 13, discriminant-stable)
- `EscrowInfo` struct gains `metadata_hash: Option<BytesN<32>>`
- `initialize()` and `initialize_with_arbiters()` both accept `metadata_hash: Option<BytesN<32>>` as a final parameter — stored when `Some`, omitted when `None`
- `get_escrow_info()` includes the field in the response
- XDR ABI snapshot test updated to reflect new field (`metadata_hash` sorts between `deadline` and `seller` alphabetically)
- Discriminant stability test updated to cover `MetadataHash = 13`
- All existing `initialize` and `try_initialize` calls in `test.rs` and `prop_test.rs` updated to pass `&None`

**Tests added:**
- `test_initialize_with_metadata_hash_stores_it` — round-trip verify stored hash equals provided hash
- `test_initialize_without_metadata_hash_is_none` — `get_escrow_info().metadata_hash` is `None` when not provided

---

## Notes

- No existing behavior is changed for any contract when the new parameters are `None` / default
- The `transfer-hook` feature is opt-in and has zero overhead when not compiled in
- The `expiry_ledgers` param on `propose_transaction` is a breaking change to the multisig ABI — callers must be updated
- The `metadata_hash` and `initialize` signature changes to escrow are breaking — all callers updated in this PR
- Discriminant stability tests were updated in both `escrow/storage.rs` and `token/storage.rs` to keep the compile-time ABI guards accurate