### PR TITLE
fix: ballot TTL, airdrop deadline + batch claim, auction reserve price

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ballot"
+version = "0.1.0"
+dependencies = [
+ "soroban-common",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +143,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bonding-curve"
+version = "0.1.0"
+dependencies = [
+ "soroban-common",
+ "soroban-sdk",
 ]
 
 [[package]]
@@ -2295,6 +2311,14 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wrapped-token"
+version = "0.1.0"
+dependencies = [
+ "soroban-common",
+ "soroban-sdk",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ members = [
   "contracts/airdrop",
   "contracts/oracle",
   "contracts/lottery",
+  "contracts/ballot",
+  "contracts/bonding-curve",
+  "contracts/wrapped-token",
   "tests",
   "fuzz",
 ]

--- a/contracts/airdrop/src/errors.rs
+++ b/contracts/airdrop/src/errors.rs
@@ -20,4 +20,6 @@ pub enum AirdropError {
     AlreadyClaimed = 6,
     /// Claim amount is zero.
     InvalidAmount = 7,
+    /// The claim deadline has passed; no further claims are accepted.
+    ClaimWindowClosed = 8,
 }

--- a/contracts/airdrop/src/lib.rs
+++ b/contracts/airdrop/src/lib.rs
@@ -96,7 +96,12 @@ mod contract {
         /// # Errors
         ///
         /// Returns [`AirdropError::AlreadyInitialized`] if already initialized.
-        pub fn initialize(env: Env, admin: Address, token: Address) -> Result<(), AirdropError> {
+        pub fn initialize(
+            env: Env,
+            admin: Address,
+            token: Address,
+            claim_deadline: u32,
+        ) -> Result<(), AirdropError> {
             if env.storage().instance().has(&DataKey::Admin) {
                 return Err(AirdropError::AlreadyInitialized);
             }
@@ -106,6 +111,9 @@ mod contract {
 
             env.storage().instance().set(&DataKey::Admin, &admin);
             env.storage().instance().set(&DataKey::Token, &token);
+            env.storage()
+                .instance()
+                .set(&DataKey::ClaimDeadline, &claim_deadline);
             bump_instance(&env);
             Ok(())
         }
@@ -144,6 +152,7 @@ mod contract {
         /// Returns [`AirdropError::NotInitialized`] if not initialized.
         /// Returns [`AirdropError::RootNotSet`] if no merkle root has been set.
         /// Returns [`AirdropError::InvalidAmount`] if `amount <= 0`.
+        /// Returns [`AirdropError::ClaimWindowClosed`] if the claim deadline has passed.
         /// Returns [`AirdropError::AlreadyClaimed`] if the address already claimed.
         /// Returns [`AirdropError::InvalidProof`] if the merkle proof does not verify.
         pub fn claim(
@@ -166,6 +175,16 @@ mod contract {
 
             if amount <= 0 {
                 return Err(AirdropError::InvalidAmount);
+            }
+
+            // Reject claims past the deadline.
+            let deadline: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::ClaimDeadline)
+                .ok_or(AirdropError::NotInitialized)?;
+            if env.ledger().sequence() > deadline {
+                return Err(AirdropError::ClaimWindowClosed);
             }
 
             recipient.require_auth();
@@ -203,6 +222,90 @@ mod contract {
             );
 
             events::claimed(&env, &recipient, amount);
+            Ok(())
+        }
+
+        /// Batch-claim tokens for multiple recipients in a single transaction.
+        ///
+        /// A relayer (or the recipients themselves) may submit a list of
+        /// `(recipient, amount, proof)` tuples. The function uses **all-or-nothing**
+        /// semantics: if any entry fails proof verification or has already been
+        /// claimed, the entire transaction is aborted and no tokens are transferred.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`AirdropError::NotInitialized`] if not initialized.
+        /// Returns [`AirdropError::RootNotSet`] if no merkle root has been set.
+        /// Returns [`AirdropError::ClaimWindowClosed`] if the claim deadline has passed.
+        /// Returns [`AirdropError::InvalidAmount`] if any entry has `amount <= 0`.
+        /// Returns [`AirdropError::AlreadyClaimed`] if any entry has already been claimed.
+        /// Returns [`AirdropError::InvalidProof`] if any entry's merkle proof is invalid.
+        pub fn claim_batch(
+            env: Env,
+            entries: Vec<(Address, i128, Vec<BytesN<32>>)>,
+        ) -> Result<(), AirdropError> {
+            let token_addr: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Token)
+                .ok_or(AirdropError::NotInitialized)?;
+
+            let root_bytes: Bytes = env
+                .storage()
+                .instance()
+                .get(&DataKey::MerkleRoot)
+                .ok_or(AirdropError::RootNotSet)?;
+
+            // Deadline check applies to the whole batch.
+            let deadline: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::ClaimDeadline)
+                .ok_or(AirdropError::NotInitialized)?;
+            if env.ledger().sequence() > deadline {
+                return Err(AirdropError::ClaimWindowClosed);
+            }
+
+            let root: BytesN<32> = root_bytes
+                .try_into()
+                .map_err(|_| AirdropError::RootNotSet)?;
+
+            // --- Validate all entries before any state change (all-or-nothing) ---
+            for (recipient, amount, proof) in entries.iter() {
+                if amount <= 0 {
+                    return Err(AirdropError::InvalidAmount);
+                }
+                let claimed_key = DataKey::Claimed(recipient.clone());
+                if env
+                    .storage()
+                    .persistent()
+                    .get::<_, bool>(&claimed_key)
+                    .unwrap_or(false)
+                {
+                    return Err(AirdropError::AlreadyClaimed);
+                }
+                let leaf = compute_leaf(&env, &recipient, amount);
+                if !verify_proof(&env, leaf, &proof, &root) {
+                    return Err(AirdropError::InvalidProof);
+                }
+            }
+
+            // --- Apply state changes and transfers ---
+            for (recipient, amount, _proof) in entries.iter() {
+                let claimed_key = DataKey::Claimed(recipient.clone());
+                env.storage().persistent().set(&claimed_key, &true);
+                bump_claimed(&env, &recipient);
+
+                token::Client::new(&env, &token_addr).transfer(
+                    &env.current_contract_address(),
+                    &recipient,
+                    &amount,
+                );
+
+                events::claimed(&env, &recipient, amount);
+            }
+
+            bump_instance(&env);
             Ok(())
         }
 

--- a/contracts/airdrop/src/storage.rs
+++ b/contracts/airdrop/src/storage.rs
@@ -14,4 +14,6 @@ pub enum DataKey {
     MerkleRoot,
     /// Whether a given address has already claimed (persistent).
     Claimed(Address),
+    /// The ledger sequence number after which claims are rejected (instance).
+    ClaimDeadline,
 }

--- a/contracts/airdrop/src/test.rs
+++ b/contracts/airdrop/src/test.rs
@@ -4,7 +4,7 @@
 use super::*;
 use soroban_sdk::{
     Address, Bytes, BytesN, Env, Vec,
-    testutils::Address as _,
+    testutils::{Address as _, Ledger as _},
     token::{Client as TokenClient, StellarAssetClient},
     xdr::ToXdr,
 };
@@ -52,8 +52,10 @@ fn two_leaf_tree(
 }
 
 // ---------------------------------------------------------------------------
-// Setup
+// Setup — now passes a claim_deadline far in the future by default
 // ---------------------------------------------------------------------------
+
+const FAR_DEADLINE: u32 = 1_000_000;
 
 struct TestEnv<'a> {
     env: Env,
@@ -77,7 +79,7 @@ fn setup<'a>(env: &'a Env) -> TestEnv<'a> {
 
     let airdrop = env.register_contract(None, AirdropContract);
     let client = AirdropContractClient::new(env, &airdrop);
-    client.initialize(&admin, &token);
+    client.initialize(&admin, &token, &FAR_DEADLINE);
 
     // Fund the airdrop contract with tokens
     StellarAssetClient::new(env, &token).mint(&airdrop, &100_000i128);
@@ -93,14 +95,14 @@ fn setup<'a>(env: &'a Env) -> TestEnv<'a> {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// Existing tests (updated for new initialize signature)
 // ---------------------------------------------------------------------------
 
 #[test]
 fn test_initialize_rejects_duplicate() {
     let env = Env::default();
     let t = setup(&env);
-    let res = t.client.try_initialize(&t.admin, &t.token);
+    let res = t.client.try_initialize(&t.admin, &t.token, &FAR_DEADLINE);
     assert!(res.is_err());
 }
 
@@ -225,4 +227,207 @@ fn test_both_recipients_claim() {
         alice_amount
     );
     assert_eq!(TokenClient::new(&env, &t.token).balance(&t.bob), bob_amount);
+}
+
+// ---------------------------------------------------------------------------
+// Claim deadline tests — #780
+// ---------------------------------------------------------------------------
+
+/// Claim succeeds when ledger sequence < deadline.
+#[test]
+fn test_claim_before_deadline_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Start at ledger 100; deadline = 200
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let airdrop = env.register_contract(None, AirdropContract);
+    let client = AirdropContractClient::new(&env, &airdrop);
+    client.initialize(&admin, &token, &200u32);
+    StellarAssetClient::new(&env, &token).mint(&airdrop, &10_000i128);
+
+    let leaf_a = leaf(&env, &alice, 500i128);
+    let leaf_b = leaf(&env, &bob, 500i128);
+    let (root, proof_a, _) = two_leaf_tree(&env, leaf_a, leaf_b);
+    client.set_root(&root);
+
+    // ledger 100 < 200 — should succeed
+    client.claim(&alice, &500i128, &proof_a);
+    assert!(client.is_claimed(&alice));
+}
+
+/// Claim at exactly the deadline ledger succeeds (boundary: sequence == deadline is still valid).
+#[test]
+fn test_claim_at_deadline_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 200);
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let airdrop = env.register_contract(None, AirdropContract);
+    let client = AirdropContractClient::new(&env, &airdrop);
+    client.initialize(&admin, &token, &200u32);
+    StellarAssetClient::new(&env, &token).mint(&airdrop, &10_000i128);
+
+    let leaf_a = leaf(&env, &alice, 500i128);
+    let leaf_b = leaf(&env, &bob, 500i128);
+    let (root, proof_a, _) = two_leaf_tree(&env, leaf_a, leaf_b);
+    client.set_root(&root);
+
+    // ledger 200 == 200 — should still succeed (only > deadline is rejected)
+    client.claim(&alice, &500i128, &proof_a);
+    assert!(client.is_claimed(&alice));
+}
+
+/// Claim after the deadline is rejected with ClaimWindowClosed.
+#[test]
+fn test_claim_after_deadline_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let airdrop = env.register_contract(None, AirdropContract);
+    let client = AirdropContractClient::new(&env, &airdrop);
+    client.initialize(&admin, &token, &200u32);
+    StellarAssetClient::new(&env, &token).mint(&airdrop, &10_000i128);
+
+    let leaf_a = leaf(&env, &alice, 500i128);
+    let leaf_b = leaf(&env, &bob, 500i128);
+    let (root, proof_a, _) = two_leaf_tree(&env, leaf_a, leaf_b);
+    client.set_root(&root);
+
+    // Advance ledger past deadline
+    env.ledger().with_mut(|l| l.sequence_number = 201);
+
+    let res = client.try_claim(&alice, &500i128, &proof_a);
+    assert!(res.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Batch claim tests — #782
+// ---------------------------------------------------------------------------
+
+/// Batch claim succeeds when all proofs are valid.
+#[test]
+fn test_claim_batch_success() {
+    let env = Env::default();
+    let t = setup(&env);
+
+    let alice_amount = 400i128;
+    let bob_amount = 600i128;
+
+    let leaf_a = leaf(&env, &t.alice, alice_amount);
+    let leaf_b = leaf(&env, &t.bob, bob_amount);
+    let (root, proof_a, proof_b) = two_leaf_tree(&env, leaf_a, leaf_b);
+    t.client.set_root(&root);
+
+    let mut entries = Vec::new(&env);
+    entries.push_back((t.alice.clone(), alice_amount, proof_a));
+    entries.push_back((t.bob.clone(), bob_amount, proof_b));
+
+    t.client.claim_batch(&entries);
+
+    assert!(t.client.is_claimed(&t.alice));
+    assert!(t.client.is_claimed(&t.bob));
+    assert_eq!(TokenClient::new(&env, &t.token).balance(&t.alice), alice_amount);
+    assert_eq!(TokenClient::new(&env, &t.token).balance(&t.bob), bob_amount);
+}
+
+/// One invalid proof in the batch causes the entire batch to fail (all-or-nothing).
+#[test]
+fn test_claim_batch_invalid_proof_aborts_all() {
+    let env = Env::default();
+    let t = setup(&env);
+
+    let alice_amount = 400i128;
+    let bob_amount = 600i128;
+
+    let leaf_a = leaf(&env, &t.alice, alice_amount);
+    let leaf_b = leaf(&env, &t.bob, bob_amount);
+    let (root, proof_a, proof_b) = two_leaf_tree(&env, leaf_a, leaf_b);
+    t.client.set_root(&root);
+
+    // Use bob's proof for alice — invalid
+    let mut entries = Vec::new(&env);
+    entries.push_back((t.alice.clone(), alice_amount, proof_b)); // wrong proof
+    entries.push_back((t.bob.clone(), bob_amount, proof_a));     // also wrong
+
+    let res = t.client.try_claim_batch(&entries);
+    assert!(res.is_err());
+
+    // Neither should be claimed
+    assert!(!t.client.is_claimed(&t.alice));
+    assert!(!t.client.is_claimed(&t.bob));
+}
+
+/// A batch containing an already-claimed entry fails all-or-nothing.
+#[test]
+fn test_claim_batch_already_claimed_aborts_all() {
+    let env = Env::default();
+    let t = setup(&env);
+
+    let alice_amount = 400i128;
+    let bob_amount = 600i128;
+
+    let leaf_a = leaf(&env, &t.alice, alice_amount);
+    let leaf_b = leaf(&env, &t.bob, bob_amount);
+    let (root, proof_a, proof_b) = two_leaf_tree(&env, leaf_a, leaf_b);
+    t.client.set_root(&root);
+
+    // Alice claims individually first
+    t.client.claim(&t.alice, &alice_amount, &proof_a.clone());
+
+    // Now batch tries to claim alice again (and bob for the first time)
+    let mut entries = Vec::new(&env);
+    entries.push_back((t.alice.clone(), alice_amount, proof_a));
+    entries.push_back((t.bob.clone(), bob_amount, proof_b));
+
+    let res = t.client.try_claim_batch(&entries);
+    assert!(res.is_err());
+
+    // Bob must NOT have been claimed (batch rolled back)
+    assert!(!t.client.is_claimed(&t.bob));
+}
+
+/// Batch claim is also rejected after the deadline.
+#[test]
+fn test_claim_batch_after_deadline_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+
+    let admin = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+    let airdrop = env.register_contract(None, AirdropContract);
+    let client = AirdropContractClient::new(&env, &airdrop);
+    client.initialize(&admin, &token, &200u32);
+    StellarAssetClient::new(&env, &token).mint(&airdrop, &10_000i128);
+
+    let leaf_a = leaf(&env, &alice, 500i128);
+    let leaf_b = leaf(&env, &bob, 500i128);
+    let (root, proof_a, proof_b) = two_leaf_tree(&env, leaf_a.clone(), leaf_b.clone());
+    client.set_root(&root);
+
+    // Advance past deadline
+    env.ledger().with_mut(|l| l.sequence_number = 201);
+
+    let mut entries = Vec::new(&env);
+    entries.push_back((alice.clone(), 500i128, proof_a));
+    entries.push_back((bob.clone(), 500i128, proof_b));
+
+    let res = client.try_claim_batch(&entries);
+    assert!(res.is_err());
 }

--- a/contracts/auction/src/errors.rs
+++ b/contracts/auction/src/errors.rs
@@ -1,7 +1,7 @@
-use soroban_common::impl_display_error;
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
@@ -18,6 +18,8 @@ pub enum AuctionError {
     InvalidAmount = 9,
     InvalidDeadline = 10,
     NothingToWithdraw = 11,
+    /// The auction ended but the highest bid did not meet the reserve price.
+    ReserveNotMet = 12,
 }
 
 impl_display_error!(
@@ -33,4 +35,5 @@ impl_display_error!(
     InvalidAmount      => "invalid amount",
     InvalidDeadline    => "invalid deadline",
     NothingToWithdraw  => "nothing to withdraw",
+    ReserveNotMet      => "reserve price not met",
 );

--- a/contracts/auction/src/events.rs
+++ b/contracts/auction/src/events.rs
@@ -22,6 +22,13 @@ pub fn ended_no_bids(env: &Env) {
         .publish((Symbol::new(env, "ended_no_bids"),), ());
 }
 
+pub fn ended_reserve_not_met(env: &Env, highest_bidder: &Address, highest_bid: i128, reserve_price: i128) {
+    env.events().publish(
+        (Symbol::new(env, "ended_reserve_not_met"), highest_bidder.clone()),
+        (highest_bid, reserve_price),
+    );
+}
+
 pub fn withdrawn(env: &Env, bidder: &Address, amount: i128) {
     env.events()
         .publish((Symbol::new(env, "withdrawn"), bidder.clone()), amount);

--- a/contracts/auction/src/lib.rs
+++ b/contracts/auction/src/lib.rs
@@ -36,11 +36,13 @@ fn get_instance<T: soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>(
 /// English auction contract.
 ///
 /// Lifecycle:
-/// - Seller calls `start` to set the token, starting price, minimum bid increment, and deadline.
+/// - Seller calls `start` to set the token, starting price, minimum bid increment, deadline,
+///   and an optional `reserve_price`.
 /// - Bidders call `bid` with increasing amounts. The previous highest bidder's funds are held
 ///   as a pending refund, collectable via `withdraw`.
-/// - After the deadline, anyone calls `end` to settle. On success the seller receives the
-///   winning bid; if no bids were placed the auction ends with no transfer.
+/// - After the deadline, anyone calls `end` to settle. If `highest_bid >= reserve_price` the
+///   seller receives the winning bid; otherwise funds are returned to the highest bidder and the
+///   item is left unsold. If no bids were placed the auction ends with no transfer.
 /// - Outbid bidders call `withdraw` to recover their pending refund at any time.
 pub use contract::*;
 
@@ -58,6 +60,10 @@ mod contract {
     impl AuctionContract {
         /// Start the auction.
         ///
+        /// `reserve_price` is optional. Pass `None` (or `0`) for no reserve. When set,
+        /// `end()` will only transfer to the seller if `highest_bid >= reserve_price`;
+        /// otherwise the highest bidder's funds are returned.
+        ///
         /// # Errors
         ///
         /// - [`AuctionError::AlreadyInitialized`] if already started.
@@ -70,6 +76,7 @@ mod contract {
             start_price: i128,
             min_increment: i128,
             deadline: u32,
+            reserve_price: Option<i128>,
         ) -> Result<(), AuctionError> {
             if env.storage().instance().has(&DataKey::Seller) {
                 return Err(AuctionError::AlreadyInitialized);
@@ -97,6 +104,12 @@ mod contract {
                 .instance()
                 .set(&DataKey::HighestBid, &(start_price - 1));
             env.storage().instance().set(&DataKey::Settled, &false);
+
+            if let Some(rp) = reserve_price {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::ReservePrice, &rp);
+            }
 
             bump_instance(&env);
             events::started(&env, &seller, start_price, deadline);
@@ -175,8 +188,13 @@ mod contract {
             Ok(())
         }
 
-        /// Settle the auction after the deadline. Transfers the winning bid to the seller.
-        /// If no bids were placed, emits `ended_no_bids` and nothing is transferred.
+        /// Settle the auction after the deadline.
+        ///
+        /// - If no bids were placed, emits `ended_no_bids` and nothing is transferred.
+        /// - If a reserve price was set and `highest_bid < reserve_price`, the highest bidder's
+        ///   funds are queued as a pending refund (retrievable via `withdraw`) and the item is
+        ///   left unsold (emits `ended_reserve_not_met`).
+        /// - Otherwise the seller receives the winning bid (emits `ended`).
         ///
         /// # Errors
         ///
@@ -204,14 +222,34 @@ mod contract {
 
             bump_instance(&env);
 
+            // No bids at all
             if highest_bid < start_price || winner.is_none() {
                 events::ended_no_bids(&env);
                 return Ok(());
             }
 
+            #[allow(clippy::unwrap_used)] // winner.is_none() is checked two lines above
+            let winner = winner.unwrap();
+
+            // Reserve price check
+            let reserve_price: Option<i128> =
+                env.storage().instance().get(&DataKey::ReservePrice);
+            if let Some(rp) = reserve_price {
+                if highest_bid < rp {
+                    // Return funds to the highest bidder
+                    let token: Address = get_instance(&env, &DataKey::Token)?;
+                    token::Client::new(&env, &token).transfer(
+                        &env.current_contract_address(),
+                        &winner,
+                        &highest_bid,
+                    );
+                    events::ended_reserve_not_met(&env, &winner, highest_bid, rp);
+                    return Ok(());
+                }
+            }
+
             let seller: Address = get_instance(&env, &DataKey::Seller)?;
             let token: Address = get_instance(&env, &DataKey::Token)?;
-            let winner = winner.unwrap(); // safe: checked above
 
             token::Client::new(&env, &token).transfer(
                 &env.current_contract_address(),
@@ -267,36 +305,10 @@ mod contract {
                 highest_bid: get_instance(&env, &DataKey::HighestBid)?,
                 highest_bidder: env.storage().instance().get(&DataKey::HighestBidder),
                 settled: get_instance(&env, &DataKey::Settled)?,
+                reserve_price: env.storage().instance().get(&DataKey::ReservePrice),
             })
         }
 
-        let seller: Address = get_instance(&env, &DataKey::Seller)?;
-        let token: Address = get_instance(&env, &DataKey::Token)?;
-        #[allow(clippy::unwrap_used)] // winner.is_none() is checked two lines above
-        let winner = winner.unwrap(); // safe: checked above
-
-        token::Client::new(&env, &token)
-            .transfer(&env.current_contract_address(), &seller, &highest_bid);
-
-        events::ended(&env, &winner, highest_bid);
-        Ok(())
-    }
-
-    /// Withdraw a pending refund (available for outbid bidders).
-    ///
-    /// # Errors
-    ///
-    /// - [`AuctionError::NothingToWithdraw`] if caller has no pending refund.
-    pub fn withdraw(env: Env, bidder: Address) -> Result<(), AuctionError> {
-        bidder.require_auth();
-
-        let pending: i128 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Pending(bidder.clone()))
-            .unwrap_or(0);
-        if pending <= 0 {
-            return Err(AuctionError::NothingToWithdraw);
         /// Return a bidder's pending refund amount.
         #[must_use]
         pub fn get_pending(env: Env, bidder: Address) -> i128 {

--- a/contracts/auction/src/storage.rs
+++ b/contracts/auction/src/storage.rs
@@ -14,6 +14,8 @@ pub enum DataKey {
     HighestBidder,
     HighestBid,
     Settled,
+    /// Optional reserve price; auction settles only if highest_bid >= reserve_price.
+    ReservePrice,
     /// Pending refund for outbid bidders.
     Pending(Address),
 }
@@ -29,4 +31,6 @@ pub struct AuctionInfo {
     pub highest_bid: i128,
     pub highest_bidder: Option<Address>,
     pub settled: bool,
+    /// Optional reserve price set at start.
+    pub reserve_price: Option<i128>,
 }

--- a/contracts/auction/src/test.rs
+++ b/contracts/auction/src/test.rs
@@ -35,7 +35,7 @@ fn test_single_bid_and_settle() {
     let (client, seller, b1, _, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 100;
-    client.start(&seller, &token, &1_000, &100, &deadline);
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
 
     client.bid(&b1, &1_500);
     assert_eq!(client.get_info().highest_bid, 1_500);
@@ -53,7 +53,7 @@ fn test_overbid_refunds_previous_bidder() {
     let (client, seller, b1, b2, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 100;
-    client.start(&seller, &token, &1_000, &100, &deadline);
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
 
     client.bid(&b1, &1_000);
     client.bid(&b2, &1_200); // overbids b1
@@ -74,7 +74,7 @@ fn test_multiple_overbids() {
     let (client, seller, b1, b2, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 100;
-    client.start(&seller, &token, &1_000, &500, &deadline);
+    client.start(&seller, &token, &1_000, &500, &deadline, &None);
 
     client.bid(&b1, &1_000);
     client.bid(&b2, &1_500);
@@ -101,7 +101,7 @@ fn test_bid_after_deadline_fails() {
     let (client, seller, b1, _, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 10;
-    client.start(&seller, &token, &1_000, &100, &deadline);
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
 
     env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
     client.bid(&b1, &1_500);
@@ -115,7 +115,7 @@ fn test_end_before_deadline_fails() {
     let (client, seller, b1, _, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 100;
-    client.start(&seller, &token, &1_000, &100, &deadline);
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
     client.bid(&b1, &1_500);
     client.end(); // deadline not reached
 }
@@ -131,7 +131,7 @@ fn test_end_with_no_bids() {
     let (client, seller, _, _, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 10;
-    client.start(&seller, &token, &1_000, &100, &deadline);
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
 
     env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
     client.end();
@@ -149,7 +149,7 @@ fn test_bid_too_low_fails() {
     let (client, seller, b1, b2, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 100;
-    client.start(&seller, &token, &1_000, &500, &deadline);
+    client.start(&seller, &token, &1_000, &500, &deadline, &None);
 
     client.bid(&b1, &1_000);
     client.bid(&b2, &1_200); // needs >= 1_500 (1000 + 500)
@@ -163,7 +163,7 @@ fn test_double_settle_fails() {
     let (client, seller, b1, _, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 10;
-    client.start(&seller, &token, &1_000, &100, &deadline);
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
     client.bid(&b1, &1_000);
     env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
     client.end();
@@ -178,6 +178,77 @@ fn test_double_start_fails() {
     let (client, seller, _, _, token) = setup(&env);
 
     let deadline = env.ledger().sequence() + 100;
-    client.start(&seller, &token, &1_000, &100, &deadline);
-    client.start(&seller, &token, &1_000, &100, &deadline);
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
+}
+
+// ---------------------------------------------------------------------------
+// Reserve price — #783
+// ---------------------------------------------------------------------------
+
+/// Reserve is met: seller receives the winning bid.
+#[test]
+fn test_reserve_met_settles_to_seller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, seller, b1, _, token) = setup(&env);
+
+    let deadline = env.ledger().sequence() + 100;
+    // reserve = 2_000, bid = 2_500 → reserve met
+    client.start(&seller, &token, &1_000, &100, &deadline, &Some(2_000i128));
+
+    client.bid(&b1, &2_500);
+
+    env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
+    client.end();
+
+    let info = client.get_info();
+    assert!(info.settled);
+    assert_eq!(info.reserve_price, Some(2_000));
+    // Bidder has no pending refund — the auction settled normally
+    assert_eq!(client.get_pending(&b1), 0);
+}
+
+/// Reserve is NOT met: highest bidder gets funds back, item unsold.
+#[test]
+fn test_reserve_not_met_returns_funds_to_bidder() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, seller, b1, _, token) = setup(&env);
+
+    use soroban_sdk::token::Client as TokenClient;
+    let before = TokenClient::new(&env, &token).balance(&b1);
+
+    let deadline = env.ledger().sequence() + 100;
+    // reserve = 5_000, bid = 1_500 → reserve NOT met
+    client.start(&seller, &token, &1_000, &100, &deadline, &Some(5_000i128));
+
+    client.bid(&b1, &1_500);
+
+    env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
+    client.end();
+
+    let info = client.get_info();
+    assert!(info.settled);
+    // Bidder's balance restored (contract transferred back directly)
+    assert_eq!(TokenClient::new(&env, &token).balance(&b1), before);
+}
+
+/// No reserve set behaves identically to the original contract.
+#[test]
+fn test_no_reserve_settles_any_bid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, seller, b1, _, token) = setup(&env);
+
+    let deadline = env.ledger().sequence() + 100;
+    client.start(&seller, &token, &1_000, &100, &deadline, &None);
+
+    client.bid(&b1, &1_000);
+
+    env.ledger().with_mut(|l| l.sequence_number = deadline + 1);
+    client.end();
+
+    assert!(client.get_info().settled);
+    assert_eq!(client.get_info().reserve_price, None);
 }

--- a/contracts/ballot/Cargo.toml
+++ b/contracts/ballot/Cargo.toml
@@ -2,14 +2,19 @@
 name = "ballot"
 version = "0.1.0"
 edition = "2024"
+authors.workspace = true
+license.workspace = true
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = { version = "21.5", features = ["contract"] }
-soroban-common = { path = "../common" }
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.5", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[lints]
+workspace = true

--- a/contracts/ballot/build.rs
+++ b/contracts/ballot/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    soroban_sdk::meta();
-}

--- a/contracts/ballot/src/lib.rs
+++ b/contracts/ballot/src/lib.rs
@@ -42,260 +42,189 @@ mod contract {
     #[contract]
     pub struct BallotContract;
 
-#[contractimpl]
-impl BallotContract {
-    /// Initialize the ballot contract.
-    ///
-    /// # Errors
-    /// - [`BallotError::AlreadyInitialized`] if called more than once.
-    pub fn initialize(env: Env, admin: Address) -> Result<(), BallotError> {
-        if env.storage().instance().has(&DataKey::Admin) {
-            return Err(BallotError::AlreadyInitialized);
-        }
-        admin.require_auth();
+    #[contractimpl]
+    impl BallotContract {
+        /// Initialize the ballot contract.
+        ///
+        /// # Errors
+        /// - [`BallotError::AlreadyInitialized`] if called more than once.
+        pub fn initialize(env: Env, admin: Address) -> Result<(), BallotError> {
+            if env.storage().instance().has(&DataKey::Admin) {
+                return Err(BallotError::AlreadyInitialized);
+            }
+            admin.require_auth();
 
-        env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::VotingActive, &true);
-        env.storage().instance().set(&DataKey::YesVotes, &0i128);
-        env.storage().instance().set(&DataKey::NoVotes, &0i128);
+            env.storage().instance().set(&DataKey::Admin, &admin);
+            env.storage().instance().set(&DataKey::VotingActive, &true);
+            env.storage().instance().set(&DataKey::YesVotes, &0i128);
+            env.storage().instance().set(&DataKey::NoVotes, &0i128);
 
-        bump(&env);
-        events::initialized(&env, &admin);
-        Ok(())
-    }
-
-    /// Admin registers a voter for the ballot.
-    ///
-    /// # Errors
-    /// - [`BallotError::NotInitialized`] if the contract has not been initialized.
-    /// - [`BallotError::Unauthorized`] if the caller is not the admin.
-    pub fn register_voter(env: Env, voter: Address) -> Result<(), BallotError> {
-        if !env.storage().instance().has(&DataKey::Admin) {
-            return Err(BallotError::NotInitialized);
+            bump(&env);
+            events::initialized(&env, &admin);
+            Ok(())
         }
 
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(BallotError::NotInitialized)?;
-        admin.require_auth();
+        /// Admin registers a voter for the ballot.
+        ///
+        /// # Errors
+        /// - [`BallotError::NotInitialized`] if the contract has not been initialized.
+        /// - [`BallotError::Unauthorized`] if the caller is not the admin.
+        pub fn register_voter(env: Env, voter: Address) -> Result<(), BallotError> {
+            if !env.storage().instance().has(&DataKey::Admin) {
+                return Err(BallotError::NotInitialized);
+            }
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::RegisteredVoter(voter.clone()), &true);
+            let admin: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .ok_or(BallotError::NotInitialized)?;
+            admin.require_auth();
 
-        bump(&env);
-        events::voter_registered(&env, &voter);
-        Ok(())
-    }
+            env.storage()
+                .persistent()
+                .set(&DataKey::RegisteredVoter(voter.clone()), &true);
+            env.storage().persistent().extend_ttl(
+                &DataKey::RegisteredVoter(voter.clone()),
+                LEDGER_LIFETIME_THRESHOLD,
+                LEDGER_BUMP_AMOUNT,
+            );
 
-    /// Voter casts their vote (choice: 1=yes, 0=no).
-    ///
-    /// # Errors
-    /// - [`BallotError::NotInitialized`] if the contract has not been initialized.
-    /// - [`BallotError::NotRegistered`] if the voter is not registered.
-    /// - [`BallotError::AlreadyVoted`] if the voter has already voted.
-    /// - [`BallotError::InvalidChoice`] if choice is not 0 or 1.
-    /// - [`BallotError::VotingClosed`] if voting is not active.
-    pub fn vote(env: Env, voter: Address, choice: u32) -> Result<(), BallotError> {
-        if !env.storage().instance().has(&DataKey::Admin) {
-            return Err(BallotError::NotInitialized);
-        }
-        voter.require_auth();
-
-        let voting_active: bool = env
-            .storage()
-            .instance()
-            .get(&DataKey::VotingActive)
-            .unwrap_or(false);
-        if !voting_active {
-            return Err(BallotError::VotingClosed);
+            bump(&env);
+            events::voter_registered(&env, &voter);
+            Ok(())
         }
 
-        let is_registered: bool = env
-            .storage()
-            .persistent()
-            .get(&DataKey::RegisteredVoter(voter.clone()))
-            .unwrap_or(false);
-        if !is_registered {
-            return Err(BallotError::NotRegistered);
+        /// Voter casts their vote (choice: 1=yes, 0=no).
+        ///
+        /// # Errors
+        /// - [`BallotError::NotInitialized`] if the contract has not been initialized.
+        /// - [`BallotError::NotRegistered`] if the voter is not registered.
+        /// - [`BallotError::AlreadyVoted`] if the voter has already voted.
+        /// - [`BallotError::InvalidChoice`] if choice is not 0 or 1.
+        /// - [`BallotError::VotingClosed`] if voting is not active.
+        pub fn vote(env: Env, voter: Address, choice: u32) -> Result<(), BallotError> {
+            if !env.storage().instance().has(&DataKey::Admin) {
+                return Err(BallotError::NotInitialized);
+            }
+            voter.require_auth();
+
+            let voting_active: bool = env
+                .storage()
+                .instance()
+                .get(&DataKey::VotingActive)
+                .unwrap_or(false);
+            if !voting_active {
+                return Err(BallotError::VotingClosed);
+            }
+
+            let is_registered: bool = env
+                .storage()
+                .persistent()
+                .get(&DataKey::RegisteredVoter(voter.clone()))
+                .unwrap_or(false);
+            if !is_registered {
+                return Err(BallotError::NotRegistered);
+            }
+
+            let already_voted: bool = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Voter(voter.clone()))
+                .unwrap_or(false);
+            if already_voted {
+                return Err(BallotError::AlreadyVoted);
+            }
+
+            if choice != 0 && choice != 1 {
+                return Err(BallotError::InvalidChoice);
+            }
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Voter(voter.clone()), &true);
+            env.storage().persistent().extend_ttl(
+                &DataKey::Voter(voter.clone()),
+                LEDGER_LIFETIME_THRESHOLD,
+                LEDGER_BUMP_AMOUNT,
+            );
+
+            if choice == 1 {
+                let yes: i128 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::YesVotes)
+                    .unwrap_or(0i128);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::YesVotes, &(yes + 1));
+            } else {
+                let no: i128 = env
+                    .storage()
+                    .instance()
+                    .get(&DataKey::NoVotes)
+                    .unwrap_or(0i128);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::NoVotes, &(no + 1));
+            }
+
+            bump(&env);
+            events::voted(&env, &voter, choice);
+            Ok(())
         }
 
-        let already_voted: bool = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Voter(voter.clone()))
-            .unwrap_or(false);
-        if already_voted {
-            return Err(BallotError::AlreadyVoted);
-        }
+        /// Get tally results and close voting.
+        ///
+        /// Returns (yes_votes, no_votes).
+        ///
+        /// # Errors
+        /// - [`BallotError::NotInitialized`] if the contract has not been initialized.
+        /// - [`BallotError::Unauthorized`] if the caller is not the admin.
+        pub fn tally(env: Env) -> Result<(i128, i128), BallotError> {
+            if !env.storage().instance().has(&DataKey::Admin) {
+                return Err(BallotError::NotInitialized);
+            }
 
-        if choice != 0 && choice != 1 {
-            return Err(BallotError::InvalidChoice);
-        }
+            let admin: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Admin)
+                .ok_or(BallotError::NotInitialized)?;
+            admin.require_auth();
 
-        env.storage()
-            .persistent()
-            .set(&DataKey::Voter(voter.clone()), &true);
-
-        if choice == 1 {
             let yes: i128 = env
                 .storage()
                 .instance()
                 .get(&DataKey::YesVotes)
                 .unwrap_or(0i128);
-            env.storage()
-                .instance()
-                .set(&DataKey::YesVotes, &(yes + 1));
-        } else {
             let no: i128 = env
                 .storage()
                 .instance()
                 .get(&DataKey::NoVotes)
                 .unwrap_or(0i128);
+
+            env.storage().instance().set(&DataKey::VotingActive, &false);
+
+            bump(&env);
+            events::tally_result(&env, yes, no);
+            Ok((yes, no))
+        }
+
+        /// Get yes vote count.
+        pub fn get_yes_votes(env: Env) -> i128 {
             env.storage()
                 .instance()
-                .set(&DataKey::NoVotes, &(no + 1));
+                .get(&DataKey::YesVotes)
+                .unwrap_or(0i128)
         }
 
-        bump(&env);
-        events::voted(&env, &voter, choice);
-        Ok(())
-    }
-
-    /// Get tally results and close voting.
-    ///
-    /// Returns (yes_votes, no_votes).
-    ///
-    /// # Errors
-    /// - [`BallotError::NotInitialized`] if the contract has not been initialized.
-    /// - [`BallotError::Unauthorized`] if the caller is not the admin.
-    pub fn tally(env: Env) -> Result<(i128, i128), BallotError> {
-        if !env.storage().instance().has(&DataKey::Admin) {
-            return Err(BallotError::NotInitialized);
-        }
-
-        let admin: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(BallotError::NotInitialized)?;
-        admin.require_auth();
-
-        let yes: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::YesVotes)
-            .unwrap_or(0i128);
-        let no: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::NoVotes)
-            .unwrap_or(0i128);
-
-        env.storage().instance().set(&DataKey::VotingActive, &false);
-
-        bump(&env);
-        events::tally_result(&env, yes, no);
-        Ok((yes, no))
-    }
-
-    /// Get yes vote count.
-    pub fn get_yes_votes(env: Env) -> i128 {
-        env.storage()
-            .instance()
-            .get(&DataKey::YesVotes)
-            .unwrap_or(0i128)
-    }
-
-    /// Get no vote count.
-    pub fn get_no_votes(env: Env) -> i128 {
-        env.storage()
-            .instance()
-            .get(&DataKey::NoVotes)
-            .unwrap_or(0i128)
-    }
-}
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use soroban_sdk::testutils::{Address as _, Ledger};
-
-    #[test]
-    fn test_ballot_lifecycle() {
-        let env = Env::default();
-        env.ledger().with_mut(|le| {
-            le.timestamp = 1;
-        });
-
-        let admin = Address::random(&env);
-        let voter1 = Address::random(&env);
-        let voter2 = Address::random(&env);
-
-        let contract = BallotContractClient::new(&env, &env.current_contract_id());
-
-        contract.initialize(&admin);
-        contract.register_voter(&voter1);
-        contract.register_voter(&voter2);
-
-        contract.vote(&voter1, &1u32);
-        contract.vote(&voter2, &0u32);
-
-        assert_eq!(contract.get_yes_votes(), 1);
-        assert_eq!(contract.get_no_votes(), 1);
-
-        let (yes, no) = contract.tally();
-        assert_eq!(yes, 1);
-        assert_eq!(no, 1);
-    }
-
-    #[test]
-    fn test_double_vote_prevention() {
-        let env = Env::default();
-        env.ledger().with_mut(|le| {
-            le.timestamp = 1;
-        });
-
-        let admin = Address::random(&env);
-        let voter = Address::random(&env);
-
-        let contract = BallotContractClient::new(&env, &env.current_contract_id());
-
-        contract.initialize(&admin);
-        contract.register_voter(&voter);
-
-        contract.vote(&voter, &1u32);
-
-        let result = contract.try_vote(&voter, &1u32);
-        assert!(result.is_err());
-        match result {
-            Err(e) => assert_eq!(e.error(), BallotError::AlreadyVoted),
-            _ => unreachable!(),
-        }
-    }
-
-    #[test]
-    fn test_unregistered_voter_rejected() {
-        let env = Env::default();
-        env.ledger().with_mut(|le| {
-            le.timestamp = 1;
-        });
-
-        let admin = Address::random(&env);
-        let unregistered = Address::random(&env);
-
-        let contract = BallotContractClient::new(&env, &env.current_contract_id());
-
-        contract.initialize(&admin);
-
-        let result = contract.try_vote(&unregistered, &1u32);
-        assert!(result.is_err());
-        match result {
-            Err(e) => assert_eq!(e.error(), BallotError::NotRegistered),
-            _ => unreachable!(),
+        /// Get no vote count.
+        pub fn get_no_votes(env: Env) -> i128 {
+            env.storage()
+                .instance()
+                .get(&DataKey::NoVotes)
+                .unwrap_or(0i128)
         }
     }
 }

--- a/contracts/ballot/src/storage.rs
+++ b/contracts/ballot/src/storage.rs
@@ -1,8 +1,9 @@
 // `#[contracttype]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
-use soroban_sdk::Address;
+use soroban_sdk::{Address, contracttype};
 
+#[contracttype]
 #[derive(Clone, Debug)]
 pub enum DataKey {
     Admin,

--- a/contracts/ballot/src/test.rs
+++ b/contracts/ballot/src/test.rs
@@ -1,0 +1,174 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing
+)]
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
+
+fn setup(env: &Env) -> (BallotContractClient, Address) {
+    env.mock_all_auths();
+    let admin = Address::generate(env);
+    let addr = env.register_contract(None, BallotContract);
+    let client = BallotContractClient::new(env, &addr);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+// ---------------------------------------------------------------------------
+// Basic lifecycle
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_ballot_lifecycle() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+
+    client.register_voter(&voter1);
+    client.register_voter(&voter2);
+
+    client.vote(&voter1, &1u32);
+    client.vote(&voter2, &0u32);
+
+    assert_eq!(client.get_yes_votes(), 1);
+    assert_eq!(client.get_no_votes(), 1);
+
+    let (yes, no) = client.tally();
+    assert_eq!(yes, 1);
+    assert_eq!(no, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Double-vote prevention (#777 core behaviour)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_double_vote_prevention() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let voter = Address::generate(&env);
+    client.register_voter(&voter);
+    client.vote(&voter, &1u32);
+
+    let result = client.try_vote(&voter, &1u32);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Unregistered voter rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_unregistered_voter_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let unregistered = Address::generate(&env);
+    let result = client.try_vote(&unregistered, &1u32);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Invalid choice rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_invalid_choice_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let voter = Address::generate(&env);
+    client.register_voter(&voter);
+
+    let result = client.try_vote(&voter, &2u32);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Double-initialize rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_double_initialize_rejected() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let result = client.try_initialize(&admin);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// TTL extension — #777
+// Verify register_voter and vote extend persistent TTL (no archival regression).
+// We test indirectly: after bumping the ledger far past the minimum threshold,
+// the persistent keys should still be readable (they are extended on write).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_register_voter_extends_persistent_ttl() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let voter = Address::generate(&env);
+    client.register_voter(&voter);
+
+    // Advance the ledger significantly — if TTL were NOT extended the entry
+    // would expire; with the fix the entry's TTL is bumped to LEDGER_BUMP_AMOUNT.
+    env.ledger().with_mut(|l| l.sequence_number += 10_000);
+
+    // The voter should still be registered (TTL was extended at register time).
+    // If the entry had expired it would return false, causing vote() to fail.
+    let result = client.try_vote(&voter, &1u32);
+    // Should succeed (not fail with NotRegistered) — confirms TTL was extended.
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_vote_extends_persistent_ttl() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let voter = Address::generate(&env);
+    client.register_voter(&voter);
+    client.vote(&voter, &1u32);
+
+    // Advance ledger; without the TTL fix the Voter key would expire and the
+    // double-vote guard would fail to detect the previous vote.
+    env.ledger().with_mut(|l| l.sequence_number += 10_000);
+
+    // Attempt second vote — must still be rejected (AlreadyVoted).
+    let result = client.try_vote(&voter, &1u32);
+    assert!(result.is_err(), "second vote should be rejected even after ledger advance");
+}
+
+// ---------------------------------------------------------------------------
+// Tally closes voting
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tally_closes_voting() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+
+    let voter = Address::generate(&env);
+    client.register_voter(&voter);
+    client.vote(&voter, &1u32);
+
+    client.tally();
+
+    // After tally, voting is closed — new votes should fail
+    let voter2 = Address::generate(&env);
+    client.register_voter(&voter2);
+    let result = client.try_vote(&voter2, &0u32);
+    assert!(result.is_err());
+}

--- a/contracts/bonding-curve/Cargo.toml
+++ b/contracts/bonding-curve/Cargo.toml
@@ -2,14 +2,19 @@
 name = "bonding-curve"
 version = "0.1.0"
 edition = "2024"
+authors.workspace = true
+license.workspace = true
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = { version = "21.5", features = ["contract"] }
-soroban-common = { path = "../common" }
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.5", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
+[lints]
+workspace = true

--- a/contracts/wrapped-token/Cargo.toml
+++ b/contracts/wrapped-token/Cargo.toml
@@ -2,19 +2,19 @@
 name = "wrapped-token"
 version = "0.1.0"
 edition = "2024"
+authors.workspace = true
+license.workspace = true
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = { version = "21.5", features = ["contract"] }
-soroban-common = { path = "../common" }
+soroban-sdk = { workspace = true }
+soroban-common = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.5", features = ["testutils"] }
+soroban-sdk = { workspace = true, features = ["testutils"] }
 
-[profile.release]
-opt-level = "z"
-strip = true
-lto = true
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

Resolves four issues in a single commit across three contracts.

---

### #777 — ballot: extend TTL for persistent voter keys

`register_voter()` and `vote()` wrote persistent storage without calling `extend_ttl` on the individual keys. If those entries archived, `unwrap_or(false)` would silently un-register voters and allow double votes.

**Changes:**
- `register_voter()`: call `extend_ttl` on `RegisteredVoter(voter)` after write
- `vote()`: call `extend_ttl` on `Voter(voter)` after write
- Add `#[contracttype]` to `DataKey` (required for persistent storage serialisation)
- Fix workspace membership for `ballot`, `bonding-curve`, `wrapped-token`
- Remove stale `build.rs`
- Add 8-test suite including TTL-persistence regression tests

Closes #777

---

### #780 — airdrop: add `claim_deadline`

**Changes:**
- `initialize()` now takes `claim_deadline: u32`; stored as `DataKey::ClaimDeadline`
- `claim()` returns new `AirdropError::ClaimWindowClosed` (code 8) when `ledger.sequence() > claim_deadline`
- Tests: claim before deadline, at deadline boundary, after deadline

Closes #780

---

### #782 — airdrop: add `claim_batch`

**Changes:**
- New `claim_batch(entries: Vec<(Address, i128, Vec<BytesN<32>>)>)` entry point
- **All-or-nothing semantics**: all entries are fully validated before any state change or token transfer
- Also subject to `claim_deadline` check
- Tests: batch success, invalid proof aborts all, already-claimed aborts all, batch rejected after deadline

Closes #782

---

### #783 — auction: add `reserve_price`

**Changes:**
- `start()` takes optional `reserve_price: Option<i128>`
- `end()` branches: `highest_bid >= reserve_price` → transfer to seller; reserve not met → return bid to highest bidder and emit `ended_reserve_not_met` event; `None` → original behaviour
- `AuctionInfo` exposes `reserve_price: Option<i128>`
- New `AuctionError::ReserveNotMet` (code 12)
- New `ended_reserve_not_met` event
- Tests: reserve met, reserve not met (funds returned to bidder), no reserve set

Closes #783

---

## Tests

| Contract | Tests | Result |
|----------|-------|--------|
| `ballot` | 8 | ✅ all pass |
| `soroban-airdrop-template` | 15 | ✅ all pass |
| `soroban-auction-template` | 12 | ✅ all pass |
