### PR TITLE
feat: royalty enforcement, auction monitor, coverage CI, cross-contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,49 @@ jobs:
           echo "percent=${COVERAGE}" >> "$GITHUB_OUTPUT"
           echo "Code coverage: ${COVERAGE}%"
 
+          # Per-contract breakdown: re-run with --json and extract per-file data.
+          cargo llvm-cov --workspace --json > coverage_full.json
+
+          # Build a markdown table of coverage per contract package.
+          # Each contracts/* crate maps to a distinct set of source files.
+          echo "per_contract_table<<TABLEEOF" >> "$GITHUB_OUTPUT"
+          python3 - <<'PYEOF'
+          import json, os, sys, collections
+
+          with open("coverage_full.json") as f:
+              data = json.load(f)
+
+          # Group files by top-level contracts/<name> directory.
+          pkg_lines = collections.defaultdict(lambda: [0, 0])  # [covered, total]
+          for file_data in data["data"][0].get("files", []):
+              filename = file_data.get("filename", "")
+              summary = file_data.get("summary", {}).get("lines", {})
+              covered = summary.get("covered", 0)
+              total = summary.get("count", 0)
+              # Map path to package name
+              parts = filename.replace("\\", "/").split("/")
+              try:
+                  ci = parts.index("contracts")
+                  pkg = parts[ci + 1]
+              except (ValueError, IndexError):
+                  if "tests" in parts:
+                      pkg = "integration-tests"
+                  else:
+                      continue
+              pkg_lines[pkg][0] += covered
+              pkg_lines[pkg][1] += total
+
+          rows = []
+          for pkg in sorted(pkg_lines):
+              cov, tot = pkg_lines[pkg]
+              pct = (cov / tot * 100) if tot > 0 else 0.0
+              icon = "✅" if pct >= 80 else "⚠️"
+              rows.append(f"| `{pkg}` | {cov} / {tot} | **{pct:.1f}%** {icon} |")
+
+          print("\n".join(rows))
+          PYEOF
+          echo "TABLEEOF" >> "$GITHUB_OUTPUT"
+
       - name: Check coverage threshold
         run: |
           COVERAGE="${{ steps.coverage.outputs.percent }}"
@@ -171,6 +214,17 @@ jobs:
               : 'n/a';
             const threshold = 80;
             const status = current >= threshold ? '✅' : '❌';
+            const perContractTable = `${{ steps.coverage.outputs.per_contract_table }}`;
+            const perContractSection = perContractTable
+              ? [
+                  '',
+                  '### Per-contract coverage',
+                  '',
+                  '| Contract | Lines (covered / total) | Coverage |',
+                  '|----------|------------------------|----------|',
+                  perContractTable,
+                ].join('\n')
+              : '';
             const body = [
               '## Code Coverage Report',
               '',
@@ -181,6 +235,7 @@ jobs:
               `| Delta vs \`${{ github.base_ref }}\` | ${deltaStr}% |`,
               '',
               `Minimum line coverage of ${threshold}% is ${current >= threshold ? 'met' : '**not met**'}.`,
+              perContractSection,
             ].join('\n');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -217,7 +272,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
-          path: lcov.info
+          path: |
+            lcov.info
+            coverage_full.json
           retention-days: 30
 
   fuzz:

--- a/contracts/nft/snapshots/error_codes.snap
+++ b/contracts/nft/snapshots/error_codes.snap
@@ -1,0 +1,11 @@
+NftError::NotAuthorized = 1
+NftError::AlreadyInitialized = 2
+NftError::NotInitialized = 3
+NftError::TokenNotFound = 4
+NftError::TokenAlreadyMinted = 5
+NftError::NotOwner = 6
+NftError::NotApproved = 7
+NftError::SupplyCapReached = 8
+NftError::InvalidTokenId = 9
+NftError::InvalidRoyalty = 10
+NftError::RoyaltyRecipientMissing = 11

--- a/contracts/nft/src/errors.rs
+++ b/contracts/nft/src/errors.rs
@@ -15,19 +15,25 @@ pub enum NftError {
     NotApproved = 7,
     SupplyCapReached = 8,
     InvalidTokenId = 9,
+    /// Royalty basis points exceed 10 000 (100 %).
+    InvalidRoyalty = 10,
+    /// A royalty BPS was provided without a recipient (or vice-versa).
+    RoyaltyRecipientMissing = 11,
 }
 
 impl_display_error!(
     NftError,
-    NotAuthorized      => "not authorized",
-    AlreadyInitialized => "already initialized",
-    NotInitialized     => "not initialized",
-    TokenNotFound      => "token not found",
-    TokenAlreadyMinted => "token already minted",
-    NotOwner           => "not the token owner",
-    NotApproved        => "not approved for this token",
-    SupplyCapReached   => "supply cap reached",
-    InvalidTokenId     => "invalid token id",
+    NotAuthorized           => "not authorized",
+    AlreadyInitialized      => "already initialized",
+    NotInitialized          => "not initialized",
+    TokenNotFound           => "token not found",
+    TokenAlreadyMinted      => "token already minted",
+    NotOwner                => "not the token owner",
+    NotApproved             => "not approved for this token",
+    SupplyCapReached        => "supply cap reached",
+    InvalidTokenId          => "invalid token id",
+    InvalidRoyalty          => "royalty bps exceeds 10 000",
+    RoyaltyRecipientMissing => "royalty recipient must be set when royalty bps > 0",
 );
 
 #[cfg(test)]
@@ -50,7 +56,9 @@ NftError::TokenAlreadyMinted = {}\n\
 NftError::NotOwner = {}\n\
 NftError::NotApproved = {}\n\
 NftError::SupplyCapReached = {}\n\
-NftError::InvalidTokenId = {}\n",
+NftError::InvalidTokenId = {}\n\
+NftError::InvalidRoyalty = {}\n\
+NftError::RoyaltyRecipientMissing = {}\n",
             NftError::NotAuthorized as u32,
             NftError::AlreadyInitialized as u32,
             NftError::NotInitialized as u32,
@@ -60,6 +68,8 @@ NftError::InvalidTokenId = {}\n",
             NftError::NotApproved as u32,
             NftError::SupplyCapReached as u32,
             NftError::InvalidTokenId as u32,
+            NftError::InvalidRoyalty as u32,
+            NftError::RoyaltyRecipientMissing as u32,
         )
     }
 

--- a/contracts/nft/src/lib.rs
+++ b/contracts/nft/src/lib.rs
@@ -12,7 +12,7 @@ mod events;
 mod storage;
 
 pub use errors::NftError;
-pub use storage::{DataKey, TokenKey, TokenMetadata};
+pub use storage::{DataKey, RoyaltyInfo, TokenKey, TokenMetadata};
 
 use soroban_common::{LEDGER_BUMP_AMOUNT, LEDGER_LIFETIME_THRESHOLD};
 
@@ -50,18 +50,37 @@ mod contract {
         ///
         /// `max_supply` of `0` means no cap.
         ///
+        /// `royalty_bps` sets a collection-level default royalty in basis points
+        /// (0–10 000). `royalty_recipient` is required when `royalty_bps > 0`.
+        /// Both default to no royalty when omitted (`None`).
+        ///
         /// # Errors
         ///
         /// Returns [`NftError::AlreadyInitialized`] if called a second time.
+        /// Returns [`NftError::InvalidRoyalty`] if `royalty_bps > 10 000`.
+        /// Returns [`NftError::RoyaltyRecipientMissing`] if `royalty_bps > 0` but
+        /// `royalty_recipient` is `None`.
         pub fn initialize(
             env: Env,
             admin: Address,
             name: String,
             symbol: String,
             max_supply: u32,
+            royalty_bps: Option<u32>,
+            royalty_recipient: Option<Address>,
         ) -> Result<(), NftError> {
             if env.storage().instance().has(&DataKey::Initialized) {
                 return Err(NftError::AlreadyInitialized);
+            }
+
+            // Validate collection-level royalty parameters.
+            if let Some(bps) = royalty_bps {
+                if bps > 10_000 {
+                    return Err(NftError::InvalidRoyalty);
+                }
+                if bps > 0 && royalty_recipient.is_none() {
+                    return Err(NftError::RoyaltyRecipientMissing);
+                }
             }
 
             admin.require_auth();
@@ -75,6 +94,14 @@ mod contract {
                     .instance()
                     .set(&DataKey::MaxSupply, &max_supply);
             }
+            if let Some(bps) = royalty_bps {
+                env.storage().instance().set(&DataKey::RoyaltyBps, &bps);
+            }
+            if let Some(ref recipient) = royalty_recipient {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::RoyaltyRecipient, recipient);
+            }
             env.storage().instance().set(&DataKey::Initialized, &true);
 
             bump_instance(&env);
@@ -85,17 +112,27 @@ mod contract {
 
         /// Mint a new token to `to` with the given `token_id` and `token_uri`. Admin only.
         ///
+        /// `token_royalty_bps` and `token_royalty_recipient` are optional per-token
+        /// royalty overrides (EIP-2981-style). When set they take precedence over the
+        /// collection-level defaults returned by [`royalty_info`]. Both must be `None`
+        /// or both must be `Some` (with `token_royalty_bps` in 0–10 000).
+        ///
         /// # Errors
         ///
         /// Returns [`NftError::NotInitialized`] if the contract has not been set up.
         /// Returns [`NftError::NotAuthorized`] if the caller is not the admin.
         /// Returns [`NftError::TokenAlreadyMinted`] if `token_id` is already taken.
         /// Returns [`NftError::SupplyCapReached`] if minting would exceed the max supply.
+        /// Returns [`NftError::InvalidRoyalty`] if `token_royalty_bps > 10 000`.
+        /// Returns [`NftError::RoyaltyRecipientMissing`] if `token_royalty_bps > 0` but
+        /// `token_royalty_recipient` is `None`.
         pub fn mint(
             env: Env,
             to: Address,
             token_id: u32,
             token_uri: String,
+            token_royalty_bps: Option<u32>,
+            token_royalty_recipient: Option<Address>,
         ) -> Result<(), NftError> {
             Self::require_initialized(&env)?;
 
@@ -108,6 +145,16 @@ mod contract {
 
             if env.storage().persistent().has(&TokenKey::Owner(token_id)) {
                 return Err(NftError::TokenAlreadyMinted);
+            }
+
+            // Validate per-token royalty parameters.
+            if let Some(bps) = token_royalty_bps {
+                if bps > 10_000 {
+                    return Err(NftError::InvalidRoyalty);
+                }
+                if bps > 0 && token_royalty_recipient.is_none() {
+                    return Err(NftError::RoyaltyRecipientMissing);
+                }
             }
 
             let total: u32 = env
@@ -135,12 +182,95 @@ mod contract {
                 .instance()
                 .set(&DataKey::TotalSupply, &(total + 1));
 
+            // Store per-token royalty overrides if provided.
+            if let Some(bps) = token_royalty_bps {
+                env.storage()
+                    .persistent()
+                    .set(&TokenKey::TokenRoyaltyBps(token_id), &bps);
+                bump_token(&env, &TokenKey::TokenRoyaltyBps(token_id));
+            }
+            if let Some(ref recipient) = token_royalty_recipient {
+                env.storage()
+                    .persistent()
+                    .set(&TokenKey::TokenRoyaltyRecipient(token_id), recipient);
+                bump_token(&env, &TokenKey::TokenRoyaltyRecipient(token_id));
+            }
+
             bump_instance(&env);
             bump_token(&env, &TokenKey::Owner(token_id));
             bump_token(&env, &TokenKey::Uri(token_id));
             events::minted(&env, &to, token_id);
 
             Ok(())
+        }
+
+        /// Return royalty information for a token sale (EIP-2981-style view).
+        ///
+        /// Resolution order:
+        /// 1. Per-token royalty BPS and recipient (set at mint time), if present.
+        /// 2. Collection-level royalty BPS and recipient (set at initialize time).
+        /// 3. If neither is configured, returns `None`.
+        ///
+        /// `sale_price` is the gross sale amount in base units. The returned
+        /// [`RoyaltyInfo::amount`] is pre-computed as `sale_price * bps / 10_000`.
+        ///
+        /// Integrating marketplaces (e.g. this repo's own marketplace) should call
+        /// this before executing a sale and route the indicated `amount` to the
+        /// `recipient`.
+        ///
+        /// # Errors
+        ///
+        /// Returns [`NftError::NotInitialized`] if the contract has not been set up.
+        /// Returns [`NftError::TokenNotFound`] if `token_id` does not exist.
+        #[must_use]
+        pub fn royalty_info(
+            env: Env,
+            token_id: u32,
+            sale_price: i128,
+        ) -> Result<Option<RoyaltyInfo>, NftError> {
+            Self::require_initialized(&env)?;
+
+            // Confirm the token exists.
+            if !env.storage().persistent().has(&TokenKey::Owner(token_id)) {
+                return Err(NftError::TokenNotFound);
+            }
+
+            // 1. Per-token override.
+            let token_bps: Option<u32> = env
+                .storage()
+                .persistent()
+                .get(&TokenKey::TokenRoyaltyBps(token_id));
+            let token_recipient: Option<Address> = env
+                .storage()
+                .persistent()
+                .get(&TokenKey::TokenRoyaltyRecipient(token_id));
+
+            if let (Some(bps), Some(recipient)) = (token_bps, token_recipient) {
+                if bps == 0 {
+                    return Ok(None);
+                }
+                #[allow(clippy::arithmetic_side_effects, clippy::as_conversions, clippy::cast_possible_truncation, clippy::integer_division)]
+                let amount = (sale_price * bps as i128) / 10_000;
+                return Ok(Some(RoyaltyInfo { recipient, amount }));
+            }
+
+            // 2. Collection-level defaults.
+            let collection_bps: Option<u32> =
+                env.storage().instance().get(&DataKey::RoyaltyBps);
+            let collection_recipient: Option<Address> =
+                env.storage().instance().get(&DataKey::RoyaltyRecipient);
+
+            if let (Some(bps), Some(recipient)) = (collection_bps, collection_recipient) {
+                if bps == 0 {
+                    return Ok(None);
+                }
+                #[allow(clippy::arithmetic_side_effects, clippy::as_conversions, clippy::cast_possible_truncation, clippy::integer_division)]
+                let amount = (sale_price * bps as i128) / 10_000;
+                return Ok(Some(RoyaltyInfo { recipient, amount }));
+            }
+
+            // 3. No royalty configured.
+            Ok(None)
         }
 
         /// Transfer token `token_id` from `from` to `to`. Requires auth from `from` (the owner).

--- a/contracts/nft/src/prop_test.rs
+++ b/contracts/nft/src/prop_test.rs
@@ -17,6 +17,8 @@ fn setup_nft<'a>(env: &'a Env) -> (NftContractClient<'a>, Address) {
         &String::from_str(env, "PropTest"),
         &String::from_str(env, "PT"),
         &0,
+        &None,
+        &None,
     );
     (client, admin)
 }
@@ -31,7 +33,7 @@ proptest! {
         let owner = Address::generate(&env);
 
         for token_id in 0..n {
-            client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"));
+            client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"), &None, &None);
         }
 
         prop_assert_eq!(client.total_supply(), n);
@@ -45,7 +47,7 @@ proptest! {
         let (client, _) = setup_nft(&env);
         let owner = Address::generate(&env);
 
-        client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"));
+        client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"), &None, &None);
         prop_assert_eq!(client.total_supply(), 1);
 
         client.burn(&owner, &token_id);
@@ -61,7 +63,7 @@ proptest! {
         let alice = Address::generate(&env);
         let bob = Address::generate(&env);
 
-        client.mint(&alice, &token_id, &String::from_str(&env, "ipfs://x"));
+        client.mint(&alice, &token_id, &String::from_str(&env, "ipfs://x"), &None, &None);
         let before = client.total_supply();
         client.transfer(&alice, &bob, &token_id);
         prop_assert_eq!(client.total_supply(), before);
@@ -75,7 +77,7 @@ proptest! {
         let (client, _) = setup_nft(&env);
         let owner = Address::generate(&env);
 
-        client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"));
+        client.mint(&owner, &token_id, &String::from_str(&env, "ipfs://x"), &None, &None);
         prop_assert_eq!(client.owner_of(&token_id), owner);
     }
 }

--- a/contracts/nft/src/storage.rs
+++ b/contracts/nft/src/storage.rs
@@ -1,7 +1,7 @@
 // `#[contracttype]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
-use soroban_sdk::{String, contracttype};
+use soroban_sdk::{Address, String, contracttype};
 
 /// Instance-storage keys (shared TTL for contract-level data).
 #[contracttype]
@@ -13,6 +13,10 @@ pub enum DataKey {
     TotalSupply,
     MaxSupply,
     Initialized,
+    /// Collection-level default royalty in basis points (0–10 000).
+    RoyaltyBps,
+    /// Collection-level default royalty recipient.
+    RoyaltyRecipient,
 }
 
 /// Persistent-storage keys (per-key TTL for per-token data).
@@ -22,6 +26,10 @@ pub enum TokenKey {
     Owner(u32),
     Approval(u32),
     Uri(u32),
+    /// Optional per-token royalty override in basis points (0–10 000).
+    TokenRoyaltyBps(u32),
+    /// Optional per-token royalty recipient override.
+    TokenRoyaltyRecipient(u32),
 }
 
 #[contracttype]
@@ -30,4 +38,14 @@ pub struct TokenMetadata {
     pub name: String,
     pub symbol: String,
     pub token_uri: String,
+}
+
+/// Return value of [`NftContract::royalty_info`].
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct RoyaltyInfo {
+    /// Recipient of the royalty payment.
+    pub recipient: Address,
+    /// Royalty amount for the given `sale_price` (already computed).
+    pub amount: i128,
 }

--- a/contracts/nft/src/test.rs
+++ b/contracts/nft/src/test.rs
@@ -23,6 +23,8 @@ fn setup(env: &Env) -> (NftContractClient, Address) {
         &String::from_str(env, "My Collection"),
         &String::from_str(env, "MYC"),
         &0,
+        &None,
+        &None,
     );
     (client, admin)
 }
@@ -36,6 +38,8 @@ fn setup_with_cap(env: &Env, max_supply: u32) -> (NftContractClient, Address) {
         &String::from_str(env, "Capped"),
         &String::from_str(env, "CAP"),
         &max_supply,
+        &None,
+        &None,
     );
     (client, admin)
 }
@@ -68,12 +72,16 @@ fn test_initialize_twice_fails() {
         &String::from_str(&env, "A"),
         &String::from_str(&env, "A"),
         &0,
+        &None,
+        &None,
     );
     client.initialize(
         &admin,
         &String::from_str(&env, "B"),
         &String::from_str(&env, "B"),
         &0,
+        &None,
+        &None,
     );
 }
 
@@ -84,7 +92,13 @@ fn test_mint() {
     let (client, _) = setup(&env);
 
     let owner = Address::generate(&env);
-    client.mint(&owner, &1, &String::from_str(&env, "ipfs://token/1"));
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://token/1"),
+        &None,
+        &None,
+    );
 
     assert_eq!(client.owner_of(&1), owner);
     assert_eq!(client.total_supply(), 1);
@@ -102,8 +116,20 @@ fn test_mint_duplicate_token_id_fails() {
     let (client, _) = setup(&env);
 
     let owner = Address::generate(&env);
-    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1"));
-    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1b"));
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1b"),
+        &None,
+        &None,
+    );
 }
 
 #[test]
@@ -114,7 +140,13 @@ fn test_transfer() {
 
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
-    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(
+        &alice,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
     client.transfer(&alice, &bob, &1);
 
     assert_eq!(client.owner_of(&1), bob);
@@ -130,7 +162,13 @@ fn test_transfer_not_owner_fails() {
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
     let carol = Address::generate(&env);
-    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(
+        &alice,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
     // bob tries to transfer alice's token
     client.transfer(&bob, &carol, &1);
 }
@@ -142,7 +180,13 @@ fn test_burn() {
     let (client, _) = setup(&env);
 
     let owner = Address::generate(&env);
-    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
     assert_eq!(client.total_supply(), 1);
 
     client.burn(&owner, &1);
@@ -159,7 +203,13 @@ fn test_approve_and_transfer_from() {
     let bob = Address::generate(&env);
     let carol = Address::generate(&env);
 
-    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(
+        &alice,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
     client.approve(&1, &bob);
     assert_eq!(client.get_approved(&1), Some(bob.clone()));
 
@@ -179,7 +229,13 @@ fn test_transfer_from_without_approval_fails() {
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
     let carol = Address::generate(&env);
-    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(
+        &alice,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
     // Bob was never approved.
     client.transfer_from(&bob, &alice, &carol, &1);
 }
@@ -194,7 +250,13 @@ fn test_transfer_clears_approval() {
     let bob = Address::generate(&env);
     let carol = Address::generate(&env);
 
-    client.mint(&alice, &1, &String::from_str(&env, "ipfs://1"));
+    client.mint(
+        &alice,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
     client.approve(&1, &bob);
 
     // Direct transfer should clear the approval.
@@ -209,8 +271,20 @@ fn test_supply_cap_enforced() {
     let (client, _) = setup_with_cap(&env, 2);
 
     let owner = Address::generate(&env);
-    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1"));
-    client.mint(&owner, &2, &String::from_str(&env, "ipfs://2"));
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
+    client.mint(
+        &owner,
+        &2,
+        &String::from_str(&env, "ipfs://2"),
+        &None,
+        &None,
+    );
     assert_eq!(client.total_supply(), 2);
 }
 
@@ -222,8 +296,20 @@ fn test_supply_cap_exceeded_fails() {
     let (client, _) = setup_with_cap(&env, 1);
 
     let owner = Address::generate(&env);
-    client.mint(&owner, &1, &String::from_str(&env, "ipfs://1"));
-    client.mint(&owner, &2, &String::from_str(&env, "ipfs://2"));
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
+    client.mint(
+        &owner,
+        &2,
+        &String::from_str(&env, "ipfs://2"),
+        &None,
+        &None,
+    );
 }
 
 #[test]
@@ -235,4 +321,223 @@ fn test_metadata() {
     let meta = client.metadata();
     assert_eq!(meta.name, String::from_str(&env, "My Collection"));
     assert_eq!(meta.symbol, String::from_str(&env, "MYC"));
+}
+
+// ---------------------------------------------------------------------------
+// Royalty tests (#831)
+// ---------------------------------------------------------------------------
+
+/// No royalty configured → royalty_info returns None.
+#[test]
+fn test_royalty_info_none_when_not_configured() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
+
+    let info = client.royalty_info(&1, &10_000i128);
+    assert!(info.is_none());
+}
+
+/// Collection-level royalty is returned when no per-token override exists.
+#[test]
+fn test_royalty_info_collection_level() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let royalty_recipient = Address::generate(&env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(&env, &addr);
+
+    // 5 % collection royalty
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Royal"),
+        &String::from_str(&env, "ROY"),
+        &0,
+        &Some(500u32),
+        &Some(royalty_recipient.clone()),
+    );
+
+    let owner = Address::generate(&env);
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &None,
+        &None,
+    );
+
+    let info = client.royalty_info(&1, &10_000i128).unwrap();
+    assert_eq!(info.recipient, royalty_recipient);
+    assert_eq!(info.amount, 500i128); // 5 % of 10 000
+}
+
+/// Per-token royalty overrides the collection-level default.
+#[test]
+fn test_royalty_info_per_token_override() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let collection_recipient = Address::generate(&env);
+    let token_recipient = Address::generate(&env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(&env, &addr);
+
+    // 10 % collection royalty
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Override"),
+        &String::from_str(&env, "OVR"),
+        &0,
+        &Some(1_000u32),
+        &Some(collection_recipient.clone()),
+    );
+
+    let owner = Address::generate(&env);
+    // Mint token 1 with a 2.5 % per-token override
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &Some(250u32),
+        &Some(token_recipient.clone()),
+    );
+    // Mint token 2 with no per-token override → falls back to collection
+    client.mint(
+        &owner,
+        &2,
+        &String::from_str(&env, "ipfs://2"),
+        &None,
+        &None,
+    );
+
+    // Token 1: per-token recipient at 2.5 %
+    let info1 = client.royalty_info(&1, &10_000i128).unwrap();
+    assert_eq!(info1.recipient, token_recipient);
+    assert_eq!(info1.amount, 250i128);
+
+    // Token 2: collection recipient at 10 %
+    let info2 = client.royalty_info(&2, &10_000i128).unwrap();
+    assert_eq!(info2.recipient, collection_recipient);
+    assert_eq!(info2.amount, 1_000i128);
+}
+
+/// royalty_info returns None for a token with an explicit 0 bps per-token royalty
+/// even when collection royalty is set.
+#[test]
+fn test_royalty_info_per_token_zero_bps_returns_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let collection_recipient = Address::generate(&env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(&env, &addr);
+
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Z"),
+        &String::from_str(&env, "Z"),
+        &0,
+        &Some(500u32),
+        &Some(collection_recipient.clone()),
+    );
+
+    let owner = Address::generate(&env);
+    // Mint with an explicit 0-bps per-token override (royalty-free token)
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &Some(0u32),
+        &None,
+    );
+
+    let info = client.royalty_info(&1, &10_000i128);
+    assert!(info.is_none());
+}
+
+/// royalty_info on a non-existent token returns TokenNotFound.
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_royalty_info_token_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    // Token 99 was never minted.
+    client.royalty_info(&99, &1_000i128);
+}
+
+/// initialize rejects royalty_bps > 10 000.
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_initialize_invalid_royalty_bps_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(&env, &addr);
+
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Bad"),
+        &String::from_str(&env, "BAD"),
+        &0,
+        &Some(10_001u32),
+        &Some(recipient),
+    );
+}
+
+/// initialize rejects royalty_bps > 0 without a recipient.
+#[test]
+#[should_panic(expected = "Error(Contract, #11)")]
+fn test_initialize_royalty_missing_recipient_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let addr = env.register_contract(None, NftContract);
+    let client = NftContractClient::new(&env, &addr);
+
+    client.initialize(
+        &admin,
+        &String::from_str(&env, "Bad"),
+        &String::from_str(&env, "BAD"),
+        &0,
+        &Some(500u32),
+        &None, // missing recipient
+    );
+}
+
+/// mint rejects token_royalty_bps > 10 000.
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_mint_invalid_token_royalty_bps_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    client.mint(
+        &owner,
+        &1,
+        &String::from_str(&env, "ipfs://1"),
+        &Some(20_000u32),
+        &Some(recipient),
+    );
 }

--- a/scripts/monitor-auction.sh
+++ b/scripts/monitor-auction.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# monitor-auction.sh — display a human-readable auction status summary
+#
+# Usage:
+#   ./scripts/monitor-auction.sh [network] <CONTRACT_ID>
+#   ./scripts/monitor-auction.sh testnet CABC...
+#   ./scripts/monitor-auction.sh local CABC...
+#
+# Environment overrides:
+#   STELLAR_RPC_URL            Override the default RPC endpoint
+#   STELLAR_NETWORK_PASSPHRASE Override the default network passphrase
+#
+# What it shows:
+#   - Seller, token, start price, min increment, reserve price, extension window
+#   - Current highest bidder and bid
+#   - Deadline ledger and approximate time remaining
+#   - Settlement / cancelled status
+#   - WARNING banners for: overdue-but-unsettled, reserve not met, cancelled
+
+set -euo pipefail
+
+# ── color codes ──────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# ── argument parsing ─────────────────────────────────────────────────────────
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 [network] <CONTRACT_ID>" >&2
+  echo "  network: testnet (default) | mainnet | local" >&2
+  exit 1
+fi
+
+if [[ $# -eq 2 ]]; then
+  NETWORK="$1"
+  CONTRACT_ID="$2"
+else
+  NETWORK="testnet"
+  CONTRACT_ID="$1"
+fi
+
+case "$NETWORK" in
+  testnet)
+    RPC_URL="${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
+    ;;
+  mainnet)
+    RPC_URL="${STELLAR_RPC_URL:-https://soroban.stellar.org}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Public Global Stellar Network ; September 2015}"
+    ;;
+  local)
+    RPC_URL="${STELLAR_RPC_URL:-http://localhost:${LOCAL_RPC_PORT:-8000}}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Standalone Network ; February 2017}"
+    ;;
+  *)
+    echo "Unknown network: $NETWORK (use testnet|mainnet|local)" >&2
+    exit 1
+    ;;
+esac
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+STELLAR_ARGS=(
+  --id "$CONTRACT_ID"
+  --rpc-url "$RPC_URL"
+  --network-passphrase "$PASSPHRASE"
+  --network "$NETWORK"
+)
+
+invoke() {
+  stellar contract invoke "${STELLAR_ARGS[@]}" -- "$@" 2>/dev/null || echo "N/A"
+}
+
+# Strip surrounding quotes from stellar CLI output
+strip_quotes() {
+  echo "$1" | tr -d '"'
+}
+
+# Convert a raw ledger count (positive = remaining, negative = overdue) to a
+# human-readable string. Assumes ~5 seconds per ledger.
+ledgers_to_time() {
+  local ledgers="$1"
+  if [[ "$ledgers" == "N/A" ]]; then
+    echo "N/A"
+    return
+  fi
+  local abs_ledgers="${ledgers#-}"
+  local total_seconds=$(( abs_ledgers * 5 ))
+  local days=$(( total_seconds / 86400 ))
+  local hours=$(( (total_seconds % 86400) / 3600 ))
+  local minutes=$(( (total_seconds % 3600) / 60 ))
+
+  if [[ "$ledgers" -lt 0 ]]; then
+    echo "${days}d ${hours}h ${minutes}m ago (OVERDUE)"
+  elif [[ "$days" -gt 0 ]]; then
+    echo "${days}d ${hours}h ${minutes}m remaining"
+  elif [[ "$hours" -gt 0 ]]; then
+    echo "${hours}h ${minutes}m remaining"
+  else
+    echo "${minutes}m remaining"
+  fi
+}
+
+# Fetch the current ledger sequence from the RPC endpoint.
+get_current_ledger() {
+  local response
+  response=$(curl -sf --max-time 10 \
+    -X POST "$RPC_URL" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getLatestLedger","params":{}}' \
+    2>/dev/null || echo "")
+  if [[ -n "$response" ]]; then
+    echo "$response" | grep -o '"sequence":[0-9]*' | head -1 | cut -d':' -f2
+  else
+    echo "0"
+  fi
+}
+
+# ── fetch auction data ───────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}Auction Monitor — ${CYAN}${CONTRACT_ID}${RESET}"
+echo -e "Network: ${BOLD}${NETWORK}${RESET}  RPC: ${RPC_URL}"
+echo "────────────────────────────────────────────────────"
+
+# get_info returns a struct; parse the JSON-like output for each field.
+INFO_RAW=$(stellar contract invoke "${STELLAR_ARGS[@]}" -- get_info 2>/dev/null || echo "N/A")
+
+if [[ "$INFO_RAW" == "N/A" ]]; then
+  echo -e "${RED}Contract not initialized or unreachable.${RESET}"
+  echo "────────────────────────────────────────────────────"
+  echo ""
+  exit 0
+fi
+
+# Extract individual fields from the struct output.
+# The Soroban CLI serialises contract return values as JSON.
+parse_field() {
+  local field="$1"
+  local raw="$2"
+  echo "$raw" | grep -o "\"${field}\":[^,}]*" | head -1 | cut -d':' -f2- | tr -d '" '
+}
+
+parse_optional_field() {
+  local field="$1"
+  local raw="$2"
+  local val
+  val=$(echo "$raw" | grep -o "\"${field}\":[^,}]*" | head -1 | cut -d':' -f2- | tr -d ' ')
+  # Soroban encodes Option<T> as {"Some": value} or {"None": null}
+  if echo "$val" | grep -q '"None"'; then
+    echo "none"
+  else
+    echo "$val" | grep -o '"Some":[^}]*' | cut -d':' -f2- | tr -d '"{}' || echo "$val"
+  fi
+}
+
+SELLER=$(parse_field "seller" "$INFO_RAW")
+TOKEN=$(parse_field "token" "$INFO_RAW")
+START_PRICE=$(parse_field "start_price" "$INFO_RAW")
+MIN_INCREMENT=$(parse_field "min_increment" "$INFO_RAW")
+DEADLINE=$(parse_field "deadline" "$INFO_RAW")
+HIGHEST_BID=$(parse_field "highest_bid" "$INFO_RAW")
+SETTLED=$(parse_field "settled" "$INFO_RAW")
+RESERVE_PRICE=$(parse_optional_field "reserve_price" "$INFO_RAW")
+EXTENSION_WINDOW=$(parse_field "extension_window" "$INFO_RAW")
+
+# highest_bidder is Option<Address>
+HIGHEST_BIDDER=$(parse_optional_field "highest_bidder" "$INFO_RAW")
+if [[ "$HIGHEST_BIDDER" == "none" || -z "$HIGHEST_BIDDER" ]]; then
+  HIGHEST_BIDDER="(no bids yet)"
+fi
+
+# Determine cancelled state (not in get_info; try invoking a sentinel)
+CANCELLED_RAW=$(stellar contract invoke "${STELLAR_ARGS[@]}" -- end 2>&1 | grep -i "cancelled\|AuctionEnded" | head -1 || echo "")
+if [[ -n "$CANCELLED_RAW" ]]; then
+  # Distinguish between "auction ended (deadline)" and "cancelled"
+  if echo "$CANCELLED_RAW" | grep -qi "cancel"; then
+    IS_CANCELLED="true"
+  else
+    IS_CANCELLED="false"
+  fi
+else
+  IS_CANCELLED="false"
+fi
+
+# Compute remaining ledgers
+CURRENT_LEDGER=$(get_current_ledger)
+if [[ -n "$DEADLINE" && "$DEADLINE" != "N/A" && "$CURRENT_LEDGER" -gt 0 ]]; then
+  REMAINING=$(( DEADLINE - CURRENT_LEDGER ))
+else
+  REMAINING="N/A"
+fi
+TIME_DISPLAY=$(ledgers_to_time "$REMAINING")
+
+# ── status label ─────────────────────────────────────────────────────────────
+if [[ "$IS_CANCELLED" == "true" ]]; then
+  STATUS="${RED}Cancelled${RESET}"
+elif [[ "$SETTLED" == "true" ]]; then
+  STATUS="${GREEN}Settled${RESET}"
+elif [[ "$REMAINING" != "N/A" && "$REMAINING" -lt 0 ]]; then
+  STATUS="${YELLOW}Ended (awaiting settlement)${RESET}"
+else
+  STATUS="${CYAN}Active${RESET}"
+fi
+
+# ── print summary ─────────────────────────────────────────────────────────────
+echo -e "Status:            ${STATUS}"
+echo ""
+echo -e "Seller:            ${BOLD}${SELLER:-N/A}${RESET}"
+echo -e "Token:             ${BOLD}${TOKEN:-N/A}${RESET}"
+echo ""
+echo -e "Start price:       ${BOLD}${START_PRICE:-N/A}${RESET} (base units)"
+echo -e "Min increment:     ${BOLD}${MIN_INCREMENT:-N/A}${RESET} (base units)"
+
+if [[ "$RESERVE_PRICE" == "none" || -z "$RESERVE_PRICE" ]]; then
+  echo -e "Reserve price:     ${BOLD}none${RESET}"
+else
+  echo -e "Reserve price:     ${BOLD}${RESERVE_PRICE}${RESET} (base units)"
+fi
+
+if [[ "$EXTENSION_WINDOW" == "0" || -z "$EXTENSION_WINDOW" ]]; then
+  echo -e "Anti-snipe window: ${BOLD}disabled${RESET}"
+else
+  echo -e "Anti-snipe window: ${BOLD}${EXTENSION_WINDOW}${RESET} ledgers"
+fi
+
+echo ""
+echo -e "Highest bid:       ${BOLD}${HIGHEST_BID:-N/A}${RESET} (base units)"
+echo -e "Highest bidder:    ${BOLD}${HIGHEST_BIDDER}${RESET}"
+echo ""
+echo -e "Deadline:          ledger ${BOLD}${DEADLINE:-N/A}${RESET}"
+echo -e "Current ledger:    ${BOLD}${CURRENT_LEDGER}${RESET}"
+echo -e "Time remaining:    ${BOLD}${TIME_DISPLAY}${RESET}"
+
+# ── warning banners ───────────────────────────────────────────────────────────
+if [[ "$IS_CANCELLED" == "true" ]]; then
+  echo ""
+  echo -e "${RED}${BOLD}INFO: Auction was cancelled by the seller (no bids had been placed).${RESET}"
+elif [[ "$SETTLED" == "true" ]]; then
+  echo ""
+  echo -e "${GREEN}${BOLD}Auction has been settled. Winner: ${HIGHEST_BIDDER}${RESET}"
+  # Warn if reserve was not met (highest_bid < reserve_price at settlement)
+  if [[ "$RESERVE_PRICE" != "none" && -n "$RESERVE_PRICE" && "$HIGHEST_BID" != "N/A" ]]; then
+    if (( HIGHEST_BID < RESERVE_PRICE )); then
+      echo -e "${YELLOW}${BOLD}NOTE: Reserve price was not met. Highest bidder's funds were returned.${RESET}"
+    fi
+  fi
+elif [[ "$REMAINING" != "N/A" && "$REMAINING" -lt 0 ]]; then
+  echo ""
+  echo -e "${YELLOW}${BOLD}WARNING: Deadline has passed. Anyone may call \`end\` to settle the auction.${RESET}"
+  if [[ "$RESERVE_PRICE" != "none" && -n "$RESERVE_PRICE" && "$HIGHEST_BID" != "N/A" ]]; then
+    if (( HIGHEST_BID < RESERVE_PRICE )); then
+      echo -e "${RED}${BOLD}WARNING: Highest bid (${HIGHEST_BID}) is below reserve price (${RESERVE_PRICE}). Bidder will be refunded.${RESET}"
+    fi
+  fi
+fi
+
+echo "────────────────────────────────────────────────────"
+echo ""

--- a/tests/tests/integration.rs
+++ b/tests/tests/integration.rs
@@ -396,6 +396,8 @@ fn deploy_nft<'a>(env: &'a Env, admin: &Address) -> (NftContractClient<'a>, Addr
         &String::from_str(env, "Test NFT"),
         &String::from_str(env, "TNFT"),
         &10u32,
+        &None,
+        &None,
     );
     (client, addr)
 }
@@ -427,6 +429,8 @@ fn test_marketplace_full_lifecycle_with_royalty() {
         &seller,
         &token_id,
         &String::from_str(&env, "https://example.com/token/1"),
+        &None,
+        &None,
     );
     assert_eq!(nft.owner_of(token_id).unwrap(), seller);
 
@@ -495,6 +499,8 @@ fn test_marketplace_cancel_listing() {
         &seller,
         &token_id,
         &String::from_str(&env, "https://example.com/token/1"),
+        &None,
+        &None,
     );
     assert_eq!(nft.owner_of(token_id).unwrap(), seller);
 
@@ -753,4 +759,179 @@ fn test_lottery_ticket_cap_enforced() {
     // Third ticket must fail with TicketCapExceeded
     let result = lottery.try_buy_ticket(&buyer);
     assert!(result.is_err());
+}
+
+// ── #863: cross-contract integration test: marketplace + nft + token ─────────
+
+/// End-to-end flow: mint NFT → list on marketplace → purchase with token contract.
+///
+/// Verifies:
+/// - NFT ownership transfers from seller to buyer on purchase.
+/// - Token balances (buyer, seller, royalty recipient) are correct after the sale.
+/// - The listing is marked inactive after the purchase.
+/// - Royalty recipient receives the correct basis-point share.
+///
+/// Closes #863 – cross-contract integration test: marketplace + nft + token end-to-end.
+#[test]
+fn test_marketplace_nft_token_end_to_end() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let nft_admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let marketplace_admin = Address::generate(&env);
+    let royalty_recipient = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    // ── Deploy NFT contract ──────────────────────────────────────────────
+    let (nft, nft_addr) = deploy_nft(&env, &nft_admin);
+    let token_id = 42u32;
+    nft.mint(
+        &seller,
+        &token_id,
+        &String::from_str(&env, "https://example.com/nft/42"),
+        &None,
+        &None,
+    );
+    // Confirm initial ownership
+    assert_eq!(nft.owner_of(token_id).unwrap(), seller);
+
+    // ── Deploy payment token and fund buyer ──────────────────────────────
+    let (token, token_addr) = deploy_token(&env, &token_admin);
+    let price = 2_000i128;
+    let buyer_funds = 10_000i128;
+    token.mint(&buyer, &buyer_funds);
+    assert_eq!(token.balance(&buyer), buyer_funds);
+
+    // Seller and royalty recipient start with zero balance
+    assert_eq!(token.balance(&seller), 0);
+    assert_eq!(token.balance(&royalty_recipient), 0);
+
+    // ── Deploy and initialize marketplace (5 % royalty) ──────────────────
+    let (marketplace, marketplace_addr) = deploy_marketplace(&env);
+    let royalty_bps = 500u32; // 5 %
+    marketplace.initialize(
+        &marketplace_admin,
+        &token_addr,
+        &royalty_bps,
+        &royalty_recipient,
+    );
+
+    // ── Seller approves marketplace to transfer the NFT, then lists it ───
+    nft.approve(&token_id, &marketplace_addr);
+    let listing_id = marketplace.list(&seller, &nft_addr, &token_id, &price);
+
+    // Confirm listing is active
+    let listing = marketplace.get_listing(listing_id).unwrap();
+    assert_eq!(listing.seller, seller);
+    assert_eq!(listing.price, price);
+    assert!(listing.active);
+
+    // ── Buyer purchases the NFT ──────────────────────────────────────────
+    marketplace.buy(&buyer, &listing_id);
+
+    // ── Assert NFT ownership transferred ────────────────────────────────
+    assert_eq!(nft.owner_of(token_id).unwrap(), buyer);
+
+    // ── Assert final token balances ──────────────────────────────────────
+    let royalty_amount = (price * i128::from(royalty_bps)) / 10_000i128; // 100
+    let seller_amount = price - royalty_amount; // 1 900
+
+    assert_eq!(
+        token.balance(&buyer),
+        buyer_funds - price,
+        "buyer balance should decrease by full price"
+    );
+    assert_eq!(
+        token.balance(&seller),
+        seller_amount,
+        "seller receives price minus royalty"
+    );
+    assert_eq!(
+        token.balance(&royalty_recipient),
+        royalty_amount,
+        "royalty recipient receives royalty share"
+    );
+
+    // ── Listing is now inactive ──────────────────────────────────────────
+    let listing_after = marketplace.get_listing(listing_id).unwrap();
+    assert!(!listing_after.active);
+}
+
+/// Mint NFT with per-token royalty → list on marketplace → purchase.
+/// Verifies that the marketplace correctly surfaces royalty intent via
+/// royalty_info, even though the marketplace uses its own initialized
+/// royalty config. This test checks the NFT royalty_info view independently
+/// alongside the marketplace purchase to confirm both are consistent.
+///
+/// Closes #863, #831 – cross-contract royalty integration.
+#[test]
+fn test_marketplace_nft_token_with_per_token_royalty() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let nft_admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let marketplace_admin = Address::generate(&env);
+    let nft_royalty_recipient = Address::generate(&env);
+    let marketplace_royalty_recipient = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    // ── Deploy NFT contract with collection-level 2 % royalty ───────────
+    let nft_addr_raw = env.register_contract(None, NftContract);
+    let nft = NftContractClient::new(&env, &nft_addr_raw);
+    nft.initialize(
+        &nft_admin,
+        &String::from_str(&env, "Royalty NFT"),
+        &String::from_str(&env, "RNFT"),
+        &0u32,
+        &Some(200u32), // 2 % collection royalty
+        &Some(nft_royalty_recipient.clone()),
+    );
+
+    let token_id = 7u32;
+    let per_token_bps = 300u32; // 3 % per-token override
+    nft.mint(
+        &seller,
+        &token_id,
+        &String::from_str(&env, "ipfs://rnft/7"),
+        &Some(per_token_bps),
+        &Some(nft_royalty_recipient.clone()),
+    );
+
+    // Verify royalty_info returns the per-token override (3 % of 1 000 = 30)
+    let sale_price = 1_000i128;
+    let royalty = nft.royalty_info(&token_id, &sale_price).unwrap();
+    assert_eq!(royalty.recipient, nft_royalty_recipient);
+    assert_eq!(royalty.amount, 30i128); // 3 % of 1 000
+
+    // ── Deploy payment token and fund buyer ──────────────────────────────
+    let (token, token_addr) = deploy_token(&env, &token_admin);
+    token.mint(&buyer, &5_000i128);
+
+    // ── Deploy marketplace (1 % royalty to marketplace_royalty_recipient) ─
+    let (marketplace, marketplace_addr) = deploy_marketplace(&env);
+    marketplace.initialize(
+        &marketplace_admin,
+        &token_addr,
+        &100u32, // 1 %
+        &marketplace_royalty_recipient,
+    );
+
+    // ── List and buy ─────────────────────────────────────────────────────
+    nft.approve(&token_id, &marketplace_addr);
+    let listing_id = marketplace.list(&seller, &nft_addr_raw, &token_id, &sale_price);
+    marketplace.buy(&buyer, &listing_id);
+
+    // Buyer owns the NFT
+    assert_eq!(nft.owner_of(token_id).unwrap(), buyer);
+
+    // Marketplace distributes 1 % to its royalty recipient, 99 % to seller
+    let mkt_royalty = (sale_price * 100i128) / 10_000i128; // 10
+    let seller_amount = sale_price - mkt_royalty; // 990
+    assert_eq!(token.balance(&buyer), 5_000 - sale_price);
+    assert_eq!(token.balance(&seller), seller_amount);
+    assert_eq!(token.balance(&marketplace_royalty_recipient), mkt_royalty);
 }


### PR DESCRIPTION
Closes #831
Closes #863
Closes #864
Closes #865

## Changes

### #865 — `scripts/monitor-auction.sh`
- New script following the pattern of `monitor-escrow.sh` / `monitor-token.sh`
- Accepts `[network] <CONTRACT_ID>`; defaults to testnet
- Calls `get_info`, parses all `AuctionInfo` fields from JSON output
- Fetches current ledger via RPC `getLatestLedger` for time-remaining display
- Colour-coded status (Active / Ended / Settled / Cancelled) with warning banners

### #864 — Coverage reporting for newer contracts in CI summary
- Python script groups `lcov` data by `contracts/<name>` directory
- Per-contract table (lines covered/total, %, ✅/⚠️) emitted as step output
- PR comment step includes a **Per-contract coverage** breakdown section
- Artifact upload now includes `coverage_full.json` alongside `lcov.info`

### #863 — Cross-contract integration test: marketplace + nft + token
- `test_marketplace_nft_token_end_to_end`: mints NFT → lists on marketplace → buyer purchases; asserts NFT ownership, token balances, royalty split, listing inactive
- `test_marketplace_nft_token_with_per_token_royalty`: exercises `royalty_info` view with per-token override alongside a marketplace purchase

### #831 — NFT royalty enforcement (EIP-2981-style `royalty_info` view)
- `RoyaltyInfo` struct, collection-level and per-token royalty keys in storage
- `initialize`: optional `royalty_bps` / `royalty_recipient` params
- `mint`: optional `token_royalty_bps` / `token_royalty_recipient` params
- `royalty_info(token_id, sale_price) -> Option<RoyaltyInfo>` view with resolution order: per-token override → collection default → `None`
- `InvalidRoyalty` (10) and `RoyaltyRecipientMissing` (11) error codes
- All existing call sites updated; royalty-specific unit tests added