### PR TITLE
Fix/937 938 939 940 contract compilation fixes

### DIFF
--- a/contracts/bonding-curve/src/lib.rs
+++ b/contracts/bonding-curve/src/lib.rs
@@ -12,9 +12,6 @@ mod events;
 mod storage;
 
 #[cfg(test)]
-mod test;
-
-#[cfg(test)]
 mod prop_test;
 
 pub use errors::BondingCurveError;

--- a/contracts/marketplace/src/lib.rs
+++ b/contracts/marketplace/src/lib.rs
@@ -572,6 +572,8 @@ mod contract {
             env.storage()
                 .persistent()
                 .get(&DataKey::Offer(listing_id, buyer))
+        }
+
         /// Enumerate active listings, paginated by listing ID.
         ///
         /// `cursor` is the listing ID to resume scanning from (pass `0` to start from the

--- a/contracts/subscription/src/errors.rs
+++ b/contracts/subscription/src/errors.rs
@@ -26,6 +26,12 @@ pub enum SubscriptionError {
     IntervalNotElapsed = 9,
     /// Subscriber has not granted sufficient token allowance to this contract.
     InsufficientAllowance = 10,
+    /// Plan with this ID already exists.
+    PlanAlreadyExists = 11,
+    /// Plan does not exist.
+    PlanNotFound = 12,
+    /// Plan is not active and cannot be subscribed to.
+    PlanInactive = 13,
 }
 
 #[cfg(test)]
@@ -49,7 +55,10 @@ SubscriptionError::AlreadySubscribed = {}\n\
 SubscriptionError::NotSubscribed = {}\n\
 SubscriptionError::SubscriptionInactive = {}\n\
 SubscriptionError::IntervalNotElapsed = {}\n\
-SubscriptionError::InsufficientAllowance = {}\n",
+SubscriptionError::InsufficientAllowance = {}\n\
+SubscriptionError::PlanAlreadyExists = {}\n\
+SubscriptionError::PlanNotFound = {}\n\
+SubscriptionError::PlanInactive = {}\n",
             SubscriptionError::AlreadyInitialized as u32,
             SubscriptionError::NotInitialized as u32,
             SubscriptionError::NotAuthorized as u32,
@@ -60,6 +69,9 @@ SubscriptionError::InsufficientAllowance = {}\n",
             SubscriptionError::SubscriptionInactive as u32,
             SubscriptionError::IntervalNotElapsed as u32,
             SubscriptionError::InsufficientAllowance as u32,
+            SubscriptionError::PlanAlreadyExists as u32,
+            SubscriptionError::PlanNotFound as u32,
+            SubscriptionError::PlanInactive as u32,
         )
     }
 
@@ -70,11 +82,4 @@ SubscriptionError::InsufficientAllowance = {}\n",
             include_str!("../snapshots/error_codes.snap")
         );
     }
-}
-    /// Plan with this ID already exists.
-    PlanAlreadyExists = 11,
-    /// Plan does not exist.
-    PlanNotFound = 12,
-    /// Plan is not active and cannot be subscribed to.
-    PlanInactive = 13,
 }

--- a/contracts/subscription/src/test.rs
+++ b/contracts/subscription/src/test.rs
@@ -443,7 +443,7 @@ fn test_charge_during_trial_fails() {
     env.ledger().with_mut(|l| l.sequence_number += 50);
 
     let result = client.try_charge(&subscriber);
-    assert_eq!(result, Err(Ok(SubscriptionError::IntervalNotElapsed));
+    assert_eq!(result, Err(Ok(SubscriptionError::IntervalNotElapsed)));
     let _ = provider;
 }
 

--- a/contracts/vesting/src/errors.rs
+++ b/contracts/vesting/src/errors.rs
@@ -22,6 +22,10 @@ pub enum VestingError {
     AlreadyRevoked = 7,
     /// admin_release was called after the cliff has already passed.
     CliffAlreadyPassed = 8,
+    /// A schedule already exists for the specified beneficiary.
+    ScheduleAlreadyExists = 9,
+    /// No schedule was found for the specified beneficiary.
+    ScheduleNotFound = 10,
 }
 
 #[cfg(test)]
@@ -38,20 +42,24 @@ mod tests {
             "\
 VestingError::AlreadyInitialized = {}\n\
 VestingError::NotInitialized = {}\n\
-VestingError::Unauthorized = {}\n\
+VestingError::NotAuthorized = {}\n\
 VestingError::InvalidAmount = {}\n\
 VestingError::InvalidSchedule = {}\n\
 VestingError::NothingToClaim = {}\n\
 VestingError::AlreadyRevoked = {}\n\
-VestingError::CliffAlreadyPassed = {}\n",
+VestingError::CliffAlreadyPassed = {}\n\
+VestingError::ScheduleAlreadyExists = {}\n\
+VestingError::ScheduleNotFound = {}\n",
             VestingError::AlreadyInitialized as u32,
             VestingError::NotInitialized as u32,
-            VestingError::Unauthorized as u32,
+            VestingError::NotAuthorized as u32,
             VestingError::InvalidAmount as u32,
             VestingError::InvalidSchedule as u32,
             VestingError::NothingToClaim as u32,
             VestingError::AlreadyRevoked as u32,
             VestingError::CliffAlreadyPassed as u32,
+            VestingError::ScheduleAlreadyExists as u32,
+            VestingError::ScheduleNotFound as u32,
         )
     }
 
@@ -62,9 +70,4 @@ VestingError::CliffAlreadyPassed = {}\n",
             include_str!("../snapshots/error_codes.snap")
         );
     }
-}
-    /// A schedule already exists for the specified beneficiary.
-    ScheduleAlreadyExists = 9,
-    /// No schedule was found for the specified beneficiary.
-    ScheduleNotFound = 10,
 }


### PR DESCRIPTION
 ## Summary

  Fix compilation errors across four Soroban contracts:

  - **#937**: Add missing closing brace to `get_offer()` in marketplace contract
  - **#938**: Move error variants inside `SubscriptionError` enum and update tests
  - **#939**: Move error variants inside `VestingError` enum, fix test variant name, and update tests
  - **#940**: Remove duplicate external test module declaration in bonding-curve contract
  - Fix syntax error in subscription test (missing closing parenthesis)

  All changes restore contract compilation and ensure enum definitions are structurally correct.

  Closes #937
  Closes #938
  Closes #939
  Closes #940