### PR TITLE
feat: add dev tooling scripts and Justfile parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terraform provider version pinning and `.terraform` directory caching between plan and apply jobs (#242)
 - Structured JSON log lines (timestamp, network, contract, contractId, txHash, status) emitted by the deploy scripts so deployments can be piped to log aggregators (#696)
 - Prometheus alert definitions and a sample importable Grafana dashboard JSON in `docs/monitoring.md`, linked from the deployment guide (#697)
+- `scripts/lint-fix.sh` — one-command `cargo fmt` + `cargo clippy --fix` wrapper, documented in `CONTRIBUTING.md` (#844)
+- `scripts/install-hooks.sh` and `make`/`just install-hooks` targets — installs a `.git/hooks/pre-commit` hook running format-check and Clippy without requiring the Python `pre-commit` framework (#845)
+- `fmt-check`, `lint-fix`, `watch`, `install-hooks`, and `test-nextest` targets to the `justfile` for full parity with the `Makefile` (#846)
+- `cargo-nextest` documented as a faster local test runner, with install/usage instructions in `docs/dev-environment.md` and `test-nextest` Makefile/justfile targets (#847)
 
 ### Changed
 - Migrated all workspace crates to the Rust 2024 edition and bumped the pinned toolchain to 1.85.0 (#703)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,23 @@ To run the hooks manually without committing:
 pre-commit run --all-files
 ```
 
+### Lightweight alternative (no Python dependency)
+
+If you'd rather not install the Python `pre-commit` framework, use the bundled
+installer script instead:
+
+```bash
+./scripts/install-hooks.sh
+# or
+make install-hooks
+just install-hooks
+```
+
+This writes a `.git/hooks/pre-commit` hook that runs `scripts/format-check.sh`
+and a quick `cargo clippy --workspace --all-targets -- -D warnings` pass
+before every commit. Use `git commit --no-verify` to skip it for a single
+commit.
+
 ---
 
 ## CI checks
@@ -330,6 +347,20 @@ cargo fmt --all
 # Lint (warnings are treated as errors in CI)
 cargo clippy --all-targets -- -D warnings
 ```
+
+To auto-fix formatting and common Clippy issues in one step, run:
+
+```bash
+./scripts/lint-fix.sh
+# or
+make lint-fix
+just lint-fix
+```
+
+This runs `cargo fmt --all` followed by
+`cargo clippy --workspace --fix --allow-dirty --allow-staged`. Review the
+resulting diff before committing — not every Clippy warning can be
+auto-fixed.
 
 Additional conventions:
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build test test-all-features clippy fmt fmt-check watch deploy-testnet deploy-local bench clean
+.PHONY: help build test test-all-features test-nextest clippy fmt fmt-check lint-fix watch install-hooks deploy-testnet deploy-local bench clean
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -14,6 +14,9 @@ test: ## Run unit tests
 test-all-features: ## Run unit tests with all features enabled
 	cargo test --all-features
 
+test-nextest: ## Run unit tests via cargo-nextest (requires cargo-nextest)
+	cargo nextest run --workspace
+
 clippy: ## Run Clippy lints
 	cargo clippy --all-targets --all-features -- -D warnings
 
@@ -23,8 +26,14 @@ fmt: ## Format source code
 fmt-check: ## Verify all Rust files are rustfmt-clean (exits non-zero on failure)
 	./scripts/format-check.sh
 
+lint-fix: ## Auto-fix formatting and common Clippy issues
+	./scripts/lint-fix.sh
+
 watch: ## Re-run tests on any src/ change (requires cargo-watch)
 	cargo watch -w src -x test
+
+install-hooks: ## Install git pre-commit hook (format-check + clippy)
+	./scripts/install-hooks.sh
 
 deploy-testnet: ## Deploy contracts to testnet
 	./scripts/deploy.sh testnet

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -25,7 +25,41 @@ brew install just
 winget install Casey.Just
 ```
 
-Run `just --list` from the project root to see all available recipes.
+Run `just --list` from the project root to see all available recipes. The
+`justfile` mirrors the `Makefile` targets (`build`, `test`, `clippy`, `fmt`,
+`fmt-check`, `lint-fix`, `watch`, `install-hooks`, `deploy-testnet`,
+`deploy-local`, `bench`, `clean`) so either tool works interchangeably.
+
+---
+
+## Faster test runs with cargo-nextest
+
+[cargo-nextest](https://nexte.st/) is a faster test runner for Rust. It
+parallelizes better than `cargo test` for a workspace this size and gives
+cleaner per-test output.
+
+### Installing cargo-nextest
+
+```bash
+cargo install cargo-nextest --locked
+```
+
+### Running tests
+
+```bash
+# Run the full workspace test suite
+cargo nextest run --workspace
+
+# With all features enabled
+cargo nextest run --workspace --all-features
+
+# Via the Makefile / justfile
+make test-nextest
+just test-nextest
+```
+
+`cargo nextest` runs the same test binaries as `cargo test`, so it's a drop-in
+alternative — no test code changes are required.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ test:
 test-all-features:
     cargo test --all-features
 
+# Run unit tests via cargo-nextest (requires cargo-nextest)
+test-nextest:
+    cargo nextest run --workspace
+
 # Run Clippy lints
 clippy:
     cargo clippy --all-targets --all-features -- -D warnings
@@ -21,6 +25,22 @@ clippy:
 # Format source code
 fmt:
     cargo fmt --all
+
+# Verify all Rust files are rustfmt-clean (exits non-zero on failure)
+fmt-check:
+    ./scripts/format-check.sh
+
+# Auto-fix formatting and common Clippy issues
+lint-fix:
+    ./scripts/lint-fix.sh
+
+# Re-run tests on any src/ change (requires cargo-watch)
+watch:
+    cargo watch -w src -x test
+
+# Install git pre-commit hook (format-check + clippy)
+install-hooks:
+    ./scripts/install-hooks.sh
 
 # Deploy contracts to testnet
 deploy-testnet:

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Installs a git pre-commit hook that runs format-check and a quick Clippy
+# pass, so formatting/lint issues are caught locally instead of in CI.
+set -euo pipefail
+
+HOOK_DIR="$(git rev-parse --git-path hooks)"
+HOOK_FILE="$HOOK_DIR/pre-commit"
+
+mkdir -p "$HOOK_DIR"
+
+cat > "$HOOK_FILE" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+./scripts/format-check.sh
+cargo clippy --workspace --all-targets -- -D warnings
+EOF
+
+chmod +x "$HOOK_FILE"
+
+echo "Installed pre-commit hook at $HOOK_FILE"

--- a/scripts/lint-fix.sh
+++ b/scripts/lint-fix.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Auto-fix formatting and common Clippy issues across the workspace.
+set -euo pipefail
+
+echo "Running cargo fmt --all..."
+cargo fmt --all
+
+echo "Running cargo clippy --fix..."
+cargo clippy --workspace --fix --allow-dirty --allow-staged
+
+echo "Done. Review the changes with 'git diff' before committing."


### PR DESCRIPTION
## Summary
- `scripts/lint-fix.sh` wraps `cargo fmt --all` + `cargo clippy --workspace --fix --allow-dirty --allow-staged` for a one-command auto-fix, documented in CONTRIBUTING.md.
- `scripts/install-hooks.sh` (+ `make`/`just install-hooks`) installs a `.git/hooks/pre-commit` hook running `format-check.sh` and a quick Clippy pass, as a lightweight alternative to the Python `pre-commit` framework.
- `justfile` now mirrors every `Makefile` target (`fmt-check`, `lint-fix`, `watch`, `install-hooks`, `test-nextest`) for full parity.
- `cargo-nextest` documented as a faster local test runner in `docs/dev-environment.md`, with `test-nextest` targets added to both the Makefile and justfile.

Closes #844
Closes #845
Closes #846
Closes #847

## Test plan
- [x] Reviewed scripts and doc changes manually
- Test execution intentionally skipped per task instructions