### PR TITLE
docs: deploy-all script, access-control and upgrade-compatibility references

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,8 @@ A special thanks to all our [contributors](CONTRIBUTORS.md) who have helped make
 - [System Architecture](docs/architecture.md) — High-level design, contract relationships, storage tiers, event model, and admin framework
 - [Contract API Reference](docs/contract-api.md) — Full public API for all contracts (parameters, return types, errors)
 - [Upgrade Guide](docs/upgrade-guide.md) — Step-by-step on-chain WASM upgrade with timelock and key rotation
+- [Upgrade Compatibility Matrix](docs/upgrade-compatibility-matrix.md) — Storage layouts and storage-breaking change categories per contract
+- [Access-Control Reference](docs/access-control-reference.md) — Entry point -> role `require_auth` table for every contract
 - [Security Best Practices](docs/security.md)
 - [Integration Guide](docs/integration-guide.md)
 - [Deployment Guide](docs/deployment-guide.md)

--- a/docs/access-control-reference.md
+++ b/docs/access-control-reference.md
@@ -1,0 +1,268 @@
+# Access-Control Quick Reference
+
+This page lists every public entry point exposed by each contract in
+`contracts/` and which role's `require_auth()` check gates it, so that
+auth checks (and their absence) can be audited at a glance instead of
+reading each contract's full source. It exists to make gaps like the ones
+found in issues #773-775 easy to spot in review.
+
+**Methodology:** for each `#[contractimpl]` entry point, this table records
+every `<address>.require_auth()` call reached from that entry point —
+including calls made indirectly through a private helper function (for
+example `marketplace::list` delegates to `list_impl`, which is where the
+`seller.require_auth()` call actually lives). "NONE" means no address is
+authenticated on that call path; the Notes column says whether that is
+intentional (a read-only query, or a state change that only pays out to an
+address already fixed in contract storage) or worth a second look.
+
+This table is a manually cross-checked snapshot of the code at the time of
+writing. When you add or change an entry point, please update the
+corresponding row in the same PR.
+
+---
+
+## airdrop
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `set_root` | `admin` | |
+| `claim` | `recipient` | |
+| `claim_batch` | NONE | Permissionless relay: each entry is checked against the merkle root and a per-recipient claimed flag, so a relayer can submit on a recipient's behalf without their signature. |
+| `is_claimed` | NONE | Read-only. |
+| `get_root` | NONE | Read-only. |
+
+## auction
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `start` | `seller` | |
+| `bid` | `bidder` | |
+| `cancel` | `seller` | |
+| `end` | NONE | Permissionless settlement after the deadline; funds move per stored highest bid/seller. |
+| `withdraw` | `bidder` | |
+| `get_pending` | NONE | Read-only. |
+| `get_info` | NONE | Read-only. |
+
+## ballot
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `register_voter` | `admin` | |
+| `deregister_voter` | `admin` | |
+| `vote` | `voter` | |
+| `tally` | `admin` | |
+| `get_yes_votes` | NONE | Read-only. |
+| `get_no_votes` | NONE | Read-only. |
+
+## bonding-curve
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `buy` | `buyer` | |
+| `sell` | `seller` | |
+| `get_reserve` | NONE | Read-only. |
+| `get_supply` | NONE | Read-only. |
+| `get_price` | NONE | Read-only. |
+
+## crowdfund
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `creator` | |
+| `pledge` | `pledger` | |
+| `withdraw` | `pledger` | |
+| `extend_deadline` | `creator` | |
+| `claim` | `creator` | |
+| `refund` | `pledger` | |
+| `get_info` | NONE | Read-only. |
+| `get_pledge` | NONE | Read-only. |
+
+## dao
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `create_proposal` | `proposer` | |
+| `vote` | `voter` | |
+| `execute_proposal` | NONE | Permissionless once quorum/passing conditions are met on-chain. |
+| `cancel_proposal` | `admin` | |
+| `get_proposal` | NONE | Read-only. |
+| `proposal_count` | NONE | Read-only. |
+
+## escrow
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | NONE | Sets up escrow state; no funds move yet. |
+| `initialize_with_arbiters` | NONE | Same as above, with an arbiter set configured. |
+| `update_amount` | `buyer` | Delegates to `lifecycle::update_amount`. |
+| `fund` | `buyer` | Delegates to `lifecycle::fund`. |
+| `mark_delivered` | `seller` | Delegates to `lifecycle::mark_delivered`. |
+| `approve_delivery` | `buyer` | Delegates to `lifecycle::approve_delivery`. |
+| `release_partial` | `buyer` | Delegates to `lifecycle::release_partial`. |
+| `request_refund` | `buyer` | Delegates to `lifecycle::request_refund`. |
+| `request_partial_refund` | `buyer` | Delegates to `lifecycle::request_partial_refund`. |
+| `raise_dispute` | `caller` | Delegates to `dispute::raise_dispute`; `caller` must equal the stored buyer or seller. |
+| `resolve_dispute` | `arbiter` or `caller` | Delegates to `dispute::resolve_dispute`; single-arbiter mode checks `arbiter`, multi-arbiter mode checks `caller` after verifying membership in the arbiter set. |
+| `claim_dispute_timeout` | `buyer` | Delegates to `dispute::claim_dispute_timeout`; only callable after the dispute timeout elapses. |
+| `cancel` | `buyer` | Delegates to `lifecycle::cancel`. |
+| `extend_deadline` | `buyer` and `seller` | Delegates to `lifecycle::extend_deadline`; requires both parties' auth. |
+| `bump` | NONE | Extends storage TTL only; no state change. |
+| `get_escrow_info` / `get_state` / `is_deadline_passed` / `get_remaining_ledgers` / `contract_version` / `version` | NONE | Read-only. |
+| `pause` / `unpause` | `admin` | Feature-gated (`pausable`). |
+| `propose_upgrade` / `execute_upgrade` | `admin` | |
+
+## lottery
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `buy_ticket` | `buyer` | |
+| `commit` | `admin` | |
+| `draw` | `admin` | |
+| `claim_refund` | `buyer` | |
+| `get_info` / `get_winner` / `get_winners` / `get_ticket_count` | NONE | Read-only. |
+
+## marketplace
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `list` | `seller` | Delegates to `list_impl`. |
+| `list_with_expiry` | `seller` | Delegates to `list_impl`. |
+| `buy` | `buyer` | |
+| `cancel` | `seller` | |
+| `sweep_expired` | `seller` | |
+| `make_offer` | `buyer` | |
+| `accept_offer` | `seller` | |
+| `cancel_offer` | `buyer` | |
+| `get_listing` / `get_offer` / `get_active_listings` | NONE | Read-only. |
+
+## multisig
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | every address in `signers` | Each initial signer must independently authorize. |
+| `add_signer` | every address in `approvals` | Delegates to `require_threshold_approvals`; each approving address must be an existing signer and the set must meet the threshold. |
+| `remove_signer` | every address in `approvals` | Same as `add_signer`. |
+| `propose_transaction` | `proposer` | Must also be an existing signer. |
+| `sign_transaction` | `signer` | Must also be an existing signer. |
+| `execute_transaction` | NONE | Permissionless once the stored signature threshold is met. |
+| `cleanup_expired` | NONE | Intentionally permissionless per doc comment — removes an expired, unexecuted proposal. |
+| `get_signers` / `get_threshold` / `is_signer` / `get_transaction` / `signature_count` / `contract_version` | NONE | Read-only. |
+
+## nft
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `mint` | `admin` | |
+| `transfer` | `from` | |
+| `burn` | `from` | |
+| `approve` | `owner` | |
+| `transfer_from` | `spender` | Must hold an active approval or be the owner. |
+| `owner_of` / `get_approved` / `token_uri` / `metadata` / `name` / `symbol` / `total_supply` | NONE | Read-only. |
+
+## oracle
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `update_price` | `admin` | |
+| `set_publishers` | `admin` | |
+| `submit_price` | `publisher` | Must be in the configured publisher set. |
+| `get_price` / `get_price_checked` / `get_price_data` / `get_median_price` / `get_twap` | NONE | Read-only. |
+
+## staking
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `stake` | `staker` | |
+| `unstake` | `staker` | |
+| `claim_rewards` | `staker` | |
+| `add_rewards` | `admin` | |
+| `set_compounding` | `staker` | |
+| `compound` | `staker` | |
+| `get_stake` / `get_rewards` / `get_total_staked` / `get_total_rewards` / `contract_version` | NONE | Read-only. |
+
+## subscription
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `provider` | |
+| `subscribe` | `subscriber` | |
+| `charge` | `provider` | Pulls from the subscriber's pre-approved allowance; subscriber does not sign each charge. |
+| `cancel` | `subscriber` | |
+| `get_subscription` / `get_provider` / `get_token` | NONE | Read-only. |
+
+## swap
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `propose_swap` | `party_a` | |
+| `accept_swap` | `party_b` | |
+| `cancel_swap` | `party_a` | |
+| `get_swap` / `swap_count` | NONE | Read-only. |
+
+## timelock
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `release` | NONE | Permissionless once the target ledger passes; funds go to the fixed stored beneficiary. |
+| `cancel` | `admin` | |
+| `get_info` / `is_releasable` / `get_remaining_ledgers` | NONE | Read-only. |
+
+## token
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `mint` | `admin` | |
+| `batch_mint` | `admin` | |
+| `admin_burn` | `admin` | |
+| `propose_admin` | `admin` | |
+| `accept_admin` | `pending` (proposed new admin) | |
+| `cancel_admin_proposal` | `admin` | |
+| `set_admin` | `old_admin` | |
+| `pause` / `unpause` | `admin` | |
+| `freeze_account` / `unfreeze_account` | `admin` | |
+| `propose_upgrade` / `execute_upgrade` | `admin` | |
+| `set_transfer_hook` | `admin` | |
+| `snapshot` | `caller` | |
+| `admin` / `total_supply` / `balance_of` / `version` / `contract_version` / `allowance_expiry` / `balance_at` / `max_supply` / `get_transfer_hook` | NONE | Read-only. |
+| `approve` *(SEP-41 `TokenInterface`)* | `from` | |
+| `transfer` *(SEP-41)* | `from` | |
+| `transfer_from` *(SEP-41)* | `spender` | Must hold an active allowance. |
+| `burn` *(SEP-41)* | `from` | |
+| `burn_from` *(SEP-41)* | `spender` | Must hold an active allowance. |
+| `allowance` / `balance` / `decimals` / `name` / `symbol` *(SEP-41)* | NONE | Read-only. |
+
+## vesting
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `claim` | `beneficiary` | |
+| `revoke` | `admin` | |
+| `admin_release` | `admin` | |
+| `get_info` / `claimable` / `contract_version` | NONE | Read-only. |
+
+## wrapped-token
+
+| Entry Point | Auth Required | Notes |
+|---|---|---|
+| `initialize` | `admin` | |
+| `wrap` | `user` | |
+| `unwrap` | `user` | |
+| `get_total_wrapped` | NONE | Read-only. |
+
+## common
+
+`contracts/common` is a shared library crate (`crate-type = ["rlib"]`) with
+no `#[contract]`/`#[contractimpl]` of its own — it has no entry points and
+is not deployed independently, so it is out of scope for this table.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -214,6 +214,10 @@ Deploy all contracts:
 ./scripts/deploy.sh testnet
 ```
 
+Or use `./scripts/deploy-all.sh testnet` for the same full-workspace deploy with a
+`contract -> contract ID` summary table printed at the end, and a fail-fast stop on
+the first contract that errors.
+
 Deploy a single contract:
 
 ```bash

--- a/docs/upgrade-compatibility-matrix.md
+++ b/docs/upgrade-compatibility-matrix.md
@@ -1,0 +1,76 @@
+# Upgrade Compatibility Matrix
+
+Companion to the [Upgrade Guide](upgrade-guide.md): what storage each
+contract actually persists, which contracts share a storage layout or data
+structure with another contract (so a layout change in one must be applied
+consistently to the other), and what kinds of code changes are
+storage-breaking for a live deployment of each contract.
+
+## How storage compatibility works here
+
+- **`#[contracttype]` enums used as storage keys encode by variant *name*,
+  not declaration order.** Every `storage.rs` in this repo documents this
+  rule directly above its `DataKey` enum. Renaming or removing a variant
+  changes the on-chain key and orphans existing data; adding a variant is
+  safe as long as it's appended and no existing variant is renamed.
+- **Struct shape matters.** For `#[contracttype]` structs actually written
+  to storage (as opposed to response DTOs assembled at query time, see
+  below), adding a field, removing a field, or changing a field's type is
+  storage-breaking. Reordering `#[contracttype]` struct fields is also
+  unsafe if the struct derives `Ord`/`PartialOrd`, since comparisons then
+  depend on declaration order.
+- **Not everything with a `#[contracttype]` on it is stored.** Most
+  contracts expose a `get_info` / `get_*_data` query that assembles a
+  response struct (`EscrowInfo`, `AuctionInfo`, `CrowdfundInfo`,
+  `LotteryInfo`, `VestingInfo`, `PriceData`, `ListingEntry`, `ListingPage`,
+  ...) from several individually-stored keys. These response DTOs can be
+  changed freely between upgrades — they're never written to storage, only
+  constructed on read. The matrix below lists only the types that are
+  actually persisted.
+- **Storage tier matters for TTL, not shape.** Moving a key between
+  instance, persistent, and temporary storage doesn't change its XDR
+  encoding, but changes its bump/eviction lifecycle — treat it as an
+  operational change to test, even though it isn't "storage-breaking" in
+  the layout sense.
+
+## Contracts sharing a storage layout or data structure
+
+| Pattern | Contracts | Why it matters |
+|---|---|---|
+| Admin address key | All 19 deployable contracts store a single admin `Address`. **`escrow`** is the only one that stores it under `soroban_common::AdminKey::Admin` (a shared type from the `common` crate) instead of a local `DataKey::Admin` variant — every other contract defines its own independent `DataKey::Admin`. A rename of `AdminKey::Admin` in `contracts/common` is storage-breaking for `escrow` specifically; it has no effect on the other 18, since their `Admin` variant lives in their own enum. |
+| Upgrade timelock (`PendingUpgrade` + `Version`) | `escrow`, `token` | Both store the identical shape `PendingUpgrade: (BytesN<32>, u32)` = `(wasm_hash, ready_after_ledger)` plus a `Version: u32` counter, backing `propose_upgrade`/`execute_upgrade`. If this pattern is extended (e.g. to add a proposer address to the tuple), change both contracts together and update [`upgrade-guide.md`](upgrade-guide.md) — currently the only two contracts with on-chain upgrade timelocks. |
+| Address-keyed persistent record | `airdrop` (`Claimed(Address)`), `auction` (`Pending(Address)`), `ballot` (`RegisteredVoter`/`Voter(Address)`), `crowdfund` (`Pledge(Address)`), `lottery` (`TicketCount(Address)`), `oracle` (`Submission(Address)`), `staking` (`Stake`/`RewardPerTokenPaid`/`Rewards`/`Compounding(Address)`), `subscription` (`Subscription(Address)`), `token` (`Balance`/`Frozen(Address)`) | Same *pattern* (an `Address` as part of the storage key) reused independently by each contract. Each contract's value shape is unrelated to the others' — this row is about template consistency, not a shared type. Changing one contract's per-address value shape doesn't affect any other contract. |
+| Contract version counter | `escrow`, `multisig`, `staking`, `token`, `vesting` | All expose `contract_version()` backed by a `Version: u32` instance key. Only `escrow` and `token` pair it with `PendingUpgrade` (see above); in `multisig`/`staking`/`vesting` it is a plain counter with no upgrade-timelock storage attached. |
+
+## Per-contract storage matrix
+
+For each contract: the `DataKey` variants it defines (dynamic/persistent
+keys marked), any `#[contracttype]` structs actually written to storage,
+and change categories that would break storage for that contract
+specifically, beyond the general rules above.
+
+| Contract | Storage keys (`DataKey`) | Stored structs | Contract-specific storage-breaking risks |
+|---|---|---|---|
+| `airdrop` | `Admin`, `Token`, `MerkleRoot`, `ClaimDeadline`; dynamic: `Claimed(Address)` | — | None beyond the general rules. |
+| `auction` | `Seller`, `Token`, `StartPrice`, `MinIncrement`, `Deadline`, `HighestBidder`, `HighestBid`, `Settled`, `ReservePrice`, `ExtensionWindow`, `Cancelled`; dynamic: `Pending(Address)` | — | None beyond the general rules. |
+| `ballot` | `Admin`, `VotingActive`, `YesVotes`, `NoVotes`, `VotingStart`, `VotingEnd`, `TotalVotes`; dynamic: `RegisteredVoter(Address)`, `Voter(Address)` | — | None beyond the general rules. |
+| `bonding-curve` | `Admin`, `Token`, `Reserve`, `Supply`, `Price` | — | None beyond the general rules. |
+| `crowdfund` | `Creator`, `Token`, `Goal`, `Deadline`, `TotalPledged`, `Claimed`, `Tiers`, `MaxPledgePerAddress`, `DeadlineExtended`; dynamic: `Pledge(Address)` | `FundingTier` (stored inside the `Tiers: Vec<FundingTier>` list) | `FundingTier`'s field shape is storage-breaking since it's nested inside a stored `Vec`. `TierStatus` is a query-only DTO, not stored. |
+| `dao` | `Admin`, `Token`, `VotingPeriod`, `Quorum`, `ProposalCount`, `Initialized` | `Proposal` (per-proposal, keyed by a separate `ProposalKey`), `VoteKey` | `Proposal`'s field shape and `ProposalState`'s variant names are storage-breaking. |
+| `escrow` | `Buyer`, `Seller`, `Arbiter`, `TokenContract`, `Amount`, `Deadline`, `State`, `Paused`, `Version`, `PendingUpgrade`, `Arbiters`, `RequiredSignatures`, `ArbiterVotes`, `MetadataHash`, `DisputeTimeoutLedgers`, `DisputeRaisedAt`; admin via shared `soroban_common::AdminKey` (see table above) | `EscrowState` (stored under `State`) | `EscrowState` derives `Ord`/`PartialOrd` and lifecycle logic compares states with `<`/`>=`; reordering its variants changes comparison results even though the XDR key name doesn't change. Keep new states appended in lifecycle order, not just enum-declaration order. |
+| `lottery` | `Admin`, `Token`, `TicketPrice`, `Participants`, `State`, `Winner`, `Winners`, `RevealDeadline`, `WinnerCount`, `PrizeSplits`, `MaxTicketsPerAddress`; dynamic: `TicketCount(Address)` | `Commit` (stored under `DataKey::Commit`) | None beyond the general rules. |
+| `marketplace` | `Admin`, `PaymentToken`, `RoyaltyBps`, `RoyaltyRecipient`, `NextListingId`; dynamic: `Listing(u64)`, `Offer(u64, Address)` | `Listing` (stored per `Listing(u64)` key) | `Listing`'s field shape is storage-breaking; `ListingEntry`/`ListingPage` are pagination DTOs assembled at query time and not stored. |
+| `multisig` | `Signers`, `Threshold`, `NextTransactionId`, `Paused`, `Version`; dynamic: `Transaction(u64)` | `Transaction` (stored per `Transaction(u64)` key) | `Transaction`'s field shape (including the `Vec<Val>` args it carries) is storage-breaking. |
+| `nft` | `Admin`, `Name`, `Symbol`, `TotalSupply`, `MaxSupply`, `Initialized`; dynamic: per-token owner/approval/metadata keys (see `TokenKey`) | `TokenMetadata` | `TokenMetadata`'s field shape is storage-breaking. |
+| `oracle` | `Admin`, `Price`, `UpdatedAt`, `StalenessThreshold`, `UpdatedAtTimestamp`, `Publishers`, `History`; dynamic: `Submission(Address)` | `PublisherSubmission` (stored per `Submission(Address)`), `PriceObservation` (stored inside the `History` ring buffer) | `PriceObservation`'s shape is storage-breaking since it's nested in the stored `History` vector. `PriceData` is a query-only DTO, not stored. |
+| `staking` | `Admin`, `StakeToken`, `RewardToken`, `TotalStaked`, `TotalRewards`, `RewardPerTokenStored`, `Version`; dynamic: `Stake(Address)`, `RewardPerTokenPaid(Address)`, `Rewards(Address)`, `Compounding(Address)` | — | The `REWARD_SCALE` fixed-point scale used to interpret `RewardPerTokenStored`/`RewardPerTokenPaid` is a code constant, not stored — changing it changes how existing stored values are interpreted without any storage layout change, so treat it as storage-breaking in effect even though no key/type changes. |
+| `subscription` | `Provider`, `Token`; dynamic: `Subscription(Address)` | `SubscriptionInfo` (stored per `Subscription(Address)`) | `SubscriptionInfo`'s field shape is storage-breaking. |
+| `swap` | `SwapCount`, `Initialized`; dynamic (via `SwapKey`, see storage.rs) | `SwapInfo` | `SwapInfo`'s field shape and `SwapState`'s variant names are storage-breaking. |
+| `timelock` | `Admin`, `Token`, `Beneficiary`, `ReleaseLedger`, `Amount`, `State` | `TimelockState` (stored under `State`) | `TimelockState`'s variant names are storage-breaking. |
+| `token` | `Admin`, `PendingAdmin`, `TotalSupply`, `Paused`, `MaxSupply`, `PendingUpgrade`, `Version`, `TransferHook`; dynamic: `Balance(Address)`, `Allowance(AllowanceDataKey)`, `Metadata(MetadataKey)`, `Frozen(Address)`, `Snapshot(Address, u32)` | `AllowanceDataKey`/`AllowanceValue`, snapshot balances | `AllowanceDataKey`/`AllowanceValue`'s field shape is storage-breaking; it is also the type most likely to be read by external integrators (wallets, DEXs), so a shape change needs coordinated off-chain updates, not just an on-chain migration. Shares the `PendingUpgrade`/`Version` pattern with `escrow` (see table above). |
+| `vesting` | `Beneficiary`, `Token`, `CliffLedger`, `EndLedger`, `Amount`, `Claimed`, `Revoked`, `Admin`, `AdminReleased`, `Version` | — | None beyond the general rules. |
+| `wrapped-token` | `Admin`, `WrappedToken`, `UnderlyingToken`, `TotalWrapped` | — | None beyond the general rules. |
+
+`contracts/common` has no storage of its own beyond the `AdminKey::Admin`
+type it defines for `escrow` to reuse (see the shared-pattern table above);
+it is not deployed independently.

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -12,6 +12,11 @@ On-chain upgrades follow a timelock-protected flow:
 
 This ensures security by preventing instant unauthorized upgrades.
 
+Before writing the new WASM, check the
+[Upgrade Compatibility Matrix](upgrade-compatibility-matrix.md) for what
+storage your contract shares with other contracts and which changes would
+break existing on-chain data.
+
 ## Prerequisites
 
 - Stellar CLI installed and configured

--- a/scripts/deploy-all.sh
+++ b/scripts/deploy-all.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# deploy-all.sh — deploy every workspace contract in one command
+# Usage: ./scripts/deploy-all.sh [testnet|mainnet|local] [--identity <name>]
+#
+# Reuses scripts/deploy.sh (build + deploy for a single contract) for each
+# contract directory under contracts/, prints a contract -> deployed ID
+# summary table, and stops immediately on the first failure.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTRACTS_DIR="$ROOT/contracts"
+DEPLOY_SCRIPT="$ROOT/scripts/deploy.sh"
+
+NETWORK="${1:-testnet}"
+shift || true
+
+[[ -d "$CONTRACTS_DIR" ]] || { echo "Contracts directory not found: $CONTRACTS_DIR" >&2; exit 1; }
+
+NAMES=()
+for dir in "$CONTRACTS_DIR"/*/; do
+  name="$(basename "$dir")"
+  # "common" is a shared library crate (crate-type = rlib), not a deployable contract.
+  [[ "$name" == "common" ]] && continue
+  NAMES+=("$name")
+done
+
+STATUSES=()
+IDS=()
+FAILED_CONTRACT=""
+
+echo "Deploying ${#NAMES[@]} contracts to $NETWORK..." >&2
+
+for name in "${NAMES[@]}"; do
+  echo "" >&2
+  echo "═══ $name ═══" >&2
+  if "$DEPLOY_SCRIPT" "$NETWORK" "$name" "$@" >&2; then
+    id="$(grep "^$name: " "$ROOT/.contract-ids" 2>/dev/null | tail -1 | cut -d' ' -f2)"
+    STATUSES+=("ok")
+    IDS+=("${id:-unknown}")
+  else
+    STATUSES+=("FAILED")
+    IDS+=("-")
+    FAILED_CONTRACT="$name"
+    echo "" >&2
+    echo "ERROR: deploy failed for '$name' — stopping (fail-fast)." >&2
+    break
+  fi
+done
+
+echo "" >&2
+echo "Deploy summary ($NETWORK):"
+printf "%-20s %-8s %s\n" "CONTRACT" "STATUS" "CONTRACT ID"
+printf "%-20s %-8s %s\n" "--------------------" "--------" "--------------------------------------------"
+for i in "${!STATUSES[@]}"; do
+  printf "%-20s %-8s %s\n" "${NAMES[$i]}" "${STATUSES[$i]}" "${IDS[$i]}"
+done
+
+if [[ -n "$FAILED_CONTRACT" ]]; then
+  echo "" >&2
+  echo "Deploy stopped after failure on '$FAILED_CONTRACT' (${#STATUSES[@]}/${#NAMES[@]} attempted)." >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #843 
closes #842 
closes #841 
closes #840 

Issue  (module-level rustdoc on the 13 newer contracts) was already satisfied by the existing code -- every listed contract's `lib.rs` already has a `//!` header covering purpose, roles, and invariants -- so no change was needed for it.

## What's here

- **`scripts/deploy-all.sh`** (#843): deploys every workspace contract to a chosen network in one command, reusing `scripts/deploy.sh` per contract, printing a `contract -> contract ID` summary table, and stopping immediately (fail-fast) on the first contract that errors. Linked from `docs/deployment-guide.md`.
- **`docs/access-control-reference.md`** (#842): an entry-point -> role `require_auth` table for every contract, cross-checked against the actual `require_auth` call sites in code (including calls reached through private helper functions, e.g. `marketplace::list` -> `list_impl`, and `escrow`'s `lifecycle`/`dispute` modules).
- **`docs/upgrade-compatibility-matrix.md`** (#841): documents which contracts share a storage layout or data structure with another contract (e.g. `escrow`'s admin key is shared with the `common` crate; the `PendingUpgrade`/`Version` timelock pattern is shared between `escrow` and `token`) and what kinds of changes would be storage-breaking per contract. Cross-linked from `docs/upgrade-guide.md`.

Both new docs are also linked from the README resources list.

Per the task instructions, test additions were skipped for this PR.