### PR TITLE
Add NFT batch transfer, threat model, known issues, and glossary docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ just --list
 - **Unique Token Ownership**: Each token ID maps to exactly one owner tracked in persistent storage
 - **Admin-Controlled Minting**: Only the admin may mint new tokens; optional supply cap enforced at mint time
 - **Standard Operations**: `mint`, `transfer`, `burn`, `approve`, `transfer_from` matching ERC-721 semantics
+- **Atomic Batch Transfer**: `batch_transfer` moves multiple tokens in one call with a single auth check; ownership of every token is validated before any transfer is applied
 - **Per-Token Metadata**: Each token has an associated URI stored on-chain; collection has name and symbol
 - **Approval System**: Single-token approvals cleared automatically on transfer or burn
 - **Property Tests**: Proptest suite verifies supply invariants and ownership correctness
@@ -360,6 +361,9 @@ A special thanks to all our [contributors](CONTRIBUTORS.md) who have helped make
 ## 📚 Resources
 
 - [Directory Tree](docs/directory-tree.md) — Purpose of every directory in the repository
+- [Glossary](docs/glossary.md) — Soroban/Stellar terms used across the repo
+- [Threat Model](docs/threat-model.md) — Trust assumptions and attack surface per contract
+- [Known Issues](docs/known-issues.md) — Accepted design tradeoffs per contract
 - [FAQ](docs/faq.md) — Common developer questions: setup, testing, deployment, feature flags, token customization
 - [System Architecture](docs/architecture.md) — High-level design, contract relationships, storage tiers, event model, and admin framework
 - [Contract API Reference](docs/contract-api.md) — Full public API for all contracts (parameters, return types, errors)

--- a/contracts/nft/src/lib.rs
+++ b/contracts/nft/src/lib.rs
@@ -5,7 +5,7 @@
 //! Admin-controlled minting with per-token owners, approved spenders, metadata
 //! URIs, and an optional supply cap.
 
-use soroban_sdk::{Address, Env, String, contract, contractimpl};
+use soroban_sdk::{Address, Env, String, Vec, contract, contractimpl};
 
 mod errors;
 mod events;
@@ -178,6 +178,53 @@ mod contract {
 
             bump_token(&env, &TokenKey::Owner(token_id));
             events::transferred(&env, &from, &to, token_id);
+
+            Ok(())
+        }
+
+        /// Transfer multiple tokens from `from` to `to` in a single call. Requires a single
+        /// auth from `from` (the owner) covering the whole batch.
+        ///
+        /// Ownership of every token in `token_ids` is validated before any transfer is applied,
+        /// so the batch is atomic: either all tokens move or none do.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`NftError::TokenNotFound`] if any token in `token_ids` does not exist.
+        /// Returns [`NftError::NotOwner`] if `from` does not own any token in `token_ids`.
+        pub fn batch_transfer(
+            env: Env,
+            from: Address,
+            to: Address,
+            token_ids: Vec<u32>,
+        ) -> Result<(), NftError> {
+            Self::require_initialized(&env)?;
+            from.require_auth();
+
+            for token_id in token_ids.iter() {
+                let owner: Address = env
+                    .storage()
+                    .persistent()
+                    .get(&TokenKey::Owner(token_id))
+                    .ok_or(NftError::TokenNotFound)?;
+
+                if owner != from {
+                    return Err(NftError::NotOwner);
+                }
+            }
+
+            for token_id in token_ids.iter() {
+                env.storage()
+                    .persistent()
+                    .set(&TokenKey::Owner(token_id), &to);
+                // Clear any existing approval on transfer.
+                env.storage()
+                    .persistent()
+                    .remove(&TokenKey::Approval(token_id));
+
+                bump_token(&env, &TokenKey::Owner(token_id));
+                events::transferred(&env, &from, &to, token_id);
+            }
 
             Ok(())
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,16 @@ Welcome to the Soroban starter kit documentation. This directory contains guides
   - State machine invariants
   - Overflow/underflow protection
 
+- **[Threat Model](threat-model.md)** — Trust assumptions and attack surface per contract
+  - Trusted roles and what each can/cannot do
+  - Worst-case-per-role compromise analysis
+
+- **[Known Issues](known-issues.md)** — Accepted design tradeoffs per contract
+  - Documented limitations that are not bugs
+  - Cross-linked to relevant ADRs
+
+- **[Glossary](glossary.md)** — Soroban/Stellar terminology used across the repo
+
 - **[Integration Guide](integration-guide.md)** — How to integrate contracts into your application
   - Contract deployment
   - Client setup

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,44 @@
+# Glossary
+
+Definitions for Soroban and Stellar terms used across this repository's contracts, docs, and scripts. Terms are alphabetical. Where a term has a specific meaning in this codebase (e.g. an `AdminKey` pattern), the definition notes it.
+
+| Term | Definition |
+|------|------------|
+| **Admin model** | The pattern this repo uses for privileged operations: a single trusted `Address` (or role set, for contracts like Escrow and Multisig) stored on-chain and checked via `require_auth()` before state-changing calls. See [ADR-0003](adr/0003-admin-model.md) and [threat-model.md](threat-model.md). |
+| **Contract ID** | The unique, network-specific identifier (a strkey starting with `C`) assigned to a deployed Soroban contract instance. Used to invoke the contract from clients, scripts, and other contracts. |
+| **`#[contractclient]`** | A `soroban-sdk` macro that generates a typed client for invoking a contract's public functions, either in-process (tests) or over the network. |
+| **`#[contracterror]`** | A `soroban-sdk` macro that defines an enum of contract-specific error codes returned from fallible entry points (e.g. `NftError`, `EscrowError` in this repo). |
+| **`#[contractimpl]`** | A `soroban-sdk` macro that marks an `impl` block's `pub fn`s as the contract's externally callable entry points. |
+| **Envelope (transaction envelope)** | The signed wrapper around a Stellar transaction, containing the operations, signatures, and (for Soroban invocations) the resource footprint and fee. |
+| **Event** | An on-chain log entry a contract publishes via `env.events().publish(...)`. Used for off-chain indexing (see [event-catalogue.md](event-catalogue.md)) since Soroban contract storage isn't directly queryable by external services. |
+| **Footprint (read/write footprint)** | The declared set of ledger entries (storage keys) a transaction will read or write, required up front so the network can parallelize execution and price resource usage. Simulating a transaction (e.g. via `stellar contract invoke --sim`) computes this automatically. |
+| **Freighter** | A browser extension wallet for Stellar/Soroban, commonly used to sign transactions from a dApp frontend during local development and testing. |
+| **Futurenet / Testnet / Mainnet** | The three Stellar network tiers: Futurenet runs bleeding-edge, not-yet-released protocol features; Testnet is the stable pre-production network for integration testing; Mainnet is the production network with real asset value. |
+| **Host function** | A function implemented by the Soroban host environment (not WASM bytecode) that contracts call for capabilities like storage access, cryptography, and cross-contract invocation. Host functions are what make contract execution deterministic and metered. |
+| **Instance storage** | One of Soroban's three storage tiers. A single TTL covers all instance-storage entries for a contract; best for small, always-needed global state (e.g. this repo's `Admin`, `TotalSupply`). See [storage-layout.md](storage-layout.md) and [ADR-0001](adr/0001-storage-tier-choices.md). |
+| **Ledger** | Stellar's unit of consensus state — analogous to a "block" in other chains. Each ledger has a monotonically increasing **sequence number**, which Soroban contracts in this repo use for deadlines, TTLs, and time-based logic (there is no native wall-clock timestamp comparison at the contract level beyond `env.ledger().timestamp()`). |
+| **Ledger sequence number** | The integer identifying a specific ledger, always increasing. Used throughout this repo (e.g. escrow `deadline`, vesting `cliff_ledger`/`end_ledger`, timelock `release_ledger`) as the unit for time-based contract logic. |
+| **Muxed address** | A Stellar address (`M...`) that combines a base account address with a sub-account ID, letting one on-chain account represent many logical sub-identities (e.g. exchange user accounts) without a separate ledger entry each. |
+| **Persistent storage** | The Soroban storage tier for long-lived, per-key data that must survive independently of other entries (e.g. this repo's per-user `Balance`, per-token `Owner`). Each key has its own TTL and can be individually archived and restored. See [ADR-0001](adr/0001-storage-tier-choices.md). |
+| **Protocol version** | The version number of the Stellar network's consensus and execution rules (e.g. Protocol 21, 22, 23). Soroban SDK versions are tightly coupled to a target protocol — see the Compatibility Matrix in the [README](../README.md#-compatibility-matrix). |
+| **`require_auth()`** | The `soroban-sdk` call that asserts the current invocation was authorized by the given `Address` (via a signature or a prior `authorize_as_current_contract` sub-invocation). This is the primitive underlying every access-control check in this repo's contracts. |
+| **Resource fee** | The portion of a Soroban transaction's fee that pays for CPU instructions, memory, ledger I/O, and storage rent — separate from the classic Stellar base transaction fee. Resource fees are computed from the transaction's declared footprint and instruction count. |
+| **RPC (Soroban RPC)** | The JSON-RPC service (`soroban-rpc` / `stellar-rpc`) that clients and the Stellar CLI use to submit transactions, simulate invocations, and query ledger/contract state, since Soroban state isn't exposed through classic Horizon endpoints. |
+| **SAC (Stellar Asset Contract)** | The built-in Soroban contract type that wraps a classic Stellar asset (e.g. an issued asset or native XLM) so it can be used through the standard Soroban token interface alongside custom tokens like this repo's `token` contract. |
+| **SEP-41** | The Stellar Ecosystem Proposal defining the standard token interface (`transfer`, `approve`, `balance`, `allowance`, etc.) that this repo's `token` contract implements for interoperability with wallets and other contracts. |
+| **State archival** | The Soroban mechanism (introduced under Protocol 23, CAP-62/66) by which persistent and temporary ledger entries whose TTL expires are removed from active state and must be explicitly restored before use again. This is why every contract in this repo calls `extend_ttl` on its hot storage keys. |
+| **`stellar` / `soroban` CLI** | The command-line tool (`stellar-cli`, formerly `soroban-cli`) used throughout this repo's `scripts/` and `Makefile`/`justfile` targets to build, deploy, and invoke contracts. |
+| **Temporary storage** | The Soroban storage tier for short-lived, scratch data that is deliberately allowed to be deleted once its TTL expires, with no restoration path. Cheapest of the three tiers; unused by the current templates but available for scratch/nonce-style data. |
+| **TTL (Time To Live)** | The number of ledgers remaining before a storage entry becomes eligible for archival. Contracts in this repo call `extend_ttl` (wrapped as `bump_instance` / `bump_token` / similar helpers) on every interaction to keep active data alive; see `LEDGER_LIFETIME_THRESHOLD` and `LEDGER_BUMP_AMOUNT` in [architecture.md](architecture.md#ttl--bump-strategy). |
+| **Upgrade (contract upgrade)** | Replacing a deployed contract's WASM bytecode via the `update_current_contract_wasm` host function while preserving its contract ID and storage. Some templates in this repo (e.g. `token`, `escrow` under the `upgradeable`/`pausable` feature) gate this behind an admin-proposed, time-locked flow — see [upgrade-guide.md](upgrade-guide.md). |
+| **WASM (WebAssembly)** | The compiled bytecode format Soroban contracts run as. `cargo build` in this repo targets `wasm32-unknown-unknown`; `stellar contract build` produces the optimized `.wasm` that gets deployed. |
+| **XDR** | External Data Representation — the binary encoding Stellar uses for ledger entries, transactions, and contract values (`ScVal`) on the wire and in storage. Tools like Stellar Laboratory decode/encode XDR for human inspection. |
+| **XLM / stroop** | XLM (lumens) is Stellar's native asset, used to pay transaction and resource fees. A stroop is the smallest unit, `1 XLM = 10,000,000 stroops`. |
+
+## See Also
+
+- [Architecture](architecture.md) — storage tiers, admin model, and TTL strategy in context
+- [Threat Model](threat-model.md) — per-contract trusted roles
+- [Storage Layout](storage-layout.md)
+- [Soroban Documentation](https://soroban.stellar.org/docs)
+- [Stellar Glossary](https://developers.stellar.org/docs/learn/glossary) — the canonical upstream glossary for terms not specific to this repo

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,114 @@
+# Known Issues
+
+This document tracks **accepted design tradeoffs** in the contract templates — decisions that are not bugs, but that anyone deploying or extending a template should understand before relying on it. Where a tradeoff was the subject of an explicit design decision, the entry links to the relevant [ADR](adr/README.md).
+
+If you believe an entry below is actually a defect rather than an intentional tradeoff, please open an issue.
+
+## Airdrop
+
+- `set_root` can be called by the admin at any time with no "finalized" lock — a legitimate root rotation and a malicious root swap look identical on-chain. Consumers should treat root changes as a trusted-admin action.
+- `claim_batch` has no upper bound on batch size; an oversized `entries` vector can exceed transaction resource limits before it exceeds any protocol-level cap.
+
+## Auction
+
+- `end()` is permissionless by design so that a stalled seller cannot block settlement.
+- Once a bid has been placed, the seller cannot `cancel()` — this is an intentional irrevocability tradeoff that favors bidder protection over seller flexibility.
+
+## Ballot
+
+- `tally()` has no minimum-turnout/quorum requirement — a proposal with very low participation is still tallied as decisive.
+- Voter registration is fully admin-gated with no on-chain whitelist proof; the deployer is trusted to register only legitimate voters.
+
+## Bonding Curve
+
+- `buy_cost` / `sell_proceeds` use an averaged-price linear approximation (`(price(old) + price(new)) / 2`) rather than the exact curve integral. This is a deliberate gas/complexity tradeoff that introduces small, curve-shape-dependent rounding versus a mathematically exact bonding curve.
+- Mitigated by required `max_cost` / `min_proceeds` slippage bounds on every trade.
+
+## Crowdfund
+
+- `extend_deadline` is capped to a single use per campaign — an intentional anti-abuse limit rather than a general-purpose extension mechanism.
+- Funding tiers / stretch goals reported by `get_info` are informational only; they do not gate `claim()`, which sweeps the entire pledged pool once the base goal is met.
+
+## DAO
+
+- Voting weight is read from the voter's **live** token balance at the moment of `vote()`, not a historical snapshot. This is a simpler model than snapshot-based voting but is vulnerable to flash-loan-style vote weighting; it is an accepted tradeoff for template simplicity, not a recommendation for production governance of high-value treasuries.
+- `execute_proposal` only transitions proposal state to `Executed` — it does not invoke a target contract. On-chain vote outcomes must be carried out off-chain or via a separate execution layer.
+
+## Escrow
+
+- No global admin exists by design (see [ADR-0003: Admin Model](adr/0003-admin-model.md)) — buyer, seller, and arbiter each hold exactly the authority described in [docs/security.md](security.md#authorization), and no single key can override all three roles.
+- Multi-arbiter dispute resolution uses on-chain vote accumulation rather than a threshold signature scheme, trading some on-chain storage/gas cost for auditability. See [ADR-0008: Multi-sig Arbiter Design](adr/0008-multisig-arbiter-design.md).
+- Deadline extension requires both parties' authorization, so a non-responsive counterparty can permanently block an extension; this is intentional (neither party can unilaterally change the agreed deadline). See [ADR-0004: Escrow State Machine Design](adr/0004-escrow-state-machine.md) and [ADR-0006: Escrow Arbiter Model](adr/0006-escrow-arbiter-model.md).
+
+## Lottery
+
+- The commit-reveal randomness scheme relies on the admin honestly choosing `secret`/`salt` before committing. A motivated admin can grind many candidate values off-chain and commit only the one that yields a favorable outcome. The on-chain check only proves the *revealed* value matches the *committed* hash — it cannot prove the admin didn't pre-select a favorable secret. Deployers who need trustless randomness should source entropy from an external VRF rather than relying on this template's admin-supplied commit-reveal alone.
+- There is no economic penalty for an admin who commits and never reveals; the only mitigation is the buyer-side refund path after `reveal_deadline`.
+
+## Marketplace
+
+- Listings depend on the seller having pre-approved the marketplace as an NFT spender. A stale or revoked approval, or a seller who transfers the NFT elsewhere after listing, causes `buy()` to fail atomically rather than losing funds — a griefing/availability concern, not a fund-safety one.
+- `get_active_listings` pagination is capped at a fixed page size as a deliberate DoS mitigation, not an oversight.
+- Royalty configuration is fixed at `initialize` with no update path, trading flexibility for a simpler, tamper-proof royalty guarantee.
+
+## Multisig
+
+- Once a proposal reaches its signature threshold, `execute_transaction` allows the multisig to invoke **any** target contract/function with attacker-or-signer-chosen arguments. There is no per-transaction spending cap or destination allow-list — the signer set is fully trusted, matching the general multisig trust model.
+- The same threshold that approves ordinary transactions also approves signer-set changes (`add_signer` / `remove_signer`), so a colluding quorum can alter its own membership.
+- Proposals carry an `expiry_ledger` to avoid stale proposals lingering indefinitely, an intentional bound on proposal lifetime.
+
+## NFT
+
+- The approval model is single-spender-per-token (`approve` / `transfer_from`); there is no `set_approval_for_all`-style operator model. Callers that need collection-wide operator approval must call `approve` per token.
+- `token_id` is caller-supplied `u32` with no auto-increment; uniqueness is enforced on-chain (`TokenAlreadyMinted`) but ID *generation* and collision avoidance across mints is left to the minter.
+- `batch_transfer` (see [ADR-0009: Batch Mint Design](adr/0009-batch-mint-design.md) for the precedent this follows) validates ownership of every token before applying any transfer, matching the same validate-all-then-apply pattern used by the token contract's `batch_mint`.
+
+## Oracle
+
+- `get_price` / `update_price` is a single-admin-trusted feed by default. The multi-publisher `get_median_price` path exists as an opt-in alternative — nothing prevents a consumer from calling the weaker single-source `get_price` instead. Contract authors that need aggregation must deliberately choose the median path.
+- `set_publishers` fully replaces the publisher set with no timelock, so publisher-set changes take effect immediately.
+- Aggregation math (`median`, `twap`) uses saturating arithmetic, which silently clamps rather than erroring on extreme inputs, trading a hard failure for availability.
+
+## Staking
+
+- Reward accounting uses an integer-scaled `reward_per_token` accumulator; very small reward deposits relative to `total_staked` can lose dust to integer-division rounding. This is the standard tradeoff of the accumulator pattern versus per-staker floating point.
+- `compound()` requires `stake_token == reward_token`; dual-asset pools cannot auto-compound by design.
+- There is no lock-up period or slashing — `unstake` is available immediately, which is intentional for a general-purpose staking template rather than a bonded/slashed validator model.
+
+## Subscription
+
+- `charge()` is bounded only by interval spacing and the subscriber's remaining token allowance, not by an on-chain max-charge count or subscription-length field. Subscribers are expected to size their allowance as the primary spending guardrail.
+- `cancel()` flips the subscription to inactive but does not revoke the underlying token allowance; subscribers who want a hard stop should also reduce their token approval separately.
+
+## Swap
+
+- `cancel_swap` after the deadline is intentionally permissionless — anyone may trigger it to return party A's funds, guaranteeing a stalled counterparty can't strand deposited tokens. This means a third party can trigger a state change on a swap they are not part of, though with no effect beyond returning funds to their rightful owner.
+- The contract supports only fixed-amount, all-or-nothing swaps; there is no partial-fill or price-improvement logic.
+
+## Timelock
+
+- `cancel()` is available to the admin at any point before `release_ledger`, with no beneficiary consent required — a single admin key fully controls whether the beneficiary ever receives funds. This is an accepted single-party-trust design for a simple timelock; contrast with [Vesting](#vesting), which restricts revocation to the unvested remainder only.
+- `release()` is permissionless once the release ledger is reached, so the beneficiary is never dependent on a specific relayer being online.
+
+## Token
+
+- `set_admin` (one-step, immediate) and `propose_admin` / `accept_admin` (two-step, confirmed) both remain available side by side. See [ADR-0003: Admin Model](adr/0003-admin-model.md). Integrators should prefer the two-step path and audit any UI that could accidentally call `set_admin`.
+- `batch_mint` validates every recipient/amount against the supply cap before minting any of them (see [ADR-0009: Batch Mint Design](adr/0009-batch-mint-design.md)) — an intentional all-or-nothing tradeoff over partial-success batching.
+- The `transfer-hook` feature invokes the configured hook with `try_invoke_contract`, so a failing or malicious hook cannot block transfers — but it also means a hook cannot be relied on as an enforcement point, only an observation point. See [ADR-0005: Feature Flag Design](adr/0005-feature-flags.md).
+- The upgrade delay (`upgradeable` feature) is a fixed constant rather than a configurable parameter, trading deployment flexibility for a predictable, auditable timelock.
+
+## Vesting
+
+- `admin_release` is a documented "emergency unlock" escape hatch that lets the admin force-release the full balance early, bypassing the vesting schedule. It intentionally requires no beneficiary consent or additional timelock beyond the standard admin authorization, unlike more conservative vesting designs.
+- `vested_amount` uses integer division for linear vesting, which truncates fractional token amounts; the resulting dust remains in the contract and is only recoverable via `revoke` or `admin_release`, not swept separately.
+
+## Wrapped Token
+
+- The 1:1 peg is not reconciled against the underlying token's actual balance on-chain; `get_total_wrapped` is a running counter that assumes `wrap` / `unwrap` are the only paths that mint or burn the wrapped asset. Deploying this template against a fee-on-transfer or rebasing underlying token will silently break the peg — it is designed for standard, non-rebasing Soroban tokens only.
+- There is no pause or circuit-breaker if the underlying asset contract misbehaves.
+
+## See Also
+
+- [Threat Model](threat-model.md) — trust assumptions and worst-case-per-role analysis
+- [Security Best Practices](security.md)
+- [Architecture Decision Records](adr/README.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,7 @@
 # Security
 
+> For a per-contract breakdown of trusted roles and the worst case if a role's key is compromised, see [Threat Model](threat-model.md). For accepted design tradeoffs that are not vulnerabilities, see [Known Issues](known-issues.md).
+
 ## Arbiter Time-Lock
 
 The arbiter time-lock mechanism in the escrow contract is designed to ensure that funds are not released to the seller until the buyer has had a chance to inspect the goods or services. The time-lock is implemented as a `deadline` ledger sequence number, after which the buyer can request a refund.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,155 @@
+# Threat Model
+
+This document catalogues, per contract, who is trusted, what each trusted role can and cannot do, and the assets or actions at risk if that role's key is compromised. It complements [Security Best Practices](security.md), which covers re-entrancy, state-machine, and overflow analysis, and [Known Issues](known-issues.md), which covers accepted design tradeoffs.
+
+**How to read the tables below**: "Role" is an address category established at initialization or by prior calls (not necessarily a single fixed key — e.g. a multisig contract can act as `admin`). "Compromise blast radius" describes the worst outcome if an attacker obtains signing authority for that role, assuming all other roles remain honest.
+
+## Airdrop
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize`, `set_root` (replace merkle root at any time, no lock) | Claim on behalf of a recipient without a matching proof | Full drain: attacker publishes a new root whose proofs they control, then claims the entire airdrop balance |
+| Recipient | `claim` / `claim_batch` for entries proven against the current root | Claim more than their allotted amount, or claim without a valid proof | Limited to that recipient's own allotment |
+
+## Auction
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Seller | `start`, `cancel` (only before any bid) | Cancel after a bid lands, alter bids | Low — cannot touch bidder funds; at most disrupts their own auction pre-bid |
+| Bidder | `bid`, `withdraw` (own outbid funds) | Withdraw another bidder's funds | Limited to that bidder's own pending/escrowed bid amount |
+| Anyone | `end()` (permissionless settlement) | — | None — settlement logic is fixed regardless of caller |
+
+## Ballot
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize`, `register_voter`, `deregister_voter`, `tally` | Vote on a registered voter's behalf | Governance integrity: attacker can register sybil voters and force a tally at a chosen time, controlling the outcome |
+| Voter | `vote` (once, if registered) | Vote twice, vote unregistered | None beyond that voter's own single vote |
+
+## Bonding Curve
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize` only (sets token address); no further privileged calls after setup | Re-initialize, pause, withdraw reserves | Minimal — admin key has no standing power once initialized |
+| Buyer/Seller | `buy`, `sell` against the curve, bounded by their own `max_cost` / `min_proceeds` | Affect another trader's transaction | Limited to that trader's own transaction |
+
+## Crowdfund
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Creator | `initialize`, `extend_deadline` (single use), `claim` (sweeps entire pool once goal is met) | Claim before the goal is met, extend the deadline more than once | Full drain of raised funds once the goal is met — `claim()` sends the whole pledged pool to the (attacker-controlled) creator address |
+| Pledger | `pledge`, `withdraw` / `refund` (own pledge, if goal not met or before campaign end) | Withdraw another pledger's contribution | Limited to that pledger's own pledge |
+
+## DAO
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize`, `cancel_proposal` (any proposal, any time) | Vote on others' behalf, force a proposal to pass | Governance availability: attacker can veto any proposal indefinitely. The DAO holds no treasury funds itself, so this is a censorship/liveness risk, not a direct fund-theft risk |
+| Proposer/Voter | `create_proposal`, `vote` (weight = live token balance) | Vote more than once per proposal | Vote-weight manipulation is possible via flash-loan-style balance changes (see [Known Issues](known-issues.md#dao)), not role-key compromise |
+
+## Escrow
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Buyer | `fund`, `approve_delivery`, `request_refund` / `request_partial_refund`, `cancel` (pre-fund), co-signs `extend_deadline` | Release funds unilaterally to itself, bypass seller/arbiter checks | Buyer can, at most, redirect its own escrowed refund path (e.g. force a dispute); cannot seize seller-bound funds |
+| Seller | `mark_delivered`, co-signs `extend_deadline` | Force fund release without buyer approval or arbiter resolution | Cannot unilaterally move funds; can only claim delivery, which the state machine still gates behind buyer approval or dispute resolution |
+| Arbiter(s) | `resolve_dispute` (release to either party) once a dispute is raised | Resolve a dispute that hasn't been raised, bypass the state machine | Full escrowed `amount` for that agreement can be sent to either party — direct fund theft up to the escrow amount, contained to that single escrow instance |
+| Admin (feature: `pausable`) | `pause`, `unpause`, `propose_upgrade`, `execute_upgrade` (after a ~1-day timelock) | Skip the upgrade timelock | Full logic takeover via WASM replacement, but delayed by the upgrade timelock, giving parties a window to react |
+
+See [ADR-0003](adr/0003-admin-model.md), [ADR-0004](adr/0004-escrow-state-machine.md), and [ADR-0006](adr/0006-escrow-arbiter-model.md) for the design rationale behind this role split.
+
+## Lottery
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize`, `commit` (hash of self-chosen secret+salt), `draw` (reveal + pay winner) | Change ticket purchases after the fact | Severe: the admin *chooses* the secret before committing, so a dishonest admin can grind candidate secrets off-chain and commit only the one that produces a favorable winner — see [Known Issues](known-issues.md#lottery). This is a property of the design, not merely a key-compromise scenario |
+| Buyer | `buy_ticket` (pre-commit), `claim_refund` (if admin never draws) | Influence winner selection | Limited to that buyer's own ticket purchase/refund |
+
+## Marketplace
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize` only (payment token, royalty config); no further privileged calls | Change royalty settings after init, seize listings | Minimal — no standing power post-init |
+| Seller | `list` / `list_with_expiry`, `cancel`, `sweep_expired`, `accept_offer` | Affect another seller's listings | Limited to that seller's own listings and any offers made on them |
+| Buyer | `buy`, `make_offer`, `cancel_offer` | Affect another buyer's offers | Limited to that buyer's own purchase/offer funds |
+
+## Multisig
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Signer (below threshold) | `propose_transaction`, `sign_transaction` | Execute without threshold approvals | A single compromised signer below threshold cannot act alone |
+| Signer quorum (≥ threshold) | `execute_transaction` → invoke any target contract/function with chosen args; `add_signer` / `remove_signer` | Bypass the threshold itself | Full arbitrary-call capability: a colluding quorum can drain any asset the multisig controls elsewhere, or dilute/lock out other signers by changing the signer set |
+| Anyone | `execute_transaction` once threshold is met (execution itself is permissionless) | Change proposal content | None beyond triggering an already-approved call |
+
+## NFT
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize`, `mint` (up to `max_supply` if set) | Transfer, burn, or force-move tokens owned by others | Attacker can mint arbitrary new tokens (diluting/counterfeiting the collection) but cannot seize already-minted tokens — no admin forced-transfer or admin-burn function exists |
+| Owner | `transfer`, `batch_transfer`, `burn`, `approve` (their own tokens) | Move tokens they don't own | Limited to that owner's own token set |
+| Approved spender | `transfer_from` for the single token they were approved on | Act on any other token | Limited to the one approved token |
+
+## Oracle
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize`, `update_price` (single-source push), `set_publishers` (replace publisher allow-list, no timelock) | Force a specific consumer contract to trust a given price feed | Any downstream consumer using `get_price` / `get_price_checked` can be fed an arbitrary price until staleness rejects it — the scope of harm depends entirely on what consumer contracts do with that price |
+| Publisher (if configured) | `submit_price` | Override the admin's single-source `get_price` value | Can skew `get_median_price` alongside other publishers, mitigated by requiring collusion across the publisher set |
+
+## Staking
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize`, `add_rewards` | Withdraw stakers' principal, withdraw accrued rewards, pause staking | Minimal — worst case is refusing to top up future rewards; principal and accrued rewards are not admin-reachable |
+| Staker | `stake`, `unstake`, `claim_rewards`, `compound`, `set_compounding` | Affect another staker's principal or rewards | Limited to that staker's own principal and accrued rewards |
+
+## Subscription
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Provider | `initialize`, `charge(subscriber)` once per elapsed interval, bounded by the subscriber's remaining token allowance | Charge beyond the subscriber's approved allowance | Can accelerate draining a subscriber's pre-approved allowance the moment each interval elapses, but is hard-capped by that allowance |
+| Subscriber | `subscribe`, `cancel` | Prevent an already-elapsed, pre-approved charge | Limited to that subscriber's own allowance exposure |
+
+## Swap
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Party A | `propose_swap` (deposits `token_a` up front), `cancel_swap` (pre-deadline) | Access party B's `token_b` before acceptance | Limited to that party's own deposited `token_a` |
+| Party B | `accept_swap` | Alter the proposed terms | Limited to that party's own funds committed at acceptance |
+| Anyone | `cancel_swap` after deadline (permissionless, returns party A's funds) | Redirect funds to themselves | None — permissionless cancellation only returns funds to their original owner |
+
+## Timelock
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize` (deposits funds), `cancel` (pre-release, reclaims full locked amount) | Cancel after `release_ledger` has passed and someone has called `release` | Full amount can be redirected back to the (attacker-controlled) admin at any point before release — a complete rug-pull of the beneficiary's locked funds |
+| Anyone | `release()` once `release_ledger` is reached (permissionless) | Release early | None — release timing and destination are fixed |
+
+## Token
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `mint`, `batch_mint`, `admin_burn`, admin transfer functions, plus feature-gated `pause`/`unpause`, `freeze_account`/`unfreeze_account`, `propose_upgrade`/`execute_upgrade`, `set_transfer_hook` | Bypass an active `capped-supply` cap | The most severe role in the template set: unlimited minting (unless `capped-supply` is enabled), burning any holder's balance, freezing any account, pausing all transfers, and — with `upgradeable` enabled — full logic takeover after the upgrade timelock |
+| Holder | Standard SEP-41 `transfer`, `approve`, `burn`, etc. on their own balance | Move another holder's balance | Limited to that holder's own balance and allowances granted to them |
+
+See [ADR-0003](adr/0003-admin-model.md), [ADR-0005](adr/0005-feature-flags.md), and [ADR-0009](adr/0009-batch-mint-design.md).
+
+## Vesting
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize` (deposits funds), `revoke` (claws back unvested remainder to itself), `admin_release` (emergency unlock, releases full balance early to the beneficiary) | Reclaim tokens already vested and claimed | `revoke` diverts all unvested tokens to the (attacker-controlled) admin; `admin_release` forces early release to the beneficiary, defeating the vesting/lockup guarantee even though funds still land with the legitimate beneficiary |
+| Beneficiary | `claim` (vested-to-date amount) | Claim unvested tokens | Limited to that beneficiary's own vested balance |
+
+## Wrapped Token
+
+| Role | Can do | Cannot do | Compromise blast radius |
+|------|--------|-----------|--------------------------|
+| Admin | `initialize` only (sets `wrapped_token` / `underlying_token`); no further privileged calls | Mint/burn wrapped tokens directly | Minimal within this contract post-init; the real trust dependency is external — whichever account holds mint/burn authority on the underlying `wrapped_token` contract |
+| User | `wrap`, `unwrap` (self-authorizing) | Affect another user's deposit | Limited to that user's own wrap/unwrap amount, assuming the external wrapped-token minter authority is correctly restricted to this contract |
+
+## See Also
+
+- [Known Issues](known-issues.md) — accepted design tradeoffs referenced above
+- [Security Best Practices](security.md) — authorization table, re-entrancy, and state-machine analysis
+- [Architecture](architecture.md) — admin model and contract relationships


### PR DESCRIPTION
Closes #832 
closes #833 
closes #834 
closes #835 

## Summary

- **#832** — NFT: add `batch_transfer(from, to, token_ids)`. Validates ownership of every token before moving any (atomic, all-or-nothing), with a single `require_auth()` covering the whole batch instead of one per token.
- **#833** — Add `docs/threat-model.md`: per-contract trusted roles, what each can/cannot do, and the worst-case blast radius if a role's key is compromised. Linked from `docs/security.md`.
- **#834** — Add `docs/glossary.md`: 30 Soroban/Stellar terms used across the repo (ledger, storage tiers, TTL, resource fees, host functions, etc.). Linked from the root `README.md` and `docs/README.md`.
- **#835** — Add `docs/known-issues.md`: accepted design tradeoffs per contract (not bugs), cross-linked to the relevant ADRs.

## Test plan

- [x] `cargo check -p soroban-nft-template` — compiles (a pre-existing, unrelated `#![allow(missing_docs)]` placement error in `errors.rs` reproduces identically on `main`, confirmed unaffected by this change)
- [ ] Docs reviewed for accuracy against current contract source

