### PR TITLE
docs: sequence diagrams, testing coverage matrix, gas costs for newer contracts, French README

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -6,6 +6,7 @@
 Una colección curada de plantillas de contratos inteligentes Soroban listos para producción. Estas plantillas ayudan a los desarrolladores a iniciar rápidamente casos de uso comunes en Soroban (la plataforma de contratos inteligentes de Stellar) para DeFi, pagos, gobernanza y más.
 
 > **English version**: [README.md](README.md)
+> **Disponible en français**: [README.fr.md](README.fr.md)
 
 ## 🚀 Inicio Rápido
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,389 @@
+# Modèles de Contrats Soroban
+
+[![CI](https://github.com/Fidelis900/soroban-starter-kit/actions/workflows/ci.yml/badge.svg)](https://github.com/Fidelis900/soroban-starter-kit/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/Fidelis900/soroban-starter-kit/branch/main/graph/badge.svg)](https://codecov.io/gh/Fidelis900/soroban-starter-kit)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Fidelis900/soroban-starter-kit)
+
+Une collection organisée de modèles de contrats intelligents Soroban prêts pour la production. Ces modèles aident les développeurs à démarrer rapidement des cas d'usage courants sur Soroban (la plateforme de contrats intelligents de Stellar) pour la DeFi, les paiements, la gouvernance, et plus encore.
+
+> **English version**: [README.md](README.md)
+> **También disponible en**: [Español 🇪🇸](README.es.md)
+
+## 🚀 Démarrage Rapide
+
+```bash
+# Cloner le dépôt
+git clone https://github.com/your-username/soroban-contract-templates.git
+cd soroban-contract-templates
+
+# Construire tous les contrats
+make build
+
+# Exécuter les tests
+make test
+
+# Relancer les tests automatiquement à chaque modification (nécessite cargo-watch)
+make watch
+
+# Déployer sur testnet
+make deploy-testnet
+
+# Voir toutes les commandes disponibles
+make help
+```
+
+Ou utilisez `just` (voir [dev-environment.md](docs/dev-environment.md) pour l'installation) :
+
+```bash
+just build
+just test
+just deploy-testnet
+just --list
+```
+
+## 📦 Modèles de Contrats
+
+| Modèle | Description | Cas d'Usage | Statut |
+|----------|-------------|-----------|---------|
+| **Token** | Token fongible personnalisé avec contrôles mint/burn/admin | Tokens DeFi, tokens de gouvernance, tokens utilitaires | ✅ Complet |
+| **Escrow** | Séquestre entre deux parties avec délai et mécanisme de remboursement | Échanges P2P, paiements de services, paiements par étapes | ✅ Complet |
+| **Vesting** | Acquisition de tokens avec cliff + calendrier de libération linéaire | Allocations d'équipe, blocages d'investisseurs, attributions employés | ✅ Complet |
+| **Staking** | Staking de tokens avec distribution proportionnelle des récompenses | Rendement DeFi, incitations de protocole, minage de liquidité | ✅ Complet |
+| **Multisig** | Portefeuille N-parmi-M pour appels de contrats approuvés par seuil | Trésoreries de DAO, portefeuilles d'équipe, administration partagée | ✅ Complet |
+| **Subscription** | Contrat de paiement récurrent par prélèvement de tokens | Facturation SaaS, paiements en continu, frais d'adhésion | ✅ Complet |
+| **Timelock** | Libération de tokens verrouillée dans le temps vers un bénéficiaire | Blocages de tokens d'équipe, paiements différés, timelocks de gouvernance | ✅ Complet |
+| **NFT** | Token non fongible avec mint administré et plafond d'offre optionnel | Objets de collection numériques, propriété on-chain, tokens d'accès | ✅ Complet |
+| **DAO** | Gouvernance on-chain avec vote pondéré par les tokens | Mises à jour de protocole, gestion de trésorerie, décisions communautaires | ✅ Complet |
+| **Swap** | Échange atomique de tokens entre deux parties avec délai | Échange de tokens P2P, transactions OTC, swaps DeFi sans confiance | ✅ Complet |
+| **Oracle** | Consommateur de flux de prix avec validation de fraîcheur | Flux de prix DeFi, consommation de données on-chain, vérifications de fraîcheur | ✅ Complet |
+| **Lottery** | Loterie on-chain vérifiable avec aléatoire commit-reveal | Tombolas, tirages équitables, distribution décentralisée de prix | ✅ Complet |
+
+### Fonctionnalités du Contrat Token
+- **Interface Standard** : Compatibilité complète avec le token Soroban
+- **Contrôles Administratifs** : Gestion du mint, burn et de l'admin
+- **Support des Métadonnées** : Nom, symbole et décimales
+- **Système d'Allocation** : Fonctionnalité approve et transfer_from
+- **Émission d'Événements** : Toutes les opérations émettent des événements pour le suivi
+- **Gestion des Erreurs** : Types d'erreurs personnalisés pour un meilleur débogage
+
+### Fonctionnalités du Contrat Escrow
+- **Sécurité à Deux Parties** : Transactions sécurisées acheteur-vendeur
+- **Protection par Délai** : Remboursements automatiques après le délai
+- **Support d'Arbitre** : Résolution de litiges par un tiers
+- **Gestion d'État** : Cycle de vie clair de la transaction
+- **Agnostique au Token** : Fonctionne avec n'importe quel token Soroban
+- **Émission d'Événements** : Toutes les opérations émettent des événements pour le suivi
+
+### Fonctionnalités du Contrat Vesting
+- **Calendrier Cliff + Linéaire** : Les tokens se libèrent linéairement entre `cliff_ledger` et `end_ledger`
+- **Révocation par l'Admin** : L'admin peut annuler les tokens non acquis à tout moment ; les tokens acquis restent réclamables
+- **Réclamations Incrémentales** : Le bénéficiaire réclame les tokens accumulés à la demande
+- **Agnostique au Token** : Fonctionne avec n'importe quel token compatible Soroban
+- **Émission d'Événements** : Événements `initialized`, `claimed` et `revoked` pour le suivi hors chaîne
+- **Gestion du TTL** : Le TTL du stockage d'instance est prolongé à chaque interaction
+
+### Fonctionnalités du Contrat Staking
+- **Récompenses Proportionnelles** : Les récompenses sont distribuées au prorata de la part de chaque staker dans le pool
+- **Accumulateur de Récompense par Token** : Modèle d'accumulateur global économe en gas ; aucune boucle par staker
+- **Tokens de Stake / Récompense Séparés** : Le token de stake et le token de récompense peuvent être identiques ou différents
+- **Dépôts de Récompense par l'Admin** : L'admin appelle `add_rewards` pour alimenter le pool de récompenses à tout moment
+- **Réclamations Incrémentales** : Les stakers appellent `claim_rewards` indépendamment ; les récompenses s'accumulent en continu
+- **Agnostique au Token** : Fonctionne avec n'importe quel token compatible Soroban
+- **Émission d'Événements** : Événements `staked`, `unstaked`, `rewards_claimed` et `rewards_added`
+- **Gestion du TTL** : Le TTL du stockage d'instance est prolongé à chaque interaction
+
+### Fonctionnalités du Contrat Subscription
+- **Prélèvements Initiés par le Fournisseur** : Le fournisseur de service prélève les paiements à un intervalle de ledger configurable
+- **Plans Contrôlés par l'Abonné** : Les abonnés définissent leur propre montant et intervalle ; annulation possible à tout moment
+- **Prélèvements par Allocation** : Utilise `approve` + `transfer_from` du token — aucun fonds n'est bloqué à l'avance
+- **Support de Réabonnement** : Les abonnés annulés peuvent créer un nouveau plan sans redéployer
+- **Suivi d'État** : L'état de l'abonnement (actif, dernier ledger facturé) est stocké par abonné
+- **Émission d'Événements** : Événements `subscribed`, `charged` et `cancelled` pour le suivi hors chaîne
+- **Gestion du TTL** : Le stockage d'instance et persistant sont tous deux prolongés à chaque interaction
+
+### Fonctionnalités du Contrat Multisig
+- **Autorisation N-parmi-M** : Configurez n'importe quel seuil valide parmi des signataires uniques
+- **Gestion des Signataires** : Ajout ou suppression de signataires via des changements approuvés par seuil
+- **Propositions de Transaction** : Stocke le contrat cible, la fonction et les arguments
+- **Suivi des Signatures** : Empêche les signatures dupliquées et les approbations de non-signataires
+- **Exécution par Seuil** : Exécute les appels proposés uniquement après avoir réuni suffisamment de signatures
+- **Émission d'Événements** : L'initialisation, les changements de signataires, les signatures et l'exécution émettent des événements
+
+### Fonctionnalités du Contrat Timelock
+- **Libération Verrouillée dans le Temps** : Les tokens sont retenus jusqu'à un numéro de séquence de ledger spécifié, puis libérés au bénéficiaire
+- **Annulation par l'Admin** : L'admin peut annuler et récupérer les tokens à tout moment avant la libération
+- **Libération Ouverte** : Une fois le ledger de libération atteint, `release` est appelable par n'importe qui
+- **Agnostique au Token** : Fonctionne avec n'importe quel token compatible Soroban
+- **Émission d'Événements** : Événements `initialized`, `released` et `cancelled` pour le suivi hors chaîne
+- **Gestion du TTL** : Le TTL du stockage d'instance est prolongé à chaque interaction
+
+### Fonctionnalités du Contrat NFT
+- **Propriété Unique du Token** : Chaque ID de token correspond exactement à un propriétaire suivi en stockage persistant
+- **Mint Contrôlé par l'Admin** : Seul l'admin peut créer de nouveaux tokens ; un plafond d'offre optionnel est appliqué au moment du mint
+- **Opérations Standard** : `mint`, `transfer`, `burn`, `approve`, `transfer_from` correspondant à la sémantique ERC-721
+- **Métadonnées par Token** : Chaque token possède une URI associée stockée on-chain ; la collection a un nom et un symbole
+- **Système d'Approbation** : Les approbations d'un seul token sont automatiquement effacées lors d'un transfert ou d'un burn
+- **Tests de Propriétés** : La suite proptest vérifie les invariants d'offre et l'exactitude de la propriété
+- **Émission d'Événements** : Événements `minted`, `transferred`, `burned` et `approved`
+
+### Fonctionnalités du Contrat DAO
+- **Vote Pondéré par les Tokens** : Le pouvoir de vote est égal au solde de tokens du votant au moment du vote
+- **Paramètres Configurables** : Période de vote (en ledgers) et seuil de quorum définis à l'initialisation
+- **Cycle de Vie de la Proposition** : `Active → Exécutée` (adoptée) ou `Active → Annulée` (admin)
+- **Quorum + Majorité** : Les propositions ne s'exécutent que lorsque le total des votes ≥ quorum ET oui > non
+- **Prévention du Double Vote** : Chaque adresse ne peut voter qu'une seule fois par proposition
+- **Émission d'Événements** : Événements `proposal_created`, `voted`, `prop_executed` et `prop_cancelled`
+- **Gestion du TTL** : Les enregistrements persistants de proposition et de vote sont prolongés à chaque écriture
+
+### Fonctionnalités du Contrat Swap
+- **Échange Atomique** : Les deux transferts de tokens se produisent en une seule transaction — aucun remplissage partiel
+- **Expiration par Délai** : Les swaps expirent après un ledger configurable ; n'importe qui peut annuler pour récupérer les tokens de la partie A
+- **Contrôle de la Partie A** : La partie A peut annuler tout swap ouvert avant qu'il ne soit accepté
+- **Support Multi-Swap** : Plusieurs swaps concurrents suivis par des IDs auto-incrémentés
+- **Agnostique au Token** : Fonctionne avec n'importe quelle paire de tokens compatibles Soroban
+- **Émission d'Événements** : Événements `swap_proposed`, `swap_accepted` et `swap_cancelled`
+
+### Fonctionnalités du Contrat Oracle
+- **Consommateur de Flux de Prix** : L'admin pousse les mises à jour de prix ; les consommateurs lisent via `get_price`
+- **Validation de Fraîcheur** : `get_price` rejette les prix plus anciens que le seuil de ledger configuré
+- **Mises à Jour Contrôlées par l'Admin** : Seul l'admin peut pousser de nouveaux prix
+- **Seuil Configurable** : Le seuil de fraîcheur est défini à l'initialisation
+- **Émission d'Événements** : Événements `initialized` et `price_updated`
+- **Gestion du TTL** : Le TTL du stockage d'instance est prolongé à chaque interaction
+
+### Fonctionnalités du Contrat Lottery
+- **Aléatoire Commit-Reveal** : L'admin s'engage sur `hash(secret ++ salt)` avant le tirage, puis révèle pour prouver l'équité
+- **Achat de Billets** : N'importe quelle adresse achète des billets avant que l'admin ne s'engage
+- **Sélection Vérifiable du Gagnant** : L'index du gagnant est dérivé du SHA-256 du secret révélé, du sel et de la séquence de ledger
+- **Distribution du Pool de Prix** : Le pool complet des billets est transféré au gagnant de manière atomique
+- **Machine à États** : Ouvert → Engagé → Tiré — chaque transition est irréversible
+- **Émission d'Événements** : Événements `initialized`, `ticket_purchased`, `committed` et `winner_drawn`
+
+Chaque modèle inclut :
+- ✅ Implémentation complète du contrat
+- ✅ Tests unitaires exhaustifs (8+ cas de test chacun)
+- ✅ Scripts de déploiement avec exemples
+- ✅ Exemples d'utilisation et documentation
+
+## 🛠 Prérequis
+
+- [Rust](https://rustup.rs/) **1.82.0** (fixé via `rust-toolchain.toml` — `rustup` le détecte automatiquement)
+- [Soroban CLI](https://soroban.stellar.org/docs/getting-started/setup#install-the-soroban-cli)
+- [Docker](https://www.docker.com/) (pour un nœud Stellar local)
+
+> **Option sans installation :** Ouvrez ce dépôt dans un environnement préconfiguré avec tous les outils prêts — voir le [Guide Dev Container & Codespaces](docs/devcontainer.md).
+
+### Configuration VS Code
+
+Un fichier [.vscode/extensions.json](.vscode/extensions.json) est inclus avec des extensions recommandées pour une expérience de développement cohérente. VS Code vous proposera de les installer à l'ouverture du projet, ou vous pouvez les installer manuellement :
+
+| Extension | Utilité |
+|-----------|---------|
+| `rust-lang.rust-analyzer` | Serveur de langage Rust (complétion, aller à la définition, erreurs en ligne) |
+| `tamasfe.even-better-toml` | Coloration syntaxique et validation pour `Cargo.toml` |
+| `serayuzgur.crates` | Indications de version de crate en ligne et avertissements de dépendances obsolètes |
+| `usernamehw.errorlens` | Messages de diagnostic affichés directement dans l'éditeur |
+
+## 🔄 Matrice de Compatibilité
+
+Ce dépôt est fixé sur `soroban-sdk = "=21.7.7"`. Chaque version majeure du SDK est étroitement couplée à une version du protocole réseau Stellar. Utilisez le tableau ci-dessous pour choisir le bon SDK pour votre réseau cible.
+
+> ⚠️ **Vérifiez toujours la compatibilité avant de déployer sur Mainnet.** Les contrats compilés avec le SDK v21 ne fonctionneront pas sur un nœud exécutant le Protocol 22 ou une version ultérieure sans recompilation avec la version de SDK correspondante.
+
+| Version soroban-sdk | Protocole Stellar | Statut Réseau | Notes |
+|---------------------|-----------------|----------------|-------|
+| `21.x` (ce dépôt : `21.7.7`) | Protocol 21 | Mainnet (juin 2024) | secp256r1, extension TTL séparée pour l'instance/le code |
+| `22.x` | Protocol 22 | Mainnet (déc. 2024) | Support des constructeurs, fonctions hôtes BLS12-381 |
+| `23.x` | Protocol 23 « Whisk » | Mainnet (sept. 2025) | Événements unifiés (CAP-67), archivage d'état (CAP-62/66) |
+| `25.x` | Protocol 25 « X-Ray » | Mainnet (jan. 2026) | Opérations de courbe elliptique BN254, fonctions de hachage Poseidon |
+| `26.x` | Protocol 26 « Yardstick » | Mainnet (mai 2026) | Gel des entrées de ledger, conversions d'adresses muxed, ZK BN254 |
+
+**Pour mettre à jour ce dépôt vers un SDK plus récent :**
+1. Mettez à jour `soroban-sdk = "=<nouvelle-version>"` dans `Cargo.toml`.
+2. Mettez à jour `stellar-cli` vers la version correspondante (`cargo install stellar-cli --version <nouvelle-version>`).
+3. Reconstruisez tous les contrats et exécutez la suite de tests complète.
+4. Mettez à jour cette matrice et `docs/gas-costs.md` avec la nouvelle version de protocole et le nouveau barème de frais.
+
+Pour la table de versions faisant autorité, voir [Stellar Software Versions](https://developers.stellar.org/docs/networks/software-versions).
+
+## 📖 Utilisation
+
+### Construire les Contrats
+
+```bash
+cd contracts/[nom-du-modele]
+stellar contract build
+```
+
+### Exécuter les Tests
+
+```bash
+cd contracts/[nom-du-modele]
+cargo test
+```
+
+### Déployer sur Testnet
+
+```bash
+cd contracts/[nom-du-modele]
+./scripts/deploy.sh testnet
+```
+
+### Développement Local
+
+Démarrez un nœud Stellar local avec RPC Soroban :
+
+```bash
+docker compose up stellar-node
+```
+
+### Créer un Nouveau Contrat
+
+Générez un nouveau contrat à partir du squelette `contracts/common` avec une seule commande :
+
+```bash
+./scripts/new-contract.sh <nom-du-contrat>
+```
+
+**Exemple** — créer un contrat `price-feed` :
+
+```bash
+./scripts/new-contract.sh price-feed
+```
+
+Cela crée `contracts/price-feed/` (avec `Cargo.toml` et `src/lib.rs`) et l'enregistre dans le workspace. Vérifiez immédiatement qu'il compile et que son test passe :
+
+```bash
+cargo check -p soroban-price-feed
+cargo test  -p soroban-price-feed
+```
+
+Remplacez ensuite la méthode `hello()` du squelette dans `contracts/price-feed/src/lib.rs` par la logique de votre contrat.
+
+## ⚠️ Référence des Erreurs
+
+> Pour tous les détails — causes, déclencheurs et étapes de résolution — voir [docs/error-reference.md](docs/error-reference.md).
+
+### Erreurs du Contrat Token (`TokenError`)
+
+| Code | Nom | Description |
+|------|------|-------------|
+| 1 | `InsufficientBalance` | Le solde de l'appelant est trop faible pour effectuer le transfert ou le burn |
+| 2 | `InsufficientAllowance` | L'allocation approuvée est trop faible pour le montant `transfer_from` demandé |
+| 3 | `Unauthorized` | L'appelant n'est pas l'admin ou n'a pas la permission pour cette opération |
+| 4 | `AlreadyInitialized` | `initialize` a été appelé sur un contrat déjà configuré |
+| 5 | `NotInitialized` | Une opération a été tentée avant l'initialisation du contrat |
+| 6 | `InvalidAmount` | Le montant est nul, négatif, ou dépasse l'offre maximale configurée |
+| 7 | `Overflow` | Un débordement arithmétique s'est produit lors d'un calcul de solde ou d'offre |
+
+### Erreurs du Contrat Escrow (`EscrowError`)
+
+| Code | Nom | Description |
+|------|------|-------------|
+| 1 | `NotAuthorized` | L'appelant n'est pas autorisé à invoquer cette fonction (mauvaise partie ou arbitre) |
+| 2 | `InvalidState` | Le séquestre n'est pas dans l'état requis pour cette opération |
+| 3 | `DeadlinePassed` | Le délai du séquestre est déjà écoulé ; l'opération n'est plus valide |
+| 4 | `DeadlineNotReached` | Le délai n'est pas encore passé ; tentative prématurée de remboursement ou de réclamation de timeout |
+| 5 | `AlreadyInitialized` | `initialize` a été appelé sur un séquestre déjà configuré |
+| 6 | `NotInitialized` | Une opération a été tentée avant l'initialisation du séquestre |
+| 7 | `InsufficientFunds` | Le solde de tokens de l'acheteur est trop faible pour couvrir le montant séquestré |
+| 8 | `InvalidAmount` | Le montant spécifié est nul ou autrement invalide |
+| 9 | `InvalidParties` | Les adresses de l'acheteur, du vendeur ou de l'arbitre sont invalides ou en conflit |
+
+### Erreurs du Contrat Vesting (`VestingError`)
+
+| Code | Nom | Description |
+|------|------|-------------|
+| 1 | `AlreadyInitialized` | `initialize` a été appelé sur un contrat déjà configuré |
+| 2 | `NotInitialized` | Une opération a été tentée avant l'initialisation du contrat |
+| 3 | `Unauthorized` | L'appelant n'est pas l'admin |
+| 4 | `InvalidAmount` | Le montant d'acquisition est nul ou négatif |
+| 5 | `InvalidSchedule` | `cliff_ledger` >= `end_ledger`, ou `end_ledger` est dans le passé |
+| 6 | `NothingToClaim` | Aucun token n'a été acquis depuis la dernière réclamation (ou le montant acquis est nul) |
+| 7 | `AlreadyRevoked` | `revoke` a été appelé sur un calendrier déjà révoqué |
+
+### Erreurs du Contrat Staking (`StakingError`)
+
+| Code | Nom | Description |
+|------|------|-------------|
+| 1 | `AlreadyInitialized` | `initialize` a été appelé sur un contrat déjà configuré |
+| 2 | `NotInitialized` | Une opération a été tentée avant l'initialisation du contrat |
+| 3 | `Unauthorized` | L'appelant n'est pas l'admin |
+| 4 | `InvalidAmount` | Le montant est nul ou négatif |
+| 5 | `NoStake` | Le staker n'a aucun stake à retirer ou dont réclamer des récompenses |
+| 6 | `InsufficientStake` | Le montant de retrait demandé dépasse le stake actuel du staker |
+| 7 | `NoRewards` | Aucune récompense disponible à réclamer |
+
+### Erreurs du Contrat Multisig (`MultisigError`)
+
+| Code | Nom | Description |
+|------|------|-------------|
+| 1 | `AlreadyInitialized` | `initialize` a été appelé après que l'ensemble des signataires ait déjà été configuré |
+| 2 | `NotInitialized` | Une opération a été tentée avant l'initialisation du multisig |
+| 3 | `InvalidThreshold` | Le seuil est nul ou supérieur au nombre de signataires |
+| 4 | `InvalidSigners` | Les listes de signataires ou d'approbations sont vides ou contiennent des doublons |
+| 5 | `NotSigner` | L'appelant, l'approbateur ou le signataire ne fait pas partie de l'ensemble des signataires du portefeuille |
+| 6 | `TransactionNotFound` | L'ID de transaction demandé n'existe pas |
+| 7 | `AlreadyExecuted` | La transaction a déjà été exécutée |
+| 8 | `AlreadySigned` | Le signataire a déjà approuvé la transaction |
+| 9 | `ThresholdNotMet` | La transaction n'a pas suffisamment de signatures pour s'exécuter |
+| 10 | `InsufficientApprovals` | Le changement de gestion des signataires manque d'approbations de seuil suffisantes |
+
+## 📂 Exemples
+
+Des exemples fonctionnels de bout en bout sont fournis dans le répertoire `examples/` :
+
+| Exemple | Description |
+|---------|-------------|
+| [`examples/typescript/index.js`](examples/typescript/index.js) | Script Node.js — déploie un token, en crédite l'acheteur, exécute le cycle de vie complet d'un séquestre |
+| [`examples/shell/run.sh`](examples/shell/run.sh) | Script shell équivalent utilisant le Stellar CLI |
+
+Les deux exemples ciblent un nœud Stellar local. Démarrez-en un avec `./scripts/local-net.sh start` avant de les exécuter.
+
+### TypeScript
+
+```bash
+npm install @stellar/stellar-sdk
+TOKEN_CONTRACT_ID=<id> ESCROW_CONTRACT_ID=<id> node examples/typescript/index.js
+```
+
+### Shell
+
+```bash
+./examples/shell/run.sh
+```
+
+---
+
+## 🤝 Contribuer
+
+Les contributions sont les bienvenues ! Voir [CONTRIBUTING.md](CONTRIBUTING.md) pour la configuration de développement, les commandes de test, le style de code et le processus de PR.
+
+Un grand merci à tous nos [contributeurs](CONTRIBUTORS.md) qui ont aidé à améliorer ce projet !
+
+## 📚 Ressources
+
+- [Arborescence du Répertoire](docs/directory-tree.md) — Rôle de chaque répertoire du dépôt
+- [FAQ](docs/faq.md) — Questions fréquentes des développeurs : configuration, tests, déploiement, feature flags, personnalisation des tokens
+- [Architecture du Système](docs/architecture.md) — Conception de haut niveau, relations entre contrats, niveaux de stockage, modèle d'événements et cadre d'administration
+- [Référence de l'API des Contrats](docs/contract-api.md) — API publique complète de tous les contrats (paramètres, types de retour, erreurs)
+- [Guide de Mise à Niveau](docs/upgrade-guide.md) — Mise à niveau WASM on-chain étape par étape avec timelock et rotation de clés
+- [Bonnes Pratiques de Sécurité](docs/security.md)
+- [Guide d'Intégration](docs/integration-guide.md)
+- [Guide de Déploiement](docs/deployment-guide.md)
+- [Documentation Soroban](https://soroban.stellar.org/docs)
+- [Discord des Développeurs Stellar](https://discord.gg/stellardev)
+- [Exemples Soroban](https://github.com/stellar/soroban-examples)
+- [Portefeuille Freighter](https://freighter.app/)
+- [Stellar Laboratory](https://laboratory.stellar.org/)
+- [ADR de Conformité de l'Interface Token](docs/adr/0007-token-interface-compliance.md)
+- [ADR de Conception du Batch Mint](docs/adr/0009-batch-mint-design.md)
+- [Registres de Décisions d'Architecture](docs/adr/README.md)
+
+## 📄 Licence
+
+Ce projet est sous licence Apache License 2.0 - voir le fichier [LICENSE](LICENSE) pour plus de détails.
+
+---
+
+**Prêt à construire sur Soroban ?** Commencez avec n'importe quel modèle et personnalisez-le pour votre cas d'usage ! 🚀

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A curated collection of production-ready Soroban smart contract templates. These templates help developers quickly bootstrap common use cases on Soroban (Stellar's smart contract platform) for DeFi, payments, governance, and more.
 
-**También disponible en**: [Español 🇪🇸](README.es.md)
+**También disponible en**: [Español 🇪🇸](README.es.md) · **Disponible en**: [Français 🇫🇷](README.fr.md)
 
 ## 🚀 Quick Start
 
@@ -360,6 +360,7 @@ A special thanks to all our [contributors](CONTRIBUTORS.md) who have helped make
 ## 📚 Resources
 
 - [Directory Tree](docs/directory-tree.md) — Purpose of every directory in the repository
+- [Translations](docs/translations.md) — Source-commit checklist for `README.es.md` / `README.fr.md`
 - [FAQ](docs/faq.md) — Common developer questions: setup, testing, deployment, feature flags, token customization
 - [System Architecture](docs/architecture.md) — High-level design, contract relationships, storage tiers, event model, and admin framework
 - [Contract API Reference](docs/contract-api.md) — Full public API for all contracts (parameters, return types, errors)
@@ -367,6 +368,8 @@ A special thanks to all our [contributors](CONTRIBUTORS.md) who have helped make
 - [Security Best Practices](docs/security.md)
 - [Integration Guide](docs/integration-guide.md)
 - [Deployment Guide](docs/deployment-guide.md)
+- [Testing Strategy](docs/testing-strategy.md) — Coverage matrix (unit/property/fuzz/integration) by contract
+- [Gas / Compute Unit Costs](docs/gas-costs.md) — Measured and estimated CU costs per contract function
 - [Soroban Documentation](https://soroban.stellar.org/docs)
 - [Stellar Developer Discord](https://discord.gg/stellardev)
 - [Soroban Examples](https://github.com/stellar/soroban-examples)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -287,6 +287,82 @@ Every entry point reads the current state first and rejects invalid transitions 
 - `Delivered` → `Refunded` (via `request_refund()` after deadline or `resolve_dispute()`)
 - `Disputed` → `Completed` or `Refunded` (via `resolve_dispute()`)
 
+---
+
+## Sequence Diagrams
+
+### Escrow Lifecycle
+
+Covers initialization, funding, the happy-path release, and the dispute path.
+
+```mermaid
+sequenceDiagram
+    actor Buyer
+    actor Seller
+    actor Arbiter
+    participant Escrow as Escrow Contract
+    participant Token as Token Contract
+
+    Buyer->>Escrow: initialize(buyer, seller, arbiter, token, amount, deadline)
+    Escrow-->>Escrow: state = Created
+
+    Buyer->>Escrow: fund()
+    Escrow->>Token: transfer(buyer, escrow, amount)
+    Token-->>Escrow: ok
+    Escrow-->>Escrow: state = Funded
+
+    Seller->>Escrow: mark_delivered()
+    Escrow-->>Escrow: state = Delivered
+
+    alt Happy path: buyer approves
+        Buyer->>Escrow: approve_delivery()
+        Escrow->>Token: transfer(escrow, seller, amount)
+        Escrow-->>Escrow: state = Completed
+    else Dispute path
+        Buyer->>Escrow: raise_dispute(caller)
+        Escrow-->>Escrow: state = Disputed
+        Arbiter->>Escrow: resolve_dispute(release_to_seller_flag)
+        alt release to seller
+            Escrow->>Token: transfer(escrow, seller, amount)
+            Escrow-->>Escrow: state = Completed
+        else refund to buyer
+            Escrow->>Token: transfer(escrow, buyer, amount)
+            Escrow-->>Escrow: state = Refunded
+        end
+    end
+```
+
+### Multisig Lifecycle
+
+Covers proposing a transaction, collecting threshold signatures, and execution against the target contract.
+
+```mermaid
+sequenceDiagram
+    actor Proposer as Signer (proposer)
+    actor Signer2 as Signer (additional)
+    participant Multisig as Multisig Contract
+    participant Target as Target Contract
+
+    Proposer->>Multisig: propose_transaction(target, function, args)
+    Multisig-->>Multisig: store Transaction { signatures: [proposer] }
+    Multisig-->>Multisig: emit transaction_proposed(tx_id, proposer)
+
+    Proposer->>Multisig: sign_transaction(tx_id)
+    Multisig-->>Multisig: emit transaction_signed(tx_id, proposer, count=1)
+
+    loop until signature_count >= threshold
+        Signer2->>Multisig: sign_transaction(tx_id)
+        Multisig-->>Multisig: emit transaction_signed(tx_id, signer, count=N)
+    end
+
+    Signer2->>Multisig: execute_transaction(tx_id)
+    Multisig-->>Multisig: verify signature_count >= threshold
+    Multisig->>Target: invoke(function, args)
+    Target-->>Multisig: result
+    Multisig-->>Multisig: mark executed
+    Multisig-->>Multisig: emit transaction_executed(tx_id)
+```
+
 ### Checks-Effects-Interactions (CEI) Pattern
 
 All token transfers happen **after** state is updated:

--- a/docs/gas-costs.md
+++ b/docs/gas-costs.md
@@ -103,6 +103,175 @@ usage and the validator-set limits in effect.
 
 ---
 
+## Newer Contracts
+
+The contracts below were added after the initial Token/Escrow benchmark suite
+and do not yet have dedicated Criterion benches under `benches/`. Figures here
+are **estimated**, not measured — see [Methodology](#methodology-for-newer-contracts)
+for how they were derived. Treat them as order-of-magnitude guides only, and
+prefer the measured Token/Escrow figures above when precision matters.
+
+### Airdrop Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~450 000 | 4 writes (instance) | 0 | Stores merkle root, token, admin |
+| `set_root` | ~150 000 | 1 write (instance) | 0 | Admin auth required |
+| `claim` | ~750 000 | 1 read + 1 write (persistent) | 1 (contract → claimant) | Merkle proof verification adds hashing cost |
+| `claim_batch` | ~750 000 × N | N reads + N writes (persistent) | N | Cost scales linearly with batch size |
+| `is_claimed` / `get_root` | ~60 000 | 1 read | 0 | Read-only |
+
+### Auction Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `start` | ~500 000 | 6 writes (instance) | 0 | Seller auth; stores auction terms |
+| `bid` | ~950 000 | 3 reads + 2 writes (instance) | 1 (bidder → contract) | Refunds prior high bidder to pending balance |
+| `cancel` | ~200 000 | 2 reads + 1 write (instance) | 0 | Only valid before any bid |
+| `end` | ~950 000 | 2 reads + 1 write (instance) | 1 (contract → seller) | Settles highest bid |
+| `withdraw` | ~700 000 | 2 reads + 1 write (instance) | 1 (contract → bidder) | Pulls pending refund balance |
+| `get_pending` / `get_info` | ~70 000 | 1-2 reads | 0 | Read-only |
+
+### Ballot Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~400 000 | 3 writes (instance) | 0 | No token dependency |
+| `register_voter` / `deregister_voter` | ~200 000 | 1 read + 1 write (persistent) | 0 | Admin auth required |
+| `vote` | ~300 000 | 2 reads + 2 writes (persistent + instance) | 0 | Prevents double voting |
+| `tally` / `get_yes_votes` / `get_no_votes` | ~55 000 | 1 read (instance) | 0 | Read-only |
+
+### Bonding-Curve Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~450 000 | 4 writes (instance) | 0 | Stores curve slope + token references |
+| `buy` | ~900 000 | 2 reads + 2 writes (instance) | 1 (buyer → contract) | Price computed from reserve/supply curve before transfer |
+| `sell` | ~900 000 | 2 reads + 2 writes (instance) | 1 (contract → seller) | Same curve math, reverse direction |
+| `get_reserve` / `get_supply` / `get_price` | ~55 000 | 1 read (instance) | 0 | Read-only |
+
+### Crowdfund Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~500 000 | 5 writes (instance) | 0 | Stores goal, deadline, token |
+| `pledge` | ~900 000 | 2 reads + 2 writes (persistent + instance) | 1 (pledger → contract) | Tracks per-pledger amount |
+| `withdraw` (creator, goal met) | ~900 000 | 2 reads + 1 write (instance) | 1 (contract → creator) | Only after deadline + goal reached |
+| `extend_deadline` | ~150 000 | 1 read + 1 write (instance) | 0 | Creator auth required |
+| `claim` | ~900 000 | 2 reads + 1 write (instance) | 1 (contract → creator) | Alias path for goal-met payout |
+| `refund` | ~900 000 | 2 reads + 2 writes (persistent + instance) | 1 (contract → pledger) | Only if goal not met after deadline |
+| `get_info` / `get_pledge` | ~65 000 | 1 read | 0 | Read-only |
+
+### Lottery Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~450 000 | 4 writes (instance) | 0 | Sets ticket price, token |
+| `buy_ticket` | ~750 000 | 2 reads + 2 writes (persistent + instance) | 1 (buyer → contract) | Increments ticket count |
+| `commit` | ~200 000 | 1 write (instance) | 0 | Admin commits `hash(secret ++ salt)` |
+| `draw` | ~950 000 | 3 reads + 2 writes (instance) | 1 (contract → winner) | SHA-256 reveal check + winner payout |
+| `claim_refund` | ~750 000 | 2 reads + 1 write (persistent) | 1 (contract → buyer) | Refund path if lottery cancelled |
+| `get_info` / `get_winner` / `get_ticket_count` | ~60 000 | 1 read | 0 | Read-only |
+
+### Marketplace Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~450 000 | 3 writes (instance) | 0 | Stores payment token, fee config |
+| `list` / `list_with_expiry` | ~500 000 | 1 read + 2 writes (persistent) | 0 | Cross-contract check against NFT owner |
+| `buy` | ~1 150 000 | 3 reads + 2 writes (persistent) | 1-2 (buyer → seller, optional royalty) + 1 NFT `transfer_from` | Most expensive path: two token transfers plus an NFT transfer |
+| `cancel` | ~200 000 | 2 reads + 1 write (persistent) | 0 | Seller auth required |
+| `sweep_expired` | ~200 000 × N | N reads + N writes (persistent) | 0 | Cost scales with number of expired listings swept |
+| `make_offer` | ~900 000 | 2 reads + 2 writes (persistent) | 1 (offerer → contract, escrowed) | Escrows offer amount until accepted/cancelled |
+| `accept_offer` | ~1 150 000 | 3 reads + 2 writes (persistent) | 1-2 + 1 NFT `transfer_from` | Same shape as `buy` |
+| `cancel_offer` | ~700 000 | 2 reads + 1 write (persistent) | 1 (contract → offerer) | Returns escrowed offer amount |
+| `get_listing` / `get_offer` / `get_active_listings` | ~70 000 | 1 read | 0 | Read-only |
+
+### Oracle Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~350 000 | 3 writes (instance) | 0 | No token dependency |
+| `update_price` | ~150 000 | 1 write (instance) | 0 | Admin-pushed single price |
+| `set_publishers` | ~200 000 | 1 write (instance) | 0 | Admin-managed publisher set |
+| `submit_price` | ~250 000 | 2 reads + 1 write (persistent) | 0 | Per-publisher price submission |
+| `get_price` / `get_price_checked` / `get_price_data` | ~55 000 | 1 read (instance) | 0 | Read-only; `_checked` variant adds an age comparison |
+| `get_median_price` / `get_twap` | ~120 000 | N reads (persistent) | 0 | Cost scales with number of publisher submissions / window size |
+
+### Subscription Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~350 000 | 3 writes (instance) | 0 | Stores provider + token |
+| `subscribe` | ~250 000 | 1 write (persistent) | 0 | Subscriber sets own amount/interval; no funds move yet |
+| `charge` | ~750 000 | 2 reads + 1 write (persistent) | 1 (`transfer_from`, subscriber → provider) | Allowance-based pull; provider-initiated |
+| `cancel` | ~150 000 | 1 read + 1 write (persistent) | 0 | Subscriber auth required |
+| `get_subscription` / `get_provider` / `get_token` | ~55 000 | 1 read | 0 | Read-only |
+
+### Swap Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `propose_swap` | ~950 000 | 1 write (persistent) | 1 (Party A → contract, escrowed) | Escrows Party A's tokens on proposal |
+| `accept_swap` | ~1 400 000 | 2 reads + 1 write (persistent) | 2 (Party B → Party A, contract → Party B) | Atomic two-directional settlement |
+| `cancel_swap` | ~700 000 | 2 reads + 1 write (persistent) | 1 (contract → Party A) | Only before acceptance or after expiry |
+| `get_swap` / `swap_count` | ~55 000 | 1 read | 0 | Read-only |
+
+### Timelock Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~550 000 | 6 writes (instance) | 1 (beneficiary/admin → contract, if funded at init) | Stores beneficiary, release ledger, token |
+| `release` | ~700 000 | 2 reads + 1 write (instance) | 1 (contract → beneficiary) | Callable by anyone once release ledger reached |
+| `cancel` | ~700 000 | 2 reads + 1 write (instance) | 1 (contract → admin) | Only before release ledger |
+| `get_info` / `is_releasable` / `get_remaining_ledgers` | ~55 000 | 1 read (instance) | 0 | Read-only |
+
+### Vesting Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~550 000 | 6 writes (instance) | 0 | Stores cliff/end ledgers, admin, token |
+| `claim` | ~700 000 | 2 reads + 1 write (instance) | 1 (contract → beneficiary) | Computes linearly-vested amount since last claim |
+| `revoke` | ~750 000 | 2 reads + 2 writes (instance) | 1 (contract → beneficiary, remaining vested) | Admin auth; unvested amount stays with admin |
+| `admin_release` | ~700 000 | 2 reads + 1 write (instance) | 1 (contract → admin) | Reclaims unvested tokens post-revoke |
+| `get_info` / `claimable` / `contract_version` | ~55 000 | 1 read (instance) | 0 | Read-only |
+
+### Wrapped-Token Contract
+
+| Function | Estimated CUs (approx.) | Storage ops | Token transfers | Notes |
+|---|---|---|---|---|
+| `initialize` | ~400 000 | 3 writes (instance) | 0 | Stores underlying + wrapped token references |
+| `wrap` | ~900 000 | 1 read + 1 write (instance) | 1 (user → contract) + 1 wrapped-token mint | Deposits underlying, mints wrapped 1:1 |
+| `unwrap` | ~900 000 | 1 read + 1 write (instance) | 1 wrapped-token burn + 1 (contract → user) | Burns wrapped, releases underlying 1:1 |
+| `get_total_wrapped` | ~55 000 | 1 read (instance) | 0 | Read-only |
+
+### Methodology for Newer Contracts
+
+Unlike the Token and Escrow tables above (measured via the Criterion benches in
+`benches/`), the tables in this section were **derived, not measured**:
+
+1. Each function's storage reads/writes were counted by inspecting
+   `contracts/<name>/src/lib.rs` for `env.storage()` calls.
+2. Cross-contract token transfers (`token::Client::...transfer`,
+   `transfer_from`, mint/burn on a wrapped/NFT contract) were counted from the
+   same source pass.
+3. Those counts were multiplied against the flat per-operation costs already
+   established in the [Cost Breakdown by Operation Type](#cost-breakdown-by-operation-type)
+   table above (e.g. instance write ≈ 10,000 CUs, cross-contract token
+   transfer ≈ 500,000–700,000 CUs, `require_auth` ≈ 50,000–100,000 CUs) to
+   arrive at a rough total.
+4. No Criterion bench currently exists for these contracts under
+   `benches/benches/`. Adding one per contract (following the pattern of
+   `token_ops.rs` / `escrow_ops.rs`) and wiring it into
+   `.github/workflows/bench.yml` would let these figures move from *estimated*
+   to *measured* — tracked as follow-up work, not yet filed as an issue.
+
+Because these figures are model-derived rather than measured, treat them as
+directionally useful for comparing "cheap read" vs. "expensive multi-transfer
+call" rather than as precise fee predictions.
+
+---
+
 ## Reproducing the Measurements
 
 Run the Criterion benchmarks locally to get instruction counts for your

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,47 @@
+# Testing Strategy
+
+This document tracks what kind of test coverage exists for each contract template, so gaps are visible at a glance rather than discovered while debugging a regression.
+
+## Test Types
+
+| Type | What it checks | Where it lives |
+|------|-----------------|-----------------|
+| **Unit** | Individual entry points, error paths, auth checks | `contracts/<name>/src/test.rs` (or a `#[cfg(test)]` module in `lib.rs`) |
+| **Property** | Invariants that must hold across randomized inputs (e.g. "supply is conserved", "no double-spend") | `contracts/<name>/src/prop_test.rs`, run via `proptest` |
+| **Fuzz** | Crash/panic resistance against arbitrary byte input, via `cargo-fuzz` | `fuzz/fuzz_targets/*.rs` |
+| **Integration** | Multiple deployed contracts interacting in one `Env` (e.g. token + escrow) | `tests/src/*.rs`, `tests/tests/*.rs` |
+
+## Coverage Matrix
+
+| Contract | Unit | Property | Fuzz | Integration |
+|----------|:----:|:--------:|:----:|:------------:|
+| `airdrop` | ✅ | ❌ | ❌ | ❌ |
+| `auction` | ✅ | ❌ | ❌ | ❌ |
+| `ballot` | ✅ | ❌ | ❌ | ❌ |
+| `bonding-curve` | ✅ | ❌ | ❌ | ❌ |
+| `crowdfund` | ✅ | ❌ | ❌ | ❌ |
+| `dao` | ✅ | ❌ | ❌ | ❌ |
+| `escrow` | ✅ | ✅ | ✅ | ✅ |
+| `lottery` | ✅ | ❌ | ❌ | ❌ |
+| `marketplace` | ✅ | ❌ | ❌ | ❌ |
+| `multisig` | ✅ | ✅ | ❌ | ❌ |
+| `nft` | ✅ | ✅ | ❌ | ❌ |
+| `oracle` | ✅ | ❌ | ❌ | ❌ |
+| `staking` | ✅ | ✅ | ❌ | ❌ |
+| `subscription` | ✅ | ❌ | ❌ | ❌ |
+| `swap` | ✅ | ❌ | ❌ | ❌ |
+| `timelock` | ✅ | ❌ | ❌ | ❌ |
+| `token` | ✅ | ✅ | ✅ | ✅ |
+| `vesting` | ✅ | ✅ | ❌ | ❌ |
+| `wrapped-token` | ✅ | ❌ | ❌ | ❌ |
+
+_Generated against the contract list under `contracts/` and the test files present as of 2026-07-27; `contracts/common` is a shared library, not a deployable template, and is excluded._
+
+## Gaps
+
+- **No fuzz targets outside `token` and `escrow`.** `fuzz/fuzz_targets/` currently only has `token_fuzz.rs`, `token_mint_burn.rs`, and `escrow_initialize.rs`. Every other contract — including state-machine-heavy ones like `auction`, `lottery`, and `marketplace` — has no fuzz coverage. No tracking issue exists for this yet; file one against the `testing` area before picking it up so work isn't duplicated.
+- **No property tests outside `escrow`, `multisig`, `nft`, `staking`, and `token`.** Contracts with numeric invariants worth property-testing (`bonding-curve` pricing curve, `auction` bid/refund accounting, `crowdfund` pledge/refund accounting, `lottery` payout accounting) currently rely on example-based unit tests only.
+- **Integration tests only cover the token ↔ escrow pair** (`tests/tests/integration.rs`, tracking prior issues #221/#222). Contracts that compose with a token in production — `airdrop`, `auction`, `crowdfund`, `marketplace`, `subscription`, `swap`, `vesting`, `wrapped-token` — have no cross-contract integration test exercising a real token client instead of a mock.
+- **`bonding-curve` and `wrapped-token`** have the thinnest unit suites (3 and 2 test functions respectively) relative to their entry-point count; see `docs/gas-costs.md` for their full entry-point lists.
+
+When closing a gap, add a row update here in the same PR as the new tests so this matrix doesn't drift from reality.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,17 @@
+# README Translations
+
+Tracks which commit of `README.md` each translation was produced from, so it's
+easy to tell when a translation has drifted out of sync with the source.
+
+| File | Language | Source commit | Notes |
+|------|----------|----------------|-------|
+| [`README.es.md`](../README.es.md) | Español | `c89f7186` | Predates the "VS Code Setup" and "Creating a New Contract" sections and the Directory Tree / Contract API Reference / Upgrade Guide resource links added to `README.md` since — **out of sync**, needs a refresh pass. |
+| [`README.fr.md`](../README.fr.md) | Français | `bb87f4ad` | Full translation of `README.md` at this commit. |
+
+## Updating a translation
+
+1. Diff the translation's source commit against `README.md`'s current `HEAD`
+   to see what changed: `git diff <source-commit> HEAD -- README.md`.
+2. Apply the equivalent changes to the translated file.
+3. Update this table's `Source commit` column to the new `HEAD` short hash
+   (`git rev-parse --short HEAD`).


### PR DESCRIPTION
## Summary

Documentation-only PR closing four issues:

- Closes #839 — Mermaid sequence diagrams for the escrow and multisig lifecycles, added to `docs/architecture.md`.
- Closes #838 — `docs/testing-strategy.md`, a coverage matrix (unit/property/fuzz/integration) per contract with explicit gap callouts.
- Closes #837 — `docs/gas-costs.md` extended with estimated CU-cost tables for the 13 newer contracts (airdrop, auction, ballot, bonding-curve, crowdfund, lottery, marketplace, oracle, subscription, swap, timelock, vesting, wrapped-token), plus a methodology section since no Criterion bench exists yet for these contracts.
- Closes #836 — `README.fr.md`, a full French translation of `README.md`, linked from the language switcher in `README.md`/`README.es.md`, plus `docs/translations.md` tracking the source commit each translation was produced from.

## Test plan

Docs-only change; no code paths affected. Verified Mermaid diagrams use valid `sequenceDiagram` syntax and all new/updated internal links resolve to existing files.
