### PR TITLE
feat: add monitor scripts for lottery and marketplace, extend event c…

### DIFF
--- a/docs/event-catalogue.md
+++ b/docs/event-catalogue.md
@@ -109,7 +109,203 @@ env.events().publish((topic_1, topic_2, ...), data);
 
 ---
 
+## Airdrop Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Merkle Root Set | `root_set` | `(Symbol,)` → event name | `Bytes` → new Merkle root | `set_root()` called by admin |
+| Claimed | `claimed` | `(Symbol,)` → event name | `(Address, i128)` → recipient, amount | `claim()` called with valid Merkle proof |
+
+---
+
+## Auction Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Started | `started` | `(Symbol, Address)` → event name, seller | `(i128, u32)` → start price, deadline ledger | `start()` called |
+| Bid Placed | `bid_placed` | `(Symbol, Address)` → event name, bidder | `i128` → bid amount | `bid()` called |
+| Ended (winner) | `ended` | `(Symbol, Address)` → event name, winner | `i128` → winning amount | `end()` called, winner exists |
+| Ended (no bids) | `ended_no_bids` | `(Symbol,)` → event name | `()` | `end()` called with no bids |
+| Ended (reserve not met) | `ended_reserve_not_met` | `(Symbol, Address)` → event name, highest bidder | `(i128, i128)` → highest bid, reserve price | `end()` called, bid < reserve |
+| Bid Withdrawn | `withdrawn` | `(Symbol, Address)` → event name, bidder | `i128` → amount returned | `withdraw()` called by losing bidder |
+| Deadline Extended | `deadline_extended` | `(Symbol,)` → event name | `u32` → new deadline ledger | Anti-snipe window triggered during `bid()` |
+| Cancelled | `cancelled` | `(Symbol, Address)` → event name, seller | `()` | `cancel()` called by seller (no bids placed) |
+
+---
+
+## Ballot Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol,)` → event name | `Address` → admin | `initialize()` called |
+| Voter Registered | `voter_registered` | `(Symbol,)` → event name | `Address` → voter | `register_voter()` called |
+| Voter Deregistered | `voter_deregistered` | `(Symbol,)` → event name | `Address` → voter | `deregister_voter()` called |
+| Voted | `voted` | `(Symbol,)` → event name | `(Address, u32)` → voter, choice index | `vote()` called |
+| Tally Result (binary) | `tally_result` | `(Symbol,)` → event name | `(i128, i128)` → yes count, no count | `tally()` called |
+| Tally All Result (multi-choice) | `tally_all_result` | `(Symbol,)` → event name | `Vec<i128>` → per-choice vote counts | `tally_all()` called |
+
+---
+
+## Bonding Curve Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol,)` → event name | `(Address, Address)` → admin, token | `initialize()` called |
+| Bought | `bought` | `(Symbol,)` → event name | `(Address, i128, i128)` → buyer, tokens received, cost paid | `buy()` called |
+| Sold | `sold` | `(Symbol,)` → event name | `(Address, i128, i128)` → seller, tokens sold, proceeds received | `sell()` called |
+
+---
+
+## Crowdfund Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol, Address)` → event name, creator | `(i128, u32)` → goal amount, deadline ledger | `initialize()` called |
+| Pledged | `pledged` | `(Symbol, Address)` → event name, pledger | `(i128, i128)` → amount pledged, new running total | `pledge()` called |
+| Withdrawn | `withdrawn` | `(Symbol, Address)` → event name, pledger | `i128` → amount withdrawn | `withdraw()` called before deadline |
+| Claimed | `claimed` | `(Symbol, Address)` → event name, creator | `i128` → total amount claimed | `claim()` called after goal met |
+| Refunded | `refunded` | `(Symbol, Address)` → event name, pledger | `i128` → amount refunded | `refund()` called after deadline, goal not met |
+| Deadline Extended | `deadline_extended` | `(Symbol, Address)` → event name, creator | `u32` → new deadline ledger | `extend_deadline()` called by creator |
+
+---
+
+## Lottery Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol, Address)` → event name, admin | `i128` → ticket price | `initialize()` called |
+| Ticket Purchased | `ticket_purchased` | `(Symbol, Address)` → event name, buyer | `()` | `buy_ticket()` called |
+| Committed | `committed` | `(Symbol, Address)` → event name, admin | `()` | `commit()` called with hash and reveal deadline |
+| Winner Drawn | `winner_drawn` | `(Symbol, Address)` → event name, winner | `i128` → prize amount | Emitted once per winner during `draw()` |
+| Refund Claimed | `refund_claimed` | `(Symbol, Address)` → event name, buyer | `i128` → refund amount | `claim_refund()` called after reveal deadline passed |
+
+---
+
+## Marketplace Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Listed | `listed` | `(Symbol, u64)` → event name, listing ID | `(Address, i128)` → seller, price | `list()` or `list_with_expiry()` called |
+| Sold | `sold` | `(Symbol, u64)` → event name, listing ID | `(Address, i128)` → buyer, price | `buy()` called |
+| Cancelled | `cancel` | `(Symbol, u64)` → event name, listing ID | `Address` → seller | `cancel()` called by seller |
+| Swept | `swept` | `(Symbol, u64)` → event name, listing ID | `Address` → seller | `sweep_expired()` called after listing expiry |
+| Offer Made | `offered` | `(Symbol, u64)` → event name, listing ID | `(Address, i128)` → buyer, offer amount | `make_offer()` called |
+| Offer Accepted | `offracc` | `(Symbol, u64)` → event name, listing ID | `(Address, i128)` → buyer, accepted amount | `accept_offer()` called by seller |
+| Offer Cancelled | `offrcncl` | `(Symbol, u64)` → event name, listing ID | `Address` → buyer | `cancel_offer()` called by buyer |
+
+> **Note:** The `cancel`, `offracc`, and `offrcncl` symbols are abbreviated to fit Soroban's 9-byte `symbol_short!` limit.
+
+---
+
+## Oracle Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol, Address)` → event name, admin | `u32` → staleness threshold (ledgers) | `initialize()` called |
+| Price Updated | `price_updated` | `(Symbol, Address)` → event name, admin | `(i128, u32)` → price, ledger sequence | `update_price()` called by admin |
+| Price Submitted | `price_submitted` | `(Symbol, Address)` → event name, publisher | `(i128, u64)` → price, timestamp | `submit_price()` called by authorized publisher |
+
+---
+
+## Subscription Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol, Address)` → event name, provider | `Address` → payment token | `initialize()` called |
+| Plan Registered | `plan_registered` | `(Symbol, Symbol)` → event name, plan ID | `(i128, u32)` → charge amount, interval in ledgers | `register_plan()` called by provider |
+| Plan Updated | `plan_updated` | `(Symbol, Symbol)` → event name, plan ID | `bool` → new active status | `update_plan()` called by provider |
+| Subscribed | `subscribed` | `(Symbol, Address)` → event name, subscriber | `(Symbol, i128, u32)` → plan ID, amount, interval ledgers | `subscribe()` called |
+| Charged | `charged` | `(Symbol, Address, Address)` → event name, subscriber, provider | `i128` → amount charged | `charge()` called by provider |
+| Cancelled | `cancelled` | `(Symbol, Address)` → event name, subscriber | `()` | `cancel()` called by subscriber |
+| Trial Completed | `trial_completed` | `(Symbol, Address)` → event name, subscriber | `()` | `complete_trial()` called after trial period ends |
+
+---
+
+## Swap Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Proposed | `proposed` | `(Symbol, Address)` → event name, party A | `(u32, Address, i128, Address, i128, u32)` → swap ID, token A, amount A, token B, amount B, expires-at ledger | `propose()` called by party A |
+| Accepted | `accepted` | `(Symbol, Address)` → event name, party B | `u32` → swap ID | `accept()` called by party B |
+| Cancelled | `cancelled` | `(Symbol,)` → event name | `u32` → swap ID | `cancel()` called (by party A or after expiry) |
+
+---
+
+## Timelock Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol, Address, Address)` → event name, admin, beneficiary | `(u32, i128)` → release ledger, amount | `initialize()` called |
+| Released | `released` | `(Symbol, Address)` → event name, beneficiary | `i128` → amount released | `release()` called after release ledger |
+| Cancelled | `cancelled` | `(Symbol, Address)` → event name, admin | `i128` → amount returned to admin | `cancel()` called by admin before release ledger |
+
+---
+
+## Vesting Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol, Address)` → event name, beneficiary | `(i128, u32, u32)` → amount, cliff ledger, end ledger | `initialize()` called |
+| Claimed | `claimed` | `(Symbol, Address)` → event name, beneficiary | `i128` → amount claimed | `claim()` called |
+| Revoked | `revoked` | `(Symbol, Address)` → event name, beneficiary | `(Address, i128)` → admin, amount returned to admin | `revoke()` called by admin |
+| Admin Released | `admin_released` | `(Symbol, Address)` → event name, admin | `i128` → amount released to admin | `admin_release()` called after vesting end |
+
+---
+
+## Wrapped Token Contract
+
+| Event | Symbol | Topics | Data Type | When Fired |
+|-------|--------|--------|-----------|-----------|
+| Initialized | `initialized` | `(Symbol,)` → event name | `(Address, Address)` → admin, underlying token | `initialize()` called |
+| Wrapped | `wrapped` | `(Symbol,)` → event name | `(Address, i128, i128)` → user, amount wrapped, new total supply | `wrap()` called |
+| Unwrapped | `unwrapped` | `(Symbol,)` → event name | `(Address, i128, i128)` → user, amount unwrapped, new total supply | `unwrap()` called |
+| Paused | `paused` | `(Symbol, Address)` → event name, admin | `()` | `pause()` called (pausable feature only) |
+| Unpaused | `unpaused` | `(Symbol, Address)` → event name, admin | `()` | `unpause()` called (pausable feature only) |
+
+---
+
 ## Event Publishing Patterns
+
+### Event Schema Versioning
+
+Off-chain indexers must handle events whose shape may change between contract upgrades. The convention used across this kit is:
+
+**Version tag in the first topic**
+
+The first topic is always an event symbol. A `v` suffix signals the schema version:
+
+```
+(Symbol, ...)   →  topic[0] = "transfer"    (version 1, implied)
+(Symbol, ...)   →  topic[0] = "transfer_v2" (version 2, explicit)
+```
+
+When a breaking change is made to an event's topic list or data type, a new symbol is introduced with an incremented suffix. The old symbol is kept emitting from the old code path for at least one major release, giving indexers time to migrate.
+
+**Recommended indexer pattern**
+
+```javascript
+function handleEvent(event) {
+  const sym = event.topic[0];
+  if (sym === "transfer" || sym === "transfer_v1") {
+    // original shape: data = i128
+    handleTransferV1(event);
+  } else if (sym === "transfer_v2") {
+    // new shape: data = { amount: i128, memo: String }
+    handleTransferV2(event);
+  }
+  // unknown future versions: log and skip, do not throw
+}
+```
+
+**Rules**
+
+1. Non-breaking additions (e.g. adding an optional field to a tuple) do not require a version bump; document them in the changelog.
+2. Any change to the number or type of **topics** is always breaking and requires a new symbol.
+3. Any change to the **data** type that is not backward-compatible (e.g. `i128` → `(i128, Address)`) requires a new symbol.
+4. Deprecated symbols must be documented in this catalogue with a `**(deprecated as of vX.Y)**` note.
+5. The `version` field is carried in the symbol name, not in the data payload, to remain filterable via topic queries.
+
+---
 
 ### Indexing Strategy
 
@@ -172,6 +368,18 @@ This catalogue is generated from the event emission calls in each contract's `sr
 - Staking: `contracts/staking/src/events.rs`
 - Multisig: `contracts/multisig/src/events.rs`
 - DAO: `contracts/dao/src/events.rs`
+- Airdrop: `contracts/airdrop/src/events.rs`
+- Auction: `contracts/auction/src/events.rs`
+- Ballot: `contracts/ballot/src/events.rs`
+- Bonding Curve: `contracts/bonding-curve/src/events.rs`
+- Crowdfund: `contracts/crowdfund/src/events.rs`
+- Lottery: `contracts/lottery/src/events.rs`
+- Marketplace: `contracts/marketplace/src/events.rs`
+- Oracle: `contracts/oracle/src/events.rs`
+- Subscription: `contracts/subscription/src/events.rs`
+- Swap: `contracts/swap/src/events.rs`
+- Timelock: `contracts/timelock/src/events.rs`
+- Wrapped Token: `contracts/wrapped-token/src/events.rs`
 
 To keep this catalogue in sync, verify against the source before each release. A CI lint check validates that event names and topic signatures match the published code.
 

--- a/scripts/monitor-lottery.sh
+++ b/scripts/monitor-lottery.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# monitor-lottery.sh — display a human-readable lottery status summary
+#
+# Usage:
+#   ./scripts/monitor-lottery.sh [network] <CONTRACT_ID>
+#   ./scripts/monitor-lottery.sh testnet CABC...
+#   ./scripts/monitor-lottery.sh local CABC...
+#
+# Environment overrides:
+#   STELLAR_RPC_URL            Override the default RPC endpoint
+#   STELLAR_NETWORK_PASSPHRASE Override the default network passphrase
+#
+# What it shows:
+#   - Admin, token, ticket price
+#   - Lottery state (Open / Committed / Drawn)
+#   - Participant count
+#   - Commit reveal deadline and approximate time remaining (Committed state)
+#   - Winner(s) with prize amounts (Drawn state)
+#   - WARNING banners for: reveal deadline overdue without draw (refunds available)
+
+set -euo pipefail
+
+# ── color codes ──────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# ── argument parsing ─────────────────────────────────────────────────────────
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 [network] <CONTRACT_ID>" >&2
+  echo "  network: testnet (default) | mainnet | local" >&2
+  exit 1
+fi
+
+if [[ $# -eq 2 ]]; then
+  NETWORK="$1"
+  CONTRACT_ID="$2"
+else
+  NETWORK="testnet"
+  CONTRACT_ID="$1"
+fi
+
+case "$NETWORK" in
+  testnet)
+    RPC_URL="${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
+    ;;
+  mainnet)
+    RPC_URL="${STELLAR_RPC_URL:-https://soroban.stellar.org}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Public Global Stellar Network ; September 2015}"
+    ;;
+  local)
+    RPC_URL="${STELLAR_RPC_URL:-http://localhost:${LOCAL_RPC_PORT:-8000}}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Standalone Network ; February 2017}"
+    ;;
+  *)
+    echo "Unknown network: $NETWORK (use testnet|mainnet|local)" >&2
+    exit 1
+    ;;
+esac
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+STELLAR_ARGS=(
+  --id "$CONTRACT_ID"
+  --rpc-url "$RPC_URL"
+  --network-passphrase "$PASSPHRASE"
+  --network "$NETWORK"
+)
+
+invoke() {
+  stellar contract invoke "${STELLAR_ARGS[@]}" -- "$@" 2>/dev/null || echo "N/A"
+}
+
+# Strip surrounding quotes from stellar CLI output
+strip_quotes() {
+  echo "$1" | tr -d '"'
+}
+
+# Convert remaining ledgers to approximate human-readable time (5 s per ledger)
+ledgers_to_time() {
+  local ledgers="$1"
+  if [[ "$ledgers" == "N/A" ]]; then
+    echo "N/A"
+    return
+  fi
+  local abs_ledgers="${ledgers#-}"
+  local total_seconds=$(( abs_ledgers * 5 ))
+  local days=$(( total_seconds / 86400 ))
+  local hours=$(( (total_seconds % 86400) / 3600 ))
+  local minutes=$(( (total_seconds % 3600) / 60 ))
+
+  if [[ "$ledgers" -lt 0 ]]; then
+    echo "${days}d ${hours}h ${minutes}m ago (OVERDUE)"
+  elif [[ "$days" -gt 0 ]]; then
+    echo "${days}d ${hours}h ${minutes}m remaining"
+  elif [[ "$hours" -gt 0 ]]; then
+    echo "${hours}h ${minutes}m remaining"
+  else
+    echo "${minutes}m remaining"
+  fi
+}
+
+# Fetch the current ledger sequence from the RPC endpoint.
+get_current_ledger() {
+  local response
+  response=$(curl -sf --max-time 10 \
+    -X POST "$RPC_URL" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getLatestLedger","params":{}}' \
+    2>/dev/null || echo "")
+  if [[ -n "$response" ]]; then
+    echo "$response" | grep -o '"sequence":[0-9]*' | head -1 | cut -d':' -f2
+  else
+    echo "0"
+  fi
+}
+
+# Parse a JSON field from a struct output string.
+parse_field() {
+  local field="$1"
+  local raw="$2"
+  echo "$raw" | grep -o "\"${field}\":[^,}]*" | head -1 | cut -d':' -f2- | tr -d '" '
+}
+
+# Map raw state string to a colored display label.
+state_display() {
+  local raw
+  raw=$(strip_quotes "$1")
+  case "$raw" in
+    Open)       echo "${CYAN}Open (accepting tickets)${RESET}" ;;
+    Committed)  echo "${YELLOW}Committed (awaiting draw)${RESET}" ;;
+    Drawn)      echo "${GREEN}Drawn (complete)${RESET}" ;;
+    N/A)        echo "${RED}Not initialized${RESET}" ;;
+    *)          echo "$raw" ;;
+  esac
+}
+
+# ── fetch lottery data ───────────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}Lottery Monitor — ${CYAN}${CONTRACT_ID}${RESET}"
+echo -e "Network: ${BOLD}${NETWORK}${RESET}  RPC: ${RPC_URL}"
+echo "────────────────────────────────────────────────────"
+
+INFO_RAW=$(stellar contract invoke "${STELLAR_ARGS[@]}" -- get_info 2>/dev/null || echo "N/A")
+
+if [[ "$INFO_RAW" == "N/A" ]]; then
+  echo -e "${RED}Contract not initialized or unreachable.${RESET}"
+  echo "────────────────────────────────────────────────────"
+  echo ""
+  exit 0
+fi
+
+ADMIN=$(parse_field "admin" "$INFO_RAW")
+TOKEN=$(parse_field "token" "$INFO_RAW")
+TICKET_PRICE=$(parse_field "ticket_price" "$INFO_RAW")
+STATE_RAW=$(parse_field "state" "$INFO_RAW")
+
+# Participant count: the participants field is an array; count commas+1 as a proxy,
+# or fall back to 0 if empty.
+PARTICIPANTS_SEGMENT=$(echo "$INFO_RAW" | grep -o '"participants":\[[^]]*\]' | head -1)
+if echo "$PARTICIPANTS_SEGMENT" | grep -q '"'; then
+  PARTICIPANT_COUNT=$(echo "$PARTICIPANTS_SEGMENT" | grep -o '"G[^"]*"' | wc -l | tr -d ' ')
+else
+  PARTICIPANT_COUNT=0
+fi
+
+STATE_DISPLAY=$(state_display "$STATE_RAW")
+CURRENT_LEDGER=$(get_current_ledger)
+
+# ── print core summary ────────────────────────────────────────────────────────
+echo -e "State:             ${STATE_DISPLAY}"
+echo ""
+echo -e "Admin:             ${BOLD}${ADMIN:-N/A}${RESET}"
+echo -e "Token:             ${BOLD}${TOKEN:-N/A}${RESET}"
+echo -e "Ticket price:      ${BOLD}${TICKET_PRICE:-N/A}${RESET} (base units)"
+echo -e "Participants:      ${BOLD}${PARTICIPANT_COUNT}${RESET} ticket(s) sold"
+echo -e "Current ledger:    ${BOLD}${CURRENT_LEDGER}${RESET}"
+
+# ── committed-state: show reveal deadline ────────────────────────────────────
+STATE_CLEAN=$(strip_quotes "$STATE_RAW")
+if [[ "$STATE_CLEAN" == "Committed" ]]; then
+  echo ""
+  REVEAL_DEADLINE=$(invoke get_reveal_deadline 2>/dev/null || echo "N/A")
+  REVEAL_DEADLINE=$(strip_quotes "$REVEAL_DEADLINE")
+  if [[ "$REVEAL_DEADLINE" != "N/A" && "$CURRENT_LEDGER" -gt 0 ]]; then
+    REMAINING=$(( REVEAL_DEADLINE - CURRENT_LEDGER ))
+  else
+    REMAINING="N/A"
+  fi
+  TIME_DISPLAY=$(ledgers_to_time "${REMAINING}")
+  echo -e "Reveal deadline:   ledger ${BOLD}${REVEAL_DEADLINE}${RESET}"
+  echo -e "Time to reveal:    ${BOLD}${TIME_DISPLAY}${RESET}"
+
+  if [[ "$REMAINING" != "N/A" && "$REMAINING" -lt 0 ]]; then
+    echo ""
+    echo -e "${RED}${BOLD}WARNING: Reveal deadline has passed without a draw.${RESET}"
+    echo -e "${YELLOW}Ticket buyers may now call \`claim_refund\` to recover their ticket price.${RESET}"
+  fi
+fi
+
+# ── drawn-state: show winner(s) ───────────────────────────────────────────────
+if [[ "$STATE_CLEAN" == "Drawn" ]]; then
+  echo ""
+  WINNERS_RAW=$(stellar contract invoke "${STELLAR_ARGS[@]}" -- get_winners 2>/dev/null || echo "N/A")
+  if [[ "$WINNERS_RAW" != "N/A" ]]; then
+    echo -e "${GREEN}${BOLD}Winners:${RESET}"
+    # Each address is a quoted string inside the array; print one per line.
+    echo "$WINNERS_RAW" | grep -o '"G[^"]*"' | tr -d '"' | nl -w2 -s'. ' | while IFS= read -r line; do
+      echo -e "  ${BOLD}${line}${RESET}"
+    done
+  else
+    WINNER_RAW=$(invoke get_winner)
+    WINNER=$(strip_quotes "$WINNER_RAW")
+    echo -e "${GREEN}${BOLD}Winner: ${WINNER}${RESET}"
+  fi
+fi
+
+# ── open-state reminder ───────────────────────────────────────────────────────
+if [[ "$STATE_CLEAN" == "Open" ]]; then
+  echo ""
+  echo -e "${CYAN}Lottery is open. Players may call \`buy_ticket\` to participate.${RESET}"
+fi
+
+echo "────────────────────────────────────────────────────"
+echo ""

--- a/scripts/monitor-marketplace.sh
+++ b/scripts/monitor-marketplace.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# monitor-marketplace.sh — display a human-readable marketplace status summary
+#
+# Usage:
+#   ./scripts/monitor-marketplace.sh [network] <CONTRACT_ID>
+#   ./scripts/monitor-marketplace.sh testnet CABC...
+#   ./scripts/monitor-marketplace.sh local CABC...
+#
+# Environment overrides:
+#   STELLAR_RPC_URL            Override the default RPC endpoint
+#   STELLAR_NETWORK_PASSPHRASE Override the default network passphrase
+#   MARKETPLACE_PAGE_SIZE      Number of active listings to fetch per page (default: 10)
+#
+# What it shows:
+#   - Payment token, royalty BPS, royalty recipient
+#   - Paginated list of active listings (seller, NFT contract, token ID, price, expiry)
+#   - WARNING banners for: listings past their expiry that have not yet been swept
+
+set -euo pipefail
+
+# ── color codes ──────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+# ── argument parsing ─────────────────────────────────────────────────────────
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 [network] <CONTRACT_ID>" >&2
+  echo "  network: testnet (default) | mainnet | local" >&2
+  exit 1
+fi
+
+if [[ $# -eq 2 ]]; then
+  NETWORK="$1"
+  CONTRACT_ID="$2"
+else
+  NETWORK="testnet"
+  CONTRACT_ID="$1"
+fi
+
+case "$NETWORK" in
+  testnet)
+    RPC_URL="${STELLAR_RPC_URL:-https://soroban-testnet.stellar.org}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Test SDF Network ; September 2015}"
+    ;;
+  mainnet)
+    RPC_URL="${STELLAR_RPC_URL:-https://soroban.stellar.org}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Public Global Stellar Network ; September 2015}"
+    ;;
+  local)
+    RPC_URL="${STELLAR_RPC_URL:-http://localhost:${LOCAL_RPC_PORT:-8000}}"
+    PASSPHRASE="${STELLAR_NETWORK_PASSPHRASE:-Standalone Network ; February 2017}"
+    ;;
+  *)
+    echo "Unknown network: $NETWORK (use testnet|mainnet|local)" >&2
+    exit 1
+    ;;
+esac
+
+PAGE_SIZE="${MARKETPLACE_PAGE_SIZE:-10}"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+STELLAR_ARGS=(
+  --id "$CONTRACT_ID"
+  --rpc-url "$RPC_URL"
+  --network-passphrase "$PASSPHRASE"
+  --network "$NETWORK"
+)
+
+invoke() {
+  stellar contract invoke "${STELLAR_ARGS[@]}" -- "$@" 2>/dev/null || echo "N/A"
+}
+
+# Strip surrounding quotes from stellar CLI output
+strip_quotes() {
+  echo "$1" | tr -d '"'
+}
+
+# Parse a single JSON field value from a struct string.
+parse_field() {
+  local field="$1"
+  local raw="$2"
+  echo "$raw" | grep -o "\"${field}\":[^,}]*" | head -1 | cut -d':' -f2- | tr -d '" '
+}
+
+# Parse an optional JSON field (handles {"Some":value} / {"None":null} encoding).
+parse_optional_field() {
+  local field="$1"
+  local raw="$2"
+  local val
+  val=$(echo "$raw" | grep -o "\"${field}\":[^,}]*" | head -1 | cut -d':' -f2- | tr -d ' ')
+  if echo "$val" | grep -q '"None"'; then
+    echo "none"
+  else
+    echo "$val" | grep -o '"Some":[^}]*' | cut -d':' -f2- | tr -d '"{}' || echo "$val"
+  fi
+}
+
+# Fetch the current ledger sequence from the RPC endpoint.
+get_current_ledger() {
+  local response
+  response=$(curl -sf --max-time 10 \
+    -X POST "$RPC_URL" \
+    -H 'Content-Type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"getLatestLedger","params":{}}' \
+    2>/dev/null || echo "")
+  if [[ -n "$response" ]]; then
+    echo "$response" | grep -o '"sequence":[0-9]*' | head -1 | cut -d':' -f2
+  else
+    echo "0"
+  fi
+}
+
+# ── fetch marketplace config ──────────────────────────────────────────────────
+echo ""
+echo -e "${BOLD}Marketplace Monitor — ${CYAN}${CONTRACT_ID}${RESET}"
+echo -e "Network: ${BOLD}${NETWORK}${RESET}  RPC: ${RPC_URL}"
+echo "────────────────────────────────────────────────────"
+
+# The marketplace exposes config via storage; read key fields individually.
+PAYMENT_TOKEN=$(invoke get_payment_token 2>/dev/null || echo "N/A")
+ROYALTY_BPS=$(invoke get_royalty_bps 2>/dev/null || echo "N/A")
+ROYALTY_RECIPIENT=$(invoke get_royalty_recipient 2>/dev/null || echo "N/A")
+
+PAYMENT_TOKEN=$(strip_quotes "$PAYMENT_TOKEN")
+ROYALTY_BPS=$(strip_quotes "$ROYALTY_BPS")
+ROYALTY_RECIPIENT=$(strip_quotes "$ROYALTY_RECIPIENT")
+
+if [[ "$PAYMENT_TOKEN" == "N/A" && "$ROYALTY_BPS" == "N/A" ]]; then
+  echo -e "${RED}Contract not initialized or unreachable.${RESET}"
+  echo "────────────────────────────────────────────────────"
+  echo ""
+  exit 0
+fi
+
+# Convert BPS to a percentage string for display.
+royalty_pct() {
+  local bps="$1"
+  if [[ "$bps" == "N/A" || -z "$bps" ]]; then
+    echo "N/A"
+    return
+  fi
+  # Integer arithmetic: BPS / 100 = whole %, BPS % 100 = fractional
+  local whole=$(( bps / 100 ))
+  local frac=$(( bps % 100 ))
+  if [[ "$frac" -eq 0 ]]; then
+    echo "${whole}%"
+  else
+    printf "%d.%02d%%" "$whole" "$frac"
+  fi
+}
+
+ROYALTY_PCT=$(royalty_pct "$ROYALTY_BPS")
+CURRENT_LEDGER=$(get_current_ledger)
+
+echo -e "Payment token:     ${BOLD}${PAYMENT_TOKEN}${RESET}"
+echo -e "Royalty:           ${BOLD}${ROYALTY_PCT}${RESET} (${ROYALTY_BPS} bps)"
+echo -e "Royalty recipient: ${BOLD}${ROYALTY_RECIPIENT}${RESET}"
+echo -e "Current ledger:    ${BOLD}${CURRENT_LEDGER}${RESET}"
+echo ""
+
+# ── fetch active listings ─────────────────────────────────────────────────────
+echo -e "${BOLD}Active Listings${RESET}"
+echo "────────────────────────────────────────────────────"
+
+CURSOR=0
+TOTAL_ACTIVE=0
+EXPIRED_COUNT=0
+
+while true; do
+  PAGE_RAW=$(stellar contract invoke "${STELLAR_ARGS[@]}" \
+    -- get_active_listings \
+    --cursor "$CURSOR" \
+    --limit "$PAGE_SIZE" \
+    2>/dev/null || echo "N/A")
+
+  if [[ "$PAGE_RAW" == "N/A" || -z "$PAGE_RAW" ]]; then
+    break
+  fi
+
+  # Extract each listing entry block; entries are objects inside the "listings" array.
+  # We iterate by splitting on "},{"  after stripping the outer wrapper.
+  LISTINGS_SEGMENT=$(echo "$PAGE_RAW" | grep -o '"listings":\[.*\]' | head -1)
+
+  if [[ -z "$LISTINGS_SEGMENT" ]] || echo "$LISTINGS_SEGMENT" | grep -q '"listings":\[\]'; then
+    break
+  fi
+
+  # Parse individual entries. Each entry has "id" and "listing" sub-object.
+  # Use python if available for robust JSON parsing; otherwise fall back to grep.
+  if command -v python3 &>/dev/null; then
+    ENTRIES=$(python3 - "$PAGE_RAW" <<'PYEOF'
+import sys, json, re
+
+raw = sys.argv[1]
+try:
+    data = json.loads(raw)
+except Exception:
+    # Try to find the JSON object inside the raw output
+    m = re.search(r'\{.*\}', raw, re.S)
+    if m:
+        data = json.loads(m.group(0))
+    else:
+        sys.exit(0)
+
+listings = data.get("listings", [])
+for entry in listings:
+    lid = entry.get("id", "?")
+    lst = entry.get("listing", {})
+    seller = lst.get("seller", "N/A")
+    nft = lst.get("nft_contract", "N/A")
+    token_id = lst.get("token_id", "N/A")
+    price = lst.get("price", "N/A")
+    expires = lst.get("expires_at")
+    active = lst.get("active", True)
+    exp_str = str(expires) if expires is not None else "none"
+    print(f"{lid}|{seller}|{nft}|{token_id}|{price}|{exp_str}|{active}")
+PYEOF
+    )
+    while IFS='|' read -r LID SELLER NFT_CONTRACT TOKEN_ID PRICE EXPIRES ACTIVE; do
+      [[ -z "$LID" ]] && continue
+      TOTAL_ACTIVE=$(( TOTAL_ACTIVE + 1 ))
+      # Determine expiry status
+      EXPIRY_DISPLAY="none"
+      EXPIRY_WARNING=""
+      if [[ "$EXPIRES" != "none" && "$EXPIRES" != "null" && -n "$EXPIRES" ]]; then
+        EXPIRY_DISPLAY="ledger ${EXPIRES}"
+        if [[ "$CURRENT_LEDGER" -gt 0 && "$EXPIRES" -lt "$CURRENT_LEDGER" ]]; then
+          EXPIRY_DISPLAY="${EXPIRES} ${RED}(EXPIRED)${RESET}"
+          EXPIRY_WARNING=1
+          EXPIRED_COUNT=$(( EXPIRED_COUNT + 1 ))
+        fi
+      fi
+      printf "  ${BOLD}#%-6s${RESET} Seller: %-46s Price: %s\n" "$LID" "$SELLER" "$PRICE"
+      printf "          NFT: %-46s Token ID: %s\n" "$NFT_CONTRACT" "$TOKEN_ID"
+      printf "          Expiry: %b\n" "$EXPIRY_DISPLAY"
+      echo ""
+    done <<< "$ENTRIES"
+  else
+    # Fallback: simple grep-based parsing — print raw JSON entries
+    echo "$LISTINGS_SEGMENT" | grep -o '"id":[0-9]*' | cut -d':' -f2 | while read -r LID; do
+      TOTAL_ACTIVE=$(( TOTAL_ACTIVE + 1 ))
+      echo -e "  Listing ${BOLD}#${LID}${RESET}"
+    done
+  fi
+
+  # Advance cursor using next_cursor field; stop if null/absent.
+  NEXT_CURSOR=$(echo "$PAGE_RAW" | grep -o '"next_cursor":[^,}]*' | head -1 | cut -d':' -f2 | tr -d ' "')
+  if [[ -z "$NEXT_CURSOR" || "$NEXT_CURSOR" == "null" ]]; then
+    break
+  fi
+  CURSOR="$NEXT_CURSOR"
+done
+
+if [[ "$TOTAL_ACTIVE" -eq 0 ]]; then
+  echo -e "  ${CYAN}No active listings found.${RESET}"
+  echo ""
+fi
+
+echo "────────────────────────────────────────────────────"
+echo -e "Total active listings: ${BOLD}${TOTAL_ACTIVE}${RESET}"
+
+# ── warning banners ───────────────────────────────────────────────────────────
+if [[ "$EXPIRED_COUNT" -gt 0 ]]; then
+  echo ""
+  echo -e "${YELLOW}${BOLD}WARNING: ${EXPIRED_COUNT} listing(s) past their expiry.${RESET}"
+  echo -e "${YELLOW}Sellers may call \`sweep_expired\` to reclaim those listings.${RESET}"
+fi
+
+echo "────────────────────────────────────────────────────"
+echo ""


### PR DESCRIPTION
## Summary

### #866 — Add `scripts/monitor-lottery.sh`
Monitoring script for the lottery contract following existing `monitor-*.sh` conventions.
Shows state (Open/Committed/Drawn), participant count, reveal deadline with countdown,
winner list after draw, and a warning banner when the reveal deadline passes without a draw.

### #867 — Add `scripts/monitor-marketplace.sh`
Monitoring script for the marketplace contract. Shows payment token, royalty config,
and a paginated table of active listings with expiry status. Warns when listings have
passed their expiry but haven't been swept yet.

### #868 — Extend `docs/event-catalogue.md` for 13 newer contracts
Adds complete topic/data schema tables for airdrop, auction, ballot, bonding-curve,
crowdfund, lottery, marketplace, oracle, subscription, swap, timelock, vesting,
and wrapped-token. Updates the source reference list to cover all 18 contracts.

### #869 — Add event schema versioning convention
Adds an Event Schema Versioning section to `docs/event-catalogue.md` with a `v`-suffix
symbol convention, a JavaScript indexer migration pattern, and five explicit rules
covering when bumps are required and how deprecated symbols are handled.

## Files changed
| File | Change |
|---|---|
| `scripts/monitor-lottery.sh` | new |
| `scripts/monitor-marketplace.sh` | new |
| `docs/event-catalogue.md` | extended |

Closes #866
Closes #867
Closes #868
Closes #869
