### PR TITLE
Marketplace pagination + oracle staleness, multi-publisher median, and TWAP (#800, #801, #802, #803)

### DIFF
--- a/contracts/marketplace/src/lib.rs
+++ b/contracts/marketplace/src/lib.rs
@@ -5,14 +5,18 @@
 //! Sellers list assets at a fixed price; buyers purchase them, transferring
 //! payment to the seller and the asset to the buyer in one transaction.
 
-use soroban_sdk::{Address, Env, contract, contractclient, contractimpl, token};
+use soroban_sdk::{Address, Env, Vec, contract, contractclient, contractimpl, token};
 
 mod errors;
 mod events;
 mod storage;
 
 pub use errors::MarketplaceError;
-pub use storage::{DataKey, Listing};
+pub use storage::{DataKey, Listing, ListingEntry, ListingPage};
+
+/// Maximum number of listings a single [`MarketplaceContract::get_active_listings`] call
+/// may return, regardless of the requested `limit`.
+pub const MAX_LISTINGS_PAGE_SIZE: u32 = 50;
 
 use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
@@ -262,6 +266,51 @@ mod contract {
             env.storage()
                 .persistent()
                 .get(&DataKey::Listing(listing_id))
+        }
+
+        /// Enumerate active listings, paginated by listing ID.
+        ///
+        /// `cursor` is the listing ID to resume scanning from (pass `0` to start from the
+        /// beginning). `limit` is the maximum number of active listings to return and is
+        /// capped at [`MAX_LISTINGS_PAGE_SIZE`] (a `limit` of `0` is treated as `1`).
+        ///
+        /// Returns a page of matching listings together with a `next_cursor` to pass to
+        /// the following call, or `next_cursor: None` once the end of the listing range
+        /// has been reached.
+        pub fn get_active_listings(env: Env, cursor: u64, limit: u32) -> ListingPage {
+            let capped_limit = limit.clamp(1, MAX_LISTINGS_PAGE_SIZE);
+            let next_id: u64 = env
+                .storage()
+                .instance()
+                .get(&DataKey::NextListingId)
+                .unwrap_or(0);
+
+            let mut listings = Vec::new(&env);
+            let mut id = cursor;
+            let mut next_cursor = None;
+
+            while id < next_id {
+                if listings.len() >= capped_limit {
+                    next_cursor = Some(id);
+                    break;
+                }
+
+                if let Some(listing) = env
+                    .storage()
+                    .persistent()
+                    .get::<_, Listing>(&DataKey::Listing(id))
+                    && listing.active
+                {
+                    listings.push_back(ListingEntry { id, listing });
+                }
+
+                id = id.saturating_add(1);
+            }
+
+            ListingPage {
+                listings,
+                next_cursor,
+            }
         }
     }
 }

--- a/contracts/marketplace/src/lib.rs
+++ b/contracts/marketplace/src/lib.rs
@@ -151,23 +151,6 @@ mod contract {
             Ok(id)
         }
 
-        // Checks-effects-interactions: mark inactive before external calls.
-        listing.active = false;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Listing(listing_id), &listing);
-        bump_instance(&env);
-
-        let price = listing.price;
-        #[allow(clippy::arithmetic_side_effects, clippy::as_conversions, clippy::cast_possible_truncation)] // royalty BPS validated <= 10_000 at init
-        let royalty = (price * royalty_bps as i128) / 10_000;
-        #[allow(clippy::arithmetic_side_effects)]
-        let seller_amount = price - royalty;
-
-        let tok = token::Client::new(&env, &payment_token);
-        tok.transfer(&buyer, &listing.seller, &seller_amount);
-        if royalty > 0 {
-            tok.transfer(&buyer, &royalty_recipient, &royalty);
         /// Buy the NFT in listing `listing_id`.
         ///
         /// Transfers payment (minus royalty) to the seller and the royalty portion to the royalty

--- a/contracts/marketplace/src/storage.rs
+++ b/contracts/marketplace/src/storage.rs
@@ -35,3 +35,24 @@ pub struct Listing {
     /// Whether the listing is still open.
     pub active: bool,
 }
+
+/// A listing paired with its ID, as returned by [`super::MarketplaceContract::get_active_listings`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ListingEntry {
+    /// The listing ID.
+    pub id: u64,
+    /// The listing itself.
+    pub listing: Listing,
+}
+
+/// One page of results from [`super::MarketplaceContract::get_active_listings`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct ListingPage {
+    /// Active listings found in this page, in ascending ID order.
+    pub listings: soroban_sdk::Vec<ListingEntry>,
+    /// The cursor to pass to the next call to continue scanning, or `None`
+    /// if the end of the listing range has been reached.
+    pub next_cursor: Option<u64>,
+}

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -18,4 +18,6 @@ pub enum OracleError {
     StalePrice = 4,
     /// The provided staleness threshold is zero.
     InvalidStalenessThreshold = 5,
+    /// No authorized publisher has submitted a price yet.
+    NoPublisherData = 6,
 }

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -20,4 +20,6 @@ pub enum OracleError {
     InvalidStalenessThreshold = 5,
     /// No authorized publisher has submitted a price yet.
     NoPublisherData = 6,
+    /// No price observations fall within the requested TWAP window.
+    InsufficientHistory = 7,
 }

--- a/contracts/oracle/src/events.rs
+++ b/contracts/oracle/src/events.rs
@@ -13,3 +13,10 @@ pub fn price_updated(env: &Env, admin: &Address, price: i128, ledger: u32) {
         (price, ledger),
     );
 }
+
+pub fn price_submitted(env: &Env, publisher: &Address, price: i128, timestamp: u64) {
+    env.events().publish(
+        (Symbol::new(env, "price_submitted"), publisher.clone()),
+        (price, timestamp),
+    );
+}

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -13,9 +13,13 @@ mod events;
 mod storage;
 
 pub use errors::OracleError;
-pub use storage::{DataKey, PriceData, PublisherSubmission};
+pub use storage::{DataKey, PriceData, PriceObservation, PublisherSubmission};
 
 use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
+
+/// Maximum number of price observations retained for `get_twap`. Older
+/// observations are dropped as new ones are recorded.
+pub const MAX_HISTORY: u32 = 30;
 
 fn bump_instance(env: &Env) {
     env.storage()
@@ -61,6 +65,53 @@ fn median(values: &mut Vec<i128>) -> i128 {
     } else {
         values.get_unchecked(mid)
     }
+}
+
+/// Append a new price observation to the ring buffer, dropping the oldest
+/// entry once [`MAX_HISTORY`] is exceeded.
+fn push_history(env: &Env, price: i128, timestamp: u64) {
+    let mut history: Vec<PriceObservation> = env
+        .storage()
+        .instance()
+        .get(&DataKey::History)
+        .unwrap_or(Vec::new(env));
+
+    history.push_back(PriceObservation { price, timestamp });
+    while history.len() > MAX_HISTORY {
+        history.pop_front();
+    }
+
+    env.storage().instance().set(&DataKey::History, &history);
+}
+
+/// Compute the time-weighted average price over `observations`, which must be
+/// non-empty and sorted oldest-first. Each observation's price is weighted by
+/// how long it held (until the next observation, or `now` for the last one).
+#[allow(clippy::arithmetic_side_effects, clippy::integer_division)]
+fn twap(observations: &Vec<PriceObservation>, now: u64) -> i128 {
+    let len = observations.len();
+    if len == 1 {
+        return observations.get_unchecked(0).price;
+    }
+
+    let mut weighted_sum: i128 = 0;
+    let mut total_weight: i128 = 0;
+    for i in 0..len {
+        let obs = observations.get_unchecked(i);
+        let next_timestamp = if i + 1 < len {
+            observations.get_unchecked(i + 1).timestamp
+        } else {
+            now
+        };
+        let weight = i128::from(next_timestamp.saturating_sub(obs.timestamp));
+        weighted_sum = weighted_sum.saturating_add(obs.price.saturating_mul(weight));
+        total_weight = total_weight.saturating_add(weight);
+    }
+
+    if total_weight == 0 {
+        return observations.get_unchecked(len - 1).price;
+    }
+    weighted_sum / total_weight
 }
 
 pub use contract::*;
@@ -127,6 +178,7 @@ mod contract {
             env.storage()
                 .instance()
                 .set(&UpdatedAtTimestamp, &timestamp);
+            push_history(&env, price, timestamp);
 
             bump_instance(&env);
             events::price_updated(&env, &admin, price, ledger);
@@ -238,6 +290,7 @@ mod contract {
                 LEDGER_LIFETIME_THRESHOLD,
                 LEDGER_BUMP_AMOUNT,
             );
+            push_history(&env, price, timestamp);
             bump_instance(&env);
 
             events::price_submitted(&env, &publisher, price, timestamp);
@@ -269,6 +322,42 @@ mod contract {
             }
 
             Ok(median(&mut prices))
+        }
+
+        /// Compute the time-weighted average price over the last `window` seconds.
+        ///
+        /// Every `update_price` and `submit_price` call records an observation in a
+        /// ring buffer of up to [`MAX_HISTORY`] entries; this averages the
+        /// observations whose timestamp falls within `window` seconds of now,
+        /// weighting each by how long it held before the next observation (or now,
+        /// for the most recent one).
+        ///
+        /// # Errors
+        /// - [`OracleError::InsufficientHistory`] if no observation falls within
+        ///   `window` seconds of the current ledger timestamp.
+        pub fn get_twap(env: Env, window: u64) -> Result<i128, OracleError> {
+            let history: Vec<PriceObservation> = env
+                .storage()
+                .instance()
+                .get(&History)
+                .unwrap_or(Vec::new(&env));
+
+            let now = env.ledger().timestamp();
+            let cutoff = now.saturating_sub(window);
+
+            let mut in_window: Vec<PriceObservation> = Vec::new(&env);
+            for observation in history.iter() {
+                if observation.timestamp >= cutoff {
+                    in_window.push_back(observation);
+                }
+            }
+
+            if in_window.is_empty() {
+                return Err(OracleError::InsufficientHistory);
+            }
+
+            bump_instance(&env);
+            Ok(twap(&in_window, now))
         }
     }
 }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -91,8 +91,12 @@ mod contract {
             admin.require_auth();
 
             let ledger = env.ledger().sequence();
+            let timestamp = env.ledger().timestamp();
             env.storage().instance().set(&Price, &price);
             env.storage().instance().set(&UpdatedAt, &ledger);
+            env.storage()
+                .instance()
+                .set(&UpdatedAtTimestamp, &timestamp);
 
             bump_instance(&env);
             events::price_updated(&env, &admin, price, ledger);
@@ -113,6 +117,28 @@ mod contract {
 
             let age = env.ledger().sequence().saturating_sub(updated_at);
             if age > threshold {
+                return Err(OracleError::StalePrice);
+            }
+
+            bump_instance(&env);
+            Ok(price)
+        }
+
+        /// Return the current price, rejecting it if it is older than `max_age` seconds.
+        ///
+        /// Unlike `get_price` (which enforces the fixed `staleness_threshold` configured
+        /// at `initialize` time, measured in ledgers), this lets a caller specify its own
+        /// tolerance in seconds, checked against `env.ledger().timestamp()`.
+        ///
+        /// # Errors
+        /// - [`OracleError::NotInitialized`] if no price has been pushed yet.
+        /// - [`OracleError::StalePrice`] if `env.ledger().timestamp() - last_updated > max_age`.
+        pub fn get_price_checked(env: Env, max_age: u64) -> Result<i128, OracleError> {
+            let price: i128 = get_required(&env, &Price)?;
+            let updated_at_timestamp: u64 = get_required(&env, &UpdatedAtTimestamp)?;
+
+            let age = env.ledger().timestamp().saturating_sub(updated_at_timestamp);
+            if age > max_age {
                 return Err(OracleError::StalePrice);
             }
 

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -219,7 +219,10 @@ mod contract {
             let price: i128 = get_required(&env, &Price)?;
             let updated_at_timestamp: u64 = get_required(&env, &UpdatedAtTimestamp)?;
 
-            let age = env.ledger().timestamp().saturating_sub(updated_at_timestamp);
+            let age = env
+                .ledger()
+                .timestamp()
+                .saturating_sub(updated_at_timestamp);
             if age > max_age {
                 return Err(OracleError::StalePrice);
             }

--- a/contracts/oracle/src/lib.rs
+++ b/contracts/oracle/src/lib.rs
@@ -6,14 +6,14 @@
 //! `get_price`, which rejects prices older than a configurable staleness
 //! threshold.
 
-use soroban_sdk::{Address, Env, contract, contractimpl};
+use soroban_sdk::{Address, Env, Vec, contract, contractimpl};
 
 mod errors;
 mod events;
 mod storage;
 
 pub use errors::OracleError;
-pub use storage::{DataKey, PriceData};
+pub use storage::{DataKey, PriceData, PublisherSubmission};
 
 use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
@@ -31,6 +31,36 @@ fn get_required<T: soroban_sdk::TryFromVal<soroban_sdk::Env, soroban_sdk::Val>>(
         .instance()
         .get(key)
         .ok_or(OracleError::NotInitialized)
+}
+
+/// Compute the median of `values`, sorting them in place.
+///
+/// Uses insertion sort: authorized publisher sets are expected to stay small,
+/// so this stays cheap while avoiding a dependency on the standard library.
+#[allow(clippy::arithmetic_side_effects, clippy::integer_division)]
+fn median(values: &mut Vec<i128>) -> i128 {
+    let len = values.len();
+    for i in 1..len {
+        let key = values.get_unchecked(i);
+        let mut j = i;
+        while j > 0 && values.get_unchecked(j - 1) > key {
+            let prev = values.get_unchecked(j - 1);
+            values.set(j, prev);
+            j -= 1;
+        }
+        values.set(j, key);
+    }
+
+    let mid = len / 2;
+    #[allow(clippy::manual_is_multiple_of)] // is_multiple_of postdates the pinned 1.85.0 toolchain
+    if len % 2 == 0 {
+        values
+            .get_unchecked(mid - 1)
+            .saturating_add(values.get_unchecked(mid))
+            / 2
+    } else {
+        values.get_unchecked(mid)
+    }
 }
 
 pub use contract::*;
@@ -157,6 +187,88 @@ mod contract {
                 admin: get_required(&env, &Admin)?,
                 staleness_threshold: get_required(&env, &StalenessThreshold)?,
             })
+        }
+
+        /// Configure the set of addresses authorized to submit prices via `submit_price`.
+        /// Admin only. Replaces any previously configured set.
+        ///
+        /// # Errors
+        /// - [`OracleError::NotInitialized`] if not yet set up.
+        /// - [`OracleError::Unauthorized`] if `admin` is not the configured admin.
+        pub fn set_publishers(
+            env: Env,
+            admin: Address,
+            publishers: Vec<Address>,
+        ) -> Result<(), OracleError> {
+            let stored_admin: Address = get_required(&env, &Admin)?;
+            admin.require_auth();
+            if admin != stored_admin {
+                return Err(OracleError::Unauthorized);
+            }
+
+            env.storage().instance().set(&Publishers, &publishers);
+            bump_instance(&env);
+            Ok(())
+        }
+
+        /// Submit a price as an authorized publisher.
+        ///
+        /// # Errors
+        /// - [`OracleError::Unauthorized`] if `publisher` is not in the set configured
+        ///   via `set_publishers`.
+        pub fn submit_price(env: Env, publisher: Address, price: i128) -> Result<(), OracleError> {
+            publisher.require_auth();
+
+            let publishers: Vec<Address> = env
+                .storage()
+                .instance()
+                .get(&Publishers)
+                .unwrap_or(Vec::new(&env));
+            if !publishers.contains(&publisher) {
+                return Err(OracleError::Unauthorized);
+            }
+
+            let timestamp = env.ledger().timestamp();
+            let key = Submission(publisher.clone());
+            env.storage()
+                .persistent()
+                .set(&key, &PublisherSubmission { price, timestamp });
+            env.storage().persistent().extend_ttl(
+                &key,
+                LEDGER_LIFETIME_THRESHOLD,
+                LEDGER_BUMP_AMOUNT,
+            );
+            bump_instance(&env);
+
+            events::price_submitted(&env, &publisher, price, timestamp);
+            Ok(())
+        }
+
+        /// Return the median of the latest submission from each authorized publisher,
+        /// rather than trusting a single caller as `get_price` does.
+        ///
+        /// # Errors
+        /// - [`OracleError::NotInitialized`] if `set_publishers` has never been called.
+        /// - [`OracleError::NoPublisherData`] if no publisher has submitted a price yet.
+        pub fn get_median_price(env: Env) -> Result<i128, OracleError> {
+            let publishers: Vec<Address> = get_required(&env, &Publishers)?;
+
+            let mut prices: Vec<i128> = Vec::new(&env);
+            for publisher in publishers.iter() {
+                if let Some(submission) = env
+                    .storage()
+                    .persistent()
+                    .get::<_, PublisherSubmission>(&Submission(publisher))
+                {
+                    prices.push_back(submission.price);
+                }
+            }
+
+            if prices.is_empty() {
+                return Err(OracleError::NoPublisherData);
+            }
+
+            Ok(median(&mut prices))
         }
     }
 }

--- a/contracts/oracle/src/storage.rs
+++ b/contracts/oracle/src/storage.rs
@@ -22,6 +22,8 @@ pub enum DataKey {
     Publishers,
     /// The latest submission from a given publisher (persistent).
     Submission(Address),
+    /// Ring buffer of the last `N` price observations, oldest first (instance).
+    History,
 }
 
 /// Snapshot of the oracle state returned by read entry points.
@@ -45,5 +47,15 @@ pub struct PublisherSubmission {
     /// The submitted price.
     pub price: i128,
     /// The unix timestamp at which the price was submitted.
+    pub timestamp: u64,
+}
+
+/// A single historical price observation, used to compute a TWAP.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PriceObservation {
+    /// The recorded price.
+    pub price: i128,
+    /// The unix timestamp at which the price was recorded.
     pub timestamp: u64,
 }

--- a/contracts/oracle/src/storage.rs
+++ b/contracts/oracle/src/storage.rs
@@ -18,6 +18,10 @@ pub enum DataKey {
     StalenessThreshold,
     /// The unix timestamp at which the price was last updated.
     UpdatedAtTimestamp,
+    /// The admin-configured set of authorized publishers (persistent).
+    Publishers,
+    /// The latest submission from a given publisher (persistent).
+    Submission(Address),
 }
 
 /// Snapshot of the oracle state returned by read entry points.
@@ -32,4 +36,14 @@ pub struct PriceData {
     pub admin: Address,
     /// The configured staleness threshold, in ledgers.
     pub staleness_threshold: u32,
+}
+
+/// A single publisher's latest price submission.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PublisherSubmission {
+    /// The submitted price.
+    pub price: i128,
+    /// The unix timestamp at which the price was submitted.
+    pub timestamp: u64,
 }

--- a/contracts/oracle/src/storage.rs
+++ b/contracts/oracle/src/storage.rs
@@ -16,6 +16,8 @@ pub enum DataKey {
     UpdatedAt,
     /// The maximum age, in ledgers, before a price is considered stale.
     StalenessThreshold,
+    /// The unix timestamp at which the price was last updated.
+    UpdatedAtTimestamp,
 }
 
 /// Snapshot of the oracle state returned by read entry points.


### PR DESCRIPTION
## Summary

This PR closes four issues covering marketplace and oracle contract enhancements:

**#800 — Marketplace active-listings pagination**
- Adds `get_active_listings(cursor, limit)` to `MarketplaceContract`, returning a `ListingPage` (a `Vec<ListingEntry>` of active listings plus an optional `next_cursor`) so front-ends can browse the marketplace without external indexing.
- `limit` is clamped to `[1, MAX_LISTINGS_PAGE_SIZE]` (50) to bound the size of a single response.

**#801 — Oracle price staleness check (timestamp-based)**
- Adds `get_price_checked(max_age)`, which errors with `OracleError::StalePrice` if `env.ledger().timestamp() - last_updated > max_age`.
- This complements the existing ledger-sequence-based `staleness_threshold` check in `get_price()` with a caller-specified, wall-clock-time tolerance.
- `update_price` now also records the unix timestamp of each update (`DataKey::UpdatedAtTimestamp`).

**#802 — Oracle multi-publisher support with median aggregation**
- Adds `set_publishers(admin, publishers)` so the admin can configure/replace the set of addresses authorized to submit prices.
- Adds `submit_price(publisher, price)`, restricted to the configured publisher set.
- Adds `get_median_price()`, which computes the median over the latest submission from each authorized publisher, returning `OracleError::NoPublisherData` if none have submitted yet.
- This is additive alongside the existing single-admin `update_price`/`get_price` flow, so existing behavior and tests are unaffected.

**#803 — Oracle price history for TWAP**
- Both `update_price` and `submit_price` now record each price observation (price + timestamp) into a ring buffer capped at `MAX_HISTORY` (30) entries, dropping the oldest once full.
- Adds `get_twap(window)`, which computes a time-weighted average price over observations from the last `window` seconds, weighting each by how long it held before the next observation (or now, for the most recent). Returns `OracleError::InsufficientHistory` if no observation falls within the window.

**Incidental fix**
- `contracts/marketplace/src/lib.rs` had a pre-existing bug on `main`: an orphaned, unclosed fragment of the `buy()` transfer logic sitting between `list()` and `buy()`, which broke compilation for the whole crate. Removed it (the real `buy()` implementation later in the file was already complete and correct) since it blocked building anything else in this file.

## Test plan
- [x] `cargo test` passes for `contracts/marketplace` (9/9 existing tests) and `contracts/oracle` (8/8 existing tests) — no regressions.
- [x] `cargo check` passes for both crates.
- [x] Manually exercised the new median/TWAP logic locally (multi-publisher median with odd/even counts, publisher authorization rejection, TWAP over multiple observations and empty-window error case) before removing the scratch tests — no new tests were added per the task instructions.

Closes #800
Closes #801
Closes #802
Closes #803
