### PR TITLE
chore/957 958 959 960 contract reference coverage

### DIFF
--- a/docs/contract-api.md
+++ b/docs/contract-api.md
@@ -157,6 +157,482 @@ Complete public API documentation for all Soroban starter kit contracts.
 
 ---
 
+## Airdrop Contract
+
+**Location:** `contracts/airdrop/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, token: Address, claim_deadline: u32` | `Result<(), AirdropError>` | `AlreadyInitialized` |
+| `set_root` | `env: Env, root: BytesN<32>` | `Result<(), AirdropError>` | `NotInitialized`, `Unauthorized` |
+| `claim` | `env: Env, recipient: Address, amount: i128, proof: Vec<BytesN<32>>` | `Result<(), AirdropError>` | `NotInitialized`, `RootNotSet`, `InvalidAmount`, `ClaimWindowClosed`, `AlreadyClaimed`, `InvalidProof` |
+| `claim_batch` | `env: Env, entries: Vec<(Address, i128, Vec<BytesN<32>>)>` | `Result<(), AirdropError>` | `NotInitialized`, `RootNotSet`, `ClaimWindowClosed`, `InvalidAmount`, `AlreadyClaimed`, `InvalidProof` |
+| `is_claimed` | `env: Env, address: Address` | `bool` | None |
+| `get_root` | `env: Env` | `Option<Bytes>` | None |
+
+`claim_batch` uses all-or-nothing semantics: every entry is validated before any transfer executes, so a single bad entry aborts the whole batch.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `Unauthorized` (3) — Caller not admin
+- `RootNotSet` (4) — No merkle root configured yet
+- `InvalidProof` (5) — Merkle proof does not verify
+- `AlreadyClaimed` (6) — Address already claimed
+- `InvalidAmount` (7) — Claim amount <= 0
+- `ClaimWindowClosed` (8) — Current ledger past `claim_deadline`
+
+---
+
+## Auction Contract
+
+**Location:** `contracts/auction/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `start` | `env: Env, seller: Address, token: Address, start_price: i128, min_increment: i128, deadline: u32, reserve_price: Option<i128>, extension_window: u32` | `Result<(), AuctionError>` | `AlreadyInitialized`, `InvalidAmount`, `InvalidDeadline` |
+| `bid` | `env: Env, bidder: Address, amount: i128` | `Result<(), AuctionError>` | `InvalidAmount`, `AuctionEnded`, `NotInitialized`, `BidTooLow` |
+| `cancel` | `env: Env, seller: Address` | `Result<(), AuctionError>` | `NotInitialized`, `NotAuthorized`, `AlreadyEnded`, `BidAlreadyPlaced` |
+| `end` | `env: Env` | `Result<(), AuctionError>` | `NotInitialized`, `AuctionNotEnded`, `AlreadyEnded` |
+| `withdraw` | `env: Env, bidder: Address` | `Result<(), AuctionError>` | `NothingToWithdraw` |
+| `get_pending` | `env: Env, bidder: Address` | `i128` | None |
+| `get_info` | `env: Env` | `Result<AuctionInfo, AuctionError>` | `NotInitialized` |
+
+`bid` extends `deadline` by `extension_window` ledgers when a bid lands within that window of the current deadline (anti-sniping). `end` settles to the seller when `highest_bid >= reserve_price` (or no reserve is set); otherwise it refunds the highest bidder and the item goes unsold. `cancel` only succeeds before the first bid is placed.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `start` called twice
+- `NotInitialized` (2) — Operation before `start`
+- `AuctionEnded` (3) — Deadline passed or auction cancelled
+- `AuctionNotEnded` (4) — `end` called before the deadline
+- `BidTooLow` (5) — Bid below the required minimum
+- `AlreadyEnded` (6) — Already settled
+- `NoBids` (7) — Reserved; `end()` handles the no-bids case via an event, not this error
+- `NotAuthorized` (8) — Caller is not the seller
+- `InvalidAmount` (9) — `start_price`/`min_increment`/bid <= 0
+- `InvalidDeadline` (10) — `deadline` not in the future
+- `NothingToWithdraw` (11) — No pending refund
+- `ReserveNotMet` (12) — Reserved; `end()` handles this case via an event, not this error
+- `BidAlreadyPlaced` (13) — `cancel` called after a bid was placed
+
+---
+
+## Ballot Contract
+
+**Location:** `contracts/ballot/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, voting_start: u32, voting_end: u32, choices: Vec<String>` | `Result<(), BallotError>` | `AlreadyInitialized`, `NoChoices`, `InvalidWindow` |
+| `register_voter` | `env: Env, voter: Address` | `Result<(), BallotError>` | `NotInitialized`, `Unauthorized` |
+| `deregister_voter` | `env: Env, voter: Address` | `Result<(), BallotError>` | `NotInitialized`, `Unauthorized`, `VotingAlreadyStarted`, `NotRegistered` |
+| `vote` | `env: Env, voter: Address, choice: u32` | `Result<(), BallotError>` | `NotInitialized`, `VotingNotStarted`, `VotingClosed`, `NotRegistered`, `AlreadyVoted`, `InvalidChoice` |
+| `tally_all` | `env: Env` | `Result<Vec<i128>, BallotError>` | `NotInitialized`, `Unauthorized` |
+| `tally` | `env: Env` | `Result<(i128, i128), BallotError>` | `NotInitialized`, `Unauthorized` |
+| `get_yes_votes` | `env: Env` | `i128` | None |
+| `get_no_votes` | `env: Env` | `i128` | None |
+| `get_choice_votes` | `env: Env, choice_index: u32` | `i128` | None |
+| `get_choices` | `env: Env` | `Vec<String>` | None |
+
+`choice` is a 0-based index into the `choices` list from `initialize`; for two-choice ballots the convention is `0 = no`, `1 = yes`, kept in sync via `get_yes_votes`/`get_no_votes`. `tally_all` (multi-choice) and `tally` (legacy two-choice) both close voting when called.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `Unauthorized` (3) — Caller not admin
+- `NotRegistered` (4) — Voter not registered
+- `AlreadyVoted` (5) — Voter already voted
+- `InvalidChoice` (6) — Choice index out of range
+- `VotingClosed` (7) — Voting inactive or past `voting_end`
+- `VotingAlreadyStarted` (8) — `deregister_voter` called after votes were cast
+- `InvalidWindow` (9) — Invalid `voting_start`/`voting_end`
+- `VotingNotStarted` (10) — Before `voting_start`
+- `NoChoices` (11) — Empty `choices` list
+
+---
+
+## Bonding Curve Contract
+
+**Location:** `contracts/bonding-curve/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, token: Address` | `Result<(), BondingCurveError>` | `AlreadyInitialized` |
+| `buy` | `env: Env, buyer: Address, amount: i128, max_cost: i128` | `Result<(), BondingCurveError>` | `NotInitialized`, `InvalidAmount`, `Overflow` |
+| `sell` | `env: Env, seller: Address, amount: i128, min_proceeds: i128` | `Result<(), BondingCurveError>` | `NotInitialized`, `InvalidAmount`, `InsufficientReserve`, `Overflow` |
+| `get_reserve` | `env: Env` | `i128` | None |
+| `get_supply` | `env: Env` | `i128` | None |
+| `get_price` | `env: Env` | `i128` | None |
+
+Linear curve: `price = reserve / (supply + 1)` (scaled by `PRICE_SCALE`). `buy` fails with `InvalidAmount` if the computed cost exceeds `max_cost`; `sell` fails the same way if proceeds fall below `min_proceeds`.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `Unauthorized` (3) — Reserved; not returned by any current entry point
+- `InvalidAmount` (4) — Amount <= 0, or a slippage bound was violated
+- `InsufficientReserve` (5) — Reserve too low to pay out a sell
+- `Overflow` (6) — Arithmetic overflow in price/cost/proceeds calculation
+
+---
+
+## Crowdfund Contract
+
+**Location:** `contracts/crowdfund/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, creator: Address, token: Address, goal: i128, deadline: u32, tiers: Vec<FundingTier>, max_pledge_per_address: Option<i128>` | `Result<(), CrowdfundError>` | `AlreadyInitialized`, `InvalidGoal`, `InvalidDeadline`, `InvalidTier`, `InvalidAmount` |
+| `pledge` | `env: Env, pledger: Address, amount: i128` | `Result<(), CrowdfundError>` | `NotInitialized`, `DeadlinePassed`, `InvalidAmount`, `PledgeCapExceeded` |
+| `withdraw` | `env: Env, pledger: Address` | `Result<(), CrowdfundError>` | `NotInitialized`, `DeadlinePassed`, `NothingToWithdraw` |
+| `extend_deadline` | `env: Env, new_deadline: u32` | `Result<(), CrowdfundError>` | `NotInitialized`, `DeadlinePassed`, `DeadlineAlreadyExtended`, `InvalidDeadline` |
+| `claim` | `env: Env` | `Result<(), CrowdfundError>` | `NotInitialized`, `NotAuthorized`, `DeadlineNotReached`, `GoalNotMet`, `AlreadyClaimed` |
+| `refund` | `env: Env, pledger: Address` | `Result<(), CrowdfundError>` | `NotInitialized`, `DeadlineNotReached`, `GoalAlreadyMet`, `NothingToWithdraw` |
+| `get_info` | `env: Env` | `Result<CrowdfundInfo, CrowdfundError>` | `NotInitialized` |
+| `get_pledge` | `env: Env, pledger: Address` | `i128` | None |
+
+`get_info` reports each configured `FundingTier` alongside whether `total_pledged` has crossed its threshold. `extend_deadline` may only be used once per campaign.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `DeadlinePassed` (3) — Deadline has passed
+- `DeadlineNotReached` (4) — Deadline not yet reached
+- `GoalAlreadyMet` (5) — `refund` called on a successful campaign
+- `GoalNotMet` (6) — `claim` called on an unsuccessful campaign
+- `AlreadyClaimed` (7) — Funds already claimed
+- `NothingToPledge` (8) — Reserved; `pledge` reports a bad amount via `InvalidAmount` instead
+- `NothingToWithdraw` (9) — No active pledge to withdraw/refund
+- `InvalidAmount` (10) — Pledge amount or cap <= 0
+- `InvalidDeadline` (11) — Deadline not in the future / not a valid extension
+- `InvalidGoal` (12) — Goal <= 0
+- `NotAuthorized` (13) — Caller is not the creator
+- `InvalidTier` (14) — A tier threshold <= 0
+- `PledgeCapExceeded` (15) — Pledge would exceed `max_pledge_per_address`
+- `DeadlineAlreadyExtended` (16) — Deadline already extended once
+
+---
+
+## DAO Contract
+
+**Location:** `contracts/dao/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, token: Address, voting_period: u32, quorum: i128, quorum_bps: u32` | `Result<(), DaoError>` | `AlreadyInitialized`, `InvalidQuorumBps` |
+| `create_proposal` | `env: Env, proposer: Address, title: String, description: String` | `Result<u32, DaoError>` | `NotInitialized`, `InsufficientVotingPower` |
+| `vote` | `env: Env, voter: Address, proposal_id: u32, support: bool` | `Result<(), DaoError>` | `NotInitialized`, `ProposalNotFound`, `InvalidState`, `VotingClosed`, `AlreadyVoted`, `InsufficientVotingPower` |
+| `execute_proposal` | `env: Env, proposal_id: u32` | `Result<(), DaoError>` | `NotInitialized`, `ProposalNotFound`, `InvalidState`, `DeadlineNotReached`, `QuorumNotMet`, `ProposalRejected` |
+| `cancel_proposal` | `env: Env, proposal_id: u32` | `Result<(), DaoError>` | `NotInitialized`, `NotAuthorized`, `ProposalNotFound`, `InvalidState` |
+| `proposer_cancel_proposal` | `env: Env, proposer: Address, proposal_id: u32` | `Result<(), DaoError>` | `NotInitialized`, `ProposalNotFound`, `NotAuthorized`, `InvalidState`, `VotesAlreadyCast` |
+| `get_proposal` | `env: Env, proposal_id: u32` | `Result<Proposal, DaoError>` | `ProposalNotFound` |
+| `proposal_count` | `env: Env` | `u32` | None |
+
+Voting weight is the voter's token balance at vote time, capped at the total supply snapshot taken at proposal creation (flash-loan resistant). `execute_proposal` requires both the absolute `quorum` and, if `quorum_bps > 0`, that participation reach `quorum_bps` of the snapshotted total supply, plus `yes_votes > no_votes`.
+
+**Errors:**
+- `NotAuthorized` (1) — Caller not admin/original proposer
+- `AlreadyInitialized` (2) — `initialize` called twice
+- `NotInitialized` (3) — Operation before initialize
+- `ProposalNotFound` (4) — Unknown `proposal_id`
+- `InvalidState` (5) — Proposal not `Active`
+- `DeadlineNotReached` (6) — Voting deadline not yet passed
+- `AlreadyVoted` (7) — Voter already voted on this proposal
+- `QuorumNotMet` (8) — Total votes below `quorum`/`quorum_bps`
+- `ProposalRejected` (9) — `no_votes >= yes_votes`
+- `InsufficientVotingPower` (10) — Caller holds no governance tokens
+- `VotesAlreadyCast` (11) — Proposer self-cancel rejected; votes already cast
+- `InvalidQuorumBps` (12) — `quorum_bps` outside `0`–`10 000`
+- `VotingClosed` (13) — Voting period has ended
+
+---
+
+## Lottery Contract
+
+**Location:** `contracts/lottery/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, token: Address, ticket_price: i128, winner_count: u32, prize_splits: Vec<u32>, max_tickets_per_address: Option<u32>` | `Result<(), LotteryError>` | `AlreadyInitialized`, `InvalidTicketPrice`, `InvalidWinnerConfig`, `InvalidTicketCap` |
+| `buy_ticket` | `env: Env, buyer: Address` | `Result<(), LotteryError>` | `NotInitialized`, `LotteryClosed`, `TicketCapExceeded` |
+| `commit` | `env: Env, hash: BytesN<32>, reveal_deadline: u32` | `Result<(), LotteryError>` | `NotInitialized`, `Unauthorized`, `LotteryClosed`, `CommitAlreadySubmitted`, `DrawAlreadyDone`, `NoTickets`, `InvalidRevealDeadline` |
+| `draw` | `env: Env, secret: BytesN<32>, salt: BytesN<32>` | `Result<Vec<Address>, LotteryError>` | `NotInitialized`, `Unauthorized`, `DrawNotDone`, `DrawAlreadyDone`, `RevealMismatch`, `InsufficientParticipants` |
+| `claim_refund` | `env: Env, buyer: Address` | `Result<i128, LotteryError>` | `NotInitialized`, `RefundNotAvailable`, `DrawAlreadyDone`, `NothingToRefund` |
+| `get_info` | `env: Env` | `Result<LotteryInfo, LotteryError>` | `NotInitialized` |
+| `get_winner` | `env: Env` | `Result<Address, LotteryError>` | `NotInitialized`, `DrawNotDone` |
+| `get_winners` | `env: Env` | `Result<Vec<Address>, LotteryError>` | `NotInitialized`, `DrawNotDone` |
+| `get_ticket_count` | `env: Env, buyer: Address` | `u32` | None |
+
+Commit-reveal randomness: `commit` locks in `hash(secret ++ salt)` and a reveal deadline; `draw` verifies the reveal, then derives `winner_count` distinct winners from `hash(secret ++ salt ++ ledger ++ round)` and splits the prize pool per `prize_splits` (basis points, summing to 10 000). If the admin never calls `draw` before `reveal_deadline`, ticket holders can `claim_refund`.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `Unauthorized` (3) — Caller not admin
+- `LotteryClosed` (4) — Not in `Open` state
+- `DrawAlreadyDone` (5) — Already drawn
+- `DrawNotDone` (6) — Not yet drawn / not yet committed
+- `InvalidTicketPrice` (7) — `ticket_price` <= 0
+- `CommitAlreadySubmitted` (8) — Already committed
+- `RevealMismatch` (9) — Reveal doesn't match the commitment
+- `NoTickets` (10) — No tickets sold
+- `InvalidRevealDeadline` (11) — `reveal_deadline` not in the future
+- `RefundNotAvailable` (12) — Refund conditions not met
+- `NothingToRefund` (13) — Caller holds no tickets
+- `InvalidWinnerConfig` (14) — Bad `winner_count`/`prize_splits`
+- `InsufficientParticipants` (15) — Too few distinct participants for `winner_count`
+- `InvalidTicketCap` (16) — `max_tickets_per_address` is `Some(0)`
+- `TicketCapExceeded` (17) — Buyer already at their ticket cap
+
+---
+
+## Marketplace Contract
+
+**Location:** `contracts/marketplace/src/lib.rs`
+
+> **Known issue:** `lib.rs` currently contains corrupted/duplicated code — two
+> conflicting `get_active_listings` definitions (one of which is actually the
+> body of an offer-accept flow), references to error variants and a `NftClient`
+> type that don't exist anywhere in the crate, and no function that actually
+> creates an `Offer` (despite `cancel_offer` and offer-acceptance logic, and an
+> `Offer` storage key, existing). The table below documents only the coherent,
+> internally-consistent subset of the file, using the canonical error names
+> from `errors.rs`. Treat this section as a known-incomplete placeholder until
+> the contract code itself is fixed in a separate PR — see the note in
+> `error-reference.md`'s Marketplace section.
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, payment_token: Address, royalty_bps: u32, royalty_recipient: Address` | `Result<(), MarketplaceError>` | `AlreadyInitialized`, `InvalidRoyalty` |
+| `list` | `env: Env, seller: Address, token_id: u32, price: i128` | `Result<u64, MarketplaceError>` | `NotInitialized`, `NotAuthorized` |
+| `buy` | `env: Env, buyer: Address, listing_id: u64, payment_amount: i128` | `Result<(), MarketplaceError>` | `NotInitialized`, `ListingNotFound`, `ListingInactive`, `InvalidPrice` |
+| `cancel` | `env: Env, caller: Address, listing_id: u64` | `Result<(), MarketplaceError>` | `NotInitialized`, `NotAuthorized`, `ListingNotFound`, `ListingInactive` |
+| `cancel_offer` | `env: Env, buyer: Address, listing_id: u64` | `Result<(), MarketplaceError>` | `NotInitialized`, `OfferNotFound` |
+| `get_listing` | `env: Env, listing_id: u64` | `Option<Listing>` | None |
+| `get_offer` | `env: Env, listing_id: u64, buyer: Address` | `Option<i128>` | None |
+| `get_active_listings` | `env: Env, cursor: u64, limit: u32` | `ListingPage` | None |
+
+**Not currently reachable through a working entry point:** making an offer (an `Offer` is only ever read/cancelled, never created) and accepting an offer (the intended logic exists but is bound to a duplicate, misnamed `get_active_listings` definition rather than its own function).
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `NotAuthorized` (3) — Caller not seller/admin
+- `InvalidPrice` (4) — Listing price <= 0
+- `ListingNotFound` (5) — Unknown `listing_id`
+- `ListingInactive` (6) — Listing already sold/cancelled
+- `InvalidRoyalty` (7) — Royalty BPS > 10 000
+- `InvalidExpiry` (8) — Listing expiry not in the future
+- `ListingExpired` (9) — Listing expiry has passed
+- `ListingNotExpired` (10) — Sweep called on a non-expired listing
+- `InvalidOfferAmount` (11) — Offer amount invalid or not below price
+- `OfferNotFound` (12) — No offer for `(listing_id, buyer)`
+
+---
+
+## NFT Contract
+
+**Location:** `contracts/nft/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, name: String, symbol: String, max_supply: Option<u32>, royalty_bps: Option<u32>, royalty_recipient: Option<Address>` | `Result<(), NftError>` | `AlreadyInitialized`, `InvalidRoyalty`, `RoyaltyRecipientMissing` |
+| `mint` | `env: Env, to: Address, token_uri: String, token_royalty_bps: Option<u32>, token_royalty_recipient: Option<Address>` | `Result<u32, NftError>` | `NotAuthorized`, `SupplyCapReached`, `InvalidRoyalty`, `RoyaltyRecipientMissing` |
+| `royalty_info` | `env: Env, token_id: u32, sale_price: i128` | `Result<Option<RoyaltyInfo>, NftError>` | `TokenNotFound` |
+| `transfer` | `env: Env, from: Address, to: Address, token_id: u32` | `Result<(), NftError>` | `TokenNotFound`, `NotOwner` |
+| `approve` | `env: Env, owner: Address, spender: Address, token_id: u32` | `Result<(), NftError>` | `TokenNotFound`, `NotOwner` |
+| `owner_of` | `env: Env, token_id: u32` | `Result<Address, NftError>` | `TokenNotFound` |
+| `token_uri` | `env: Env, token_id: u32` | `Result<String, NftError>` | `TokenNotFound` |
+| `total_supply` | `env: Env` | `u32` | None |
+| `get_royalty_bps` | `env: Env` | `Option<u32>` | None |
+| `get_royalty_recipient` | `env: Env` | `Option<Address>` | None |
+
+`royalty_info` resolves per-token royalty overrides (set at `mint`) before falling back to the collection-level default (set at `initialize`), returning `None` when no royalty is configured at either level. `errors.rs` names the ownership/authorization variant `NotOwner`/`NotAuthorized` and the supply-cap variant `SupplyCapReached`; the doc comments in `lib.rs` refer to these as `Unauthorized`/`MaxSupplyReached` in a few places — this table uses the canonical `errors.rs` names.
+
+**Errors:**
+- `NotAuthorized` (1) — Caller not admin/owner
+- `AlreadyInitialized` (2) — `initialize` called twice
+- `NotInitialized` (3) — Operation before initialize
+- `TokenNotFound` (4) — Unknown `token_id`
+- `TokenAlreadyMinted` (5) — Reserved; not reachable via the current sequential-ID `mint`
+- `NotOwner` (6) — Caller is not the token's owner
+- `NotApproved` (7) — Reserved; `transfer` does not currently check approved spenders
+- `SupplyCapReached` (8) — Minting would exceed `max_supply`
+- `InvalidTokenId` (9) — Reserved; entry points derive `token_id` internally
+- `InvalidRoyalty` (10) — Royalty BPS > 10 000
+- `RoyaltyRecipientMissing` (11) — Royalty BPS > 0 without a recipient (or vice versa)
+
+---
+
+## Oracle Contract
+
+**Location:** `contracts/oracle/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, staleness_threshold: u32` | `Result<(), OracleError>` | `AlreadyInitialized`, `InvalidStalenessThreshold` |
+| `update_price` | `env: Env, price: i128` | `Result<(), OracleError>` | `NotInitialized`, `Unauthorized` |
+| `get_price` | `env: Env` | `Result<i128, OracleError>` | `NotInitialized`, `StalePrice` |
+| `get_price_checked` | `env: Env, max_age: u64` | `Result<i128, OracleError>` | `NotInitialized`, `StalePrice` |
+| `get_price_data` | `env: Env` | `Result<PriceData, OracleError>` | `NotInitialized` |
+| `set_publishers` | `env: Env, admin: Address, publishers: Vec<Address>` | `Result<(), OracleError>` | `NotInitialized`, `Unauthorized` |
+| `submit_price` | `env: Env, publisher: Address, price: i128` | `Result<(), OracleError>` | `Unauthorized` |
+| `get_median_price` | `env: Env, max_staleness_seconds: u64` | `Result<i128, OracleError>` | `NotInitialized`, `NoPublisherData` |
+| `get_twap` | `env: Env, window: u64` | `Result<i128, OracleError>` | `InsufficientHistory` |
+
+`get_price` checks staleness in ledgers against `staleness_threshold`; `get_price_checked` instead checks a caller-supplied `max_age` in seconds. `get_median_price` takes the median of fresh multi-publisher submissions rather than trusting a single admin-pushed price. `get_twap` computes a time-weighted average over a ring buffer of up to 30 (`MAX_HISTORY`) recorded observations.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `Unauthorized` (3) — Caller not admin/authorized publisher
+- `StalePrice` (4) — Price older than the staleness threshold
+- `InvalidStalenessThreshold` (5) — Threshold is zero
+- `NoPublisherData` (6) — No fresh publisher submission
+- `InsufficientHistory` (7) — No observation within the requested TWAP window
+
+---
+
+## Subscription Contract
+
+**Location:** `contracts/subscription/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, provider: Address, token: Address` | `Result<(), SubscriptionError>` | `AlreadyInitialized` |
+| `register_plan` | `env: Env, plan_id: Symbol, amount: i128, interval_ledgers: u32` | `Result<(), SubscriptionError>` | `NotInitialized`, `NotAuthorized`, `InvalidAmount`, `InvalidInterval`, `PlanAlreadyExists` |
+| `set_plan_active` | `env: Env, plan_id: Symbol, active: bool` | `Result<(), SubscriptionError>` | `NotInitialized`, `NotAuthorized`, `PlanNotFound` |
+| `subscribe` | `env: Env, subscriber: Address, plan_id: Symbol, trial_ledgers: Option<u32>` | `Result<(), SubscriptionError>` | `NotInitialized`, `PlanNotFound`, `PlanInactive`, `AlreadySubscribed` |
+| `charge` | `env: Env, subscriber: Address` | `Result<(), SubscriptionError>` | `NotInitialized`, `NotAuthorized`, `NotSubscribed`, `SubscriptionInactive`, `IntervalNotElapsed`, `InsufficientAllowance` |
+| `cancel` | `env: Env, subscriber: Address` | `Result<(), SubscriptionError>` | `NotInitialized`, `NotSubscribed`, `SubscriptionInactive` |
+| `get_subscription` | `env: Env, subscriber: Address` | `Option<SubscriptionInfo>` | None |
+| `get_provider` | `env: Env` | `Option<Address>` | None |
+| `get_token` | `env: Env` | `Option<Address>` | None |
+| `get_plan` | `env: Env, plan_id: Symbol` | `Option<Plan>` | None |
+
+The subscriber must pre-approve this contract as a token spender (`token.approve(subscriber, subscription_contract, amount * periods, expiry_ledger)`) before the provider can `charge`. An optional `trial_ledgers` on `subscribe` delays the first real charge; `charge` during the trial window only marks the trial complete without transferring funds.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `NotAuthorized` (3) — Caller not the provider
+- `InvalidAmount` (4) — Plan amount <= 0
+- `InvalidInterval` (5) — Plan interval is zero
+- `AlreadySubscribed` (6) — Subscriber already has an active subscription
+- `NotSubscribed` (7) — No subscription found
+- `SubscriptionInactive` (8) — Subscription cancelled
+- `IntervalNotElapsed` (9) — Charge interval/trial not yet elapsed
+- `InsufficientAllowance` (10) — Subscriber's token allowance too low
+- `PlanAlreadyExists` (11) — Plan ID already registered
+- `PlanNotFound` (12) — Unknown plan ID
+- `PlanInactive` (13) — Plan deactivated
+
+---
+
+## Swap Contract
+
+**Location:** `contracts/swap/src/lib.rs`
+
+> **Known issue:** `lib.rs` currently contains corrupted/duplicated code — both
+> `set_fee_bps` and `get_fee_bps` are defined twice in the same `impl` block,
+> and some branches reference states/errors (`SwapState::Pending`/`Accepted`,
+> `SwapError::SwapNotPending`/`SwapExpired`) that don't exist in `storage.rs`
+> / `errors.rs` (which define `SwapState::Open`/`Completed`/`Cancelled` and
+> `SwapError::InvalidState`/`DeadlineExpired`). The table below documents the
+> coherent, internally-consistent subset of the file using the canonical
+> names from `errors.rs`/`storage.rs`. Treat this section as a
+> known-incomplete placeholder until the contract code itself is fixed in a
+> separate PR — see the note in `error-reference.md`'s Swap section.
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, fee_bps: u32` | `Result<(), SwapError>` | `AlreadyInitialized`, `InvalidFee` |
+| `set_treasury` | `env: Env, new_treasury: Address` | `Result<(), SwapError>` | `NotInitialized`, `NotAuthorized` |
+| `set_fee_bps` | `env: Env, new_fee_bps: u32` | `Result<(), SwapError>` | `NotInitialized`, `NotAuthorized`, `InvalidFee` |
+| `set_admin` | `env: Env, new_admin: Address` | `Result<(), SwapError>` | `NotInitialized`, `NotAuthorized` |
+| `get_admin` | `env: Env` | `Result<Address, SwapError>` | `NotInitialized` |
+| `get_treasury` | `env: Env` | `Result<Address, SwapError>` | `NotInitialized` |
+| `get_fee_bps` | `env: Env` | `Result<u32, SwapError>` | `NotInitialized` |
+| `propose_swap` | `env: Env, party_a: Address, token_a: Address, amount_a: i128, token_b: Address, amount_b: i128, expires_at: u32` | `Result<u32, SwapError>` | `NotInitialized`, `InvalidDeadline` |
+| `accept_swap` | `env: Env, swap_id: u32, party_b: Address` | `Result<u32, SwapError>` | `NotInitialized`, `SwapNotFound`, `InvalidState`, `DeadlineExpired` |
+| `cancel_swap` | `env: Env, swap_id: u32` | `Result<(), SwapError>` | `SwapNotFound`, `InvalidState`, `NotAuthorized` |
+| `get_swap` | `env: Env, swap_id: u32` | `Result<SwapInfo, SwapError>` | `SwapNotFound` |
+
+`accept_swap` deducts a `fee_bps` fee (paid to the admin) from `token_b`'s transfer to party A, then executes both legs of the swap atomically.
+
+**Errors:**
+- `NotAuthorized` (1) — Caller not permitted
+- `SwapNotFound` (2) — Unknown `swap_id`
+- `InvalidState` (3) — Swap not `Open`
+- `DeadlineExpired` (4) — `expires_at` has passed
+- `InvalidAmount` (5) — `amount_a`/`amount_b` <= 0
+- `InvalidDeadline` (6) — `expires_at` not in the future
+- `AlreadyCompleted` (7) — Swap already accepted
+- `AlreadyCancelled` (8) — Swap already cancelled
+- `AlreadyInitialized` (9) — `initialize` called twice
+- `NotInitialized` (10) — Operation before initialize
+- `InvalidFee` (11) — Fee BPS > 10 000
+
+---
+
+## Timelock Contract
+
+**Location:** `contracts/timelock/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, token: Address, beneficiary: Address, release_ledger: u32, amount: i128` | `Result<(), TimelockError>` | `AlreadyInitialized`, `InvalidAmount`, `InvalidReleaseLedger` |
+| `initialize_with_tranches` | `env: Env, admin: Address, token: Address, beneficiary: Address, tranches: Vec<ReleaseTranche>` | `Result<(), TimelockError>` | `AlreadyInitialized`, `InvalidAmount`, `InvalidReleaseLedger` |
+| `release` | `env: Env` | `Result<(), TimelockError>` | `NotInitialized`, `AlreadyReleased`, `AlreadyCancelled`, `NotYetReleasable` |
+| `cancel` | `env: Env` | `Result<(), TimelockError>` | `NotInitialized`, `NotAuthorized`, `AlreadyReleased`, `AlreadyCancelled` |
+| `reassign_beneficiary` | `env: Env, new_beneficiary: Address` | `Result<(), TimelockError>` | `NotInitialized`, `NotAuthorized`, `AlreadyReleased`, `AlreadyCancelled` |
+| `get_info` | `env: Env` | `Result<TimelockInfo, TimelockError>` | `NotInitialized` |
+| `is_releasable` | `env: Env` | `bool` | None |
+| `get_remaining_ledgers` | `env: Env` | `i64` | None |
+
+`initialize` locks a single amount for one release ledger; `initialize_with_tranches` instead locks a schedule of `(release_ledger, amount)` tranches, releasing each independently as its ledger is reached (`release` may be called repeatedly, transitioning to `Released` only once every tranche has been paid out).
+
+**Errors:**
+- `NotAuthorized` (1) — Caller not admin
+- `AlreadyInitialized` (2) — Either initializer called twice
+- `NotInitialized` (3) — Operation before initialize
+- `NotYetReleasable` (4) — No tranche (or the single release ledger) is due yet
+- `AlreadyReleased` (5) — Fully released already
+- `AlreadyCancelled` (6) — Already cancelled
+- `InvalidAmount` (7) — Amount <= 0, or an empty tranche list
+- `InvalidReleaseLedger` (8) — Release ledger not strictly in the future / not increasing
+
+---
+
+## Wrapped-Token Contract
+
+**Location:** `contracts/wrapped-token/src/lib.rs`
+
+| Function | Parameters | Returns | Errors |
+|----------|-----------|---------|--------|
+| `initialize` | `env: Env, admin: Address, wrapped_token: Address, underlying_token: Address, max_wrap_per_address: Option<i128>` | `Result<(), WrappedTokenError>` | `AlreadyInitialized`, `InvalidAmount` |
+| `wrap` | `env: Env, user: Address, amount: i128` | `Result<(), WrappedTokenError>` | `NotInitialized`, `Unauthorized`, `InvalidAmount`, `MaxWrapExceeded` |
+| `unwrap` | `env: Env, user: Address, amount: i128` | `Result<(), WrappedTokenError>` | `NotInitialized`, `Unauthorized`, `InvalidAmount`, `InsufficientBalance` |
+| `get_total_wrapped` | `env: Env` | `i128` | None |
+| `get_reserve_balance` | `env: Env` | `Result<i128, WrappedTokenError>` | `NotInitialized` |
+| `max_wrap_per_address` | `env: Env` | `Option<i128>` | None |
+| `wrapped_by` | `env: Env, account: Address` | `i128` | None |
+| `pause` *(feature `pausable`)* | `env: Env` | `Result<(), WrappedTokenError>` | `NotInitialized` |
+| `unpause` *(feature `pausable`)* | `env: Env` | `Result<(), WrappedTokenError>` | `NotInitialized` |
+
+`wrap`/`unwrap` maintain a 1:1 peg between the wrapped and underlying tokens; `get_total_wrapped() <= get_reserve_balance()` should always hold (see `monitoring.md`'s reserve-backing invariant). `pause`/`unpause` and the `Unauthorized`-while-paused check on `wrap`/`unwrap` only compile when the `pausable` feature is enabled.
+
+**Errors:**
+- `AlreadyInitialized` (1) — `initialize` called twice
+- `NotInitialized` (2) — Operation before initialize
+- `Unauthorized` (3) — Contract paused (`pausable` feature only)
+- `InvalidAmount` (4) — Amount <= 0, or an invalid cap at initialize
+- `InsufficientBalance` (5) — Caller lacks enough wrapped tokens to unwrap
+- `InsufficientReserve` (6) — Contract lacks enough underlying reserve
+- `MaxWrapExceeded` (7) — Would exceed `max_wrap_per_address`
+
+---
+
 ## Cross-Contract Patterns
 
 ### Token Interface

--- a/docs/error-reference.md
+++ b/docs/error-reference.md
@@ -267,3 +267,1611 @@ Comprehensive reference for all error codes returned by the contracts in this re
 **Common cause:** A single address attempting to wrap more than the configured concentration-risk limit, either in one call or across multiple calls.
 
 **Resolution:** Check `wrapped_by(address)` and `max_wrap_per_address()` before calling `wrap`, and keep cumulative wraps within the cap.
+
+---
+
+## Airdrop Contract — `AirdropError`
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `initialize` was called on a contract that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same deployed contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the contract was initialized.
+
+**Common cause:** Calling `set_root`, `claim`, or `claim_batch` before `initialize` has been called.
+
+**Resolution:** Call `initialize` with the admin, payment token, and claim deadline before any other interaction.
+
+---
+
+### `Unauthorized` (code 3)
+
+**Description:** The caller is not permitted to perform this action.
+
+**Common cause:** A non-admin caller invoking an admin-only entry point.
+
+**Resolution:** Ensure the transaction is signed by the address that called `initialize`.
+
+---
+
+### `RootNotSet` (code 4)
+
+**Description:** `claim` or `claim_batch` was called before the admin set a merkle root.
+
+**Common cause:** Skipping the `set_root` call after `initialize`.
+
+**Resolution:** Have the admin call `set_root` with the distribution's merkle root before accepting claims. Use `get_root()` to verify.
+
+---
+
+### `InvalidProof` (code 5)
+
+**Description:** The supplied merkle proof does not verify against the stored root for the given `(recipient, amount)` leaf.
+
+**Common cause:** A stale or incorrectly generated proof, or a mismatch between the claimed `amount` and the amount encoded in the distribution tree.
+
+**Resolution:** Regenerate the proof from the canonical distribution tree for the exact `(recipient, amount)` pair, and confirm it against `get_root()`.
+
+---
+
+### `AlreadyClaimed` (code 6)
+
+**Description:** The address has already successfully claimed its airdrop allocation.
+
+**Common cause:** Calling `claim` or `claim_batch` a second time for the same recipient.
+
+**Resolution:** Call `is_claimed(address)` before submitting a claim to avoid a redundant, failing transaction.
+
+---
+
+### `InvalidAmount` (code 7)
+
+**Description:** The claim amount is zero or negative.
+
+**Common cause:** Passing `0` (or a negative value) as the `amount` argument to `claim` or an entry in `claim_batch`.
+
+**Resolution:** Use the exact positive amount assigned to the recipient in the distribution tree.
+
+---
+
+### `ClaimWindowClosed` (code 8)
+
+**Description:** The current ledger sequence is past the `claim_deadline` set at `initialize`.
+
+**Common cause:** Submitting a claim after the airdrop's claim window has expired.
+
+**Resolution:** Claims must be submitted before the configured deadline ledger; there is no way to extend it post-deployment.
+
+---
+
+## Auction Contract — `AuctionError`
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `start` was called on an auction that has already been started.
+
+**Common cause:** Calling `start` more than once on the same contract instance.
+
+**Resolution:** Deploy a new contract instance per auction; `start` may only be called once.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the auction was started.
+
+**Common cause:** Calling `bid`, `cancel`, `end`, or `get_info` before `start` has been called.
+
+**Resolution:** Call `start` with the seller, token, pricing, and deadline parameters first.
+
+---
+
+### `AuctionEnded` (code 3)
+
+**Description:** A bid was placed after the auction's deadline passed or after it was cancelled.
+
+**Common cause:** Submitting `bid` too late, or against an auction the seller already cancelled.
+
+**Resolution:** Check `get_info()` for the current deadline and cancellation status before bidding.
+
+---
+
+### `AuctionNotEnded` (code 4)
+
+**Description:** `end` was called before the auction deadline was reached.
+
+**Common cause:** Calling `end` prematurely, or racing anti-sniping deadline extensions triggered by late bids.
+
+**Resolution:** Wait until the current ledger exceeds `get_info().deadline` (which may have been extended by a late bid) before calling `end`.
+
+---
+
+### `BidTooLow` (code 5)
+
+**Description:** The submitted bid does not meet the minimum required amount.
+
+**Common cause:** Bidding below `start_price` on the first bid, or below `highest_bid + min_increment` on subsequent bids.
+
+**Resolution:** Read `get_info()` to determine the current highest bid and increment, and bid at least that much.
+
+---
+
+### `AlreadyEnded` (code 6)
+
+**Description:** The auction has already been settled (or cancelled), so `end` or `cancel` cannot run again.
+
+**Common cause:** Calling `end` a second time, or calling `cancel` after the auction was already settled or cancelled.
+
+**Resolution:** Check `get_info().settled` before calling `end` or `cancel`.
+
+---
+
+### `NoBids` (code 7)
+
+**Description:** Reserved for the no-bids code path; the contract instead emits an `ended_no_bids` event from `end()` rather than returning this error. Included for completeness with the error enum.
+
+**Common cause:** N/A — `end()` succeeds with no transfer when no bids were placed.
+
+**Resolution:** N/A.
+
+---
+
+### `NotAuthorized` (code 8)
+
+**Description:** The caller is not permitted to perform this action.
+
+**Common cause:** Someone other than the seller calling `cancel`.
+
+**Resolution:** Only the address passed as `seller` to `start` may call `cancel`.
+
+---
+
+### `InvalidAmount` (code 9)
+
+**Description:** `start_price`, `min_increment`, or a bid `amount` is zero or negative.
+
+**Common cause:** Passing non-positive values to `start` or `bid`.
+
+**Resolution:** Ensure `start_price`, `min_increment`, and every bid amount are strictly positive.
+
+---
+
+### `InvalidDeadline` (code 10)
+
+**Description:** The supplied `deadline` is not in the future relative to the current ledger.
+
+**Common cause:** Passing a `deadline` <= the current ledger sequence to `start`.
+
+**Resolution:** Choose a `deadline` ledger sequence greater than `env.ledger().sequence()` at call time.
+
+---
+
+### `NothingToWithdraw` (code 11)
+
+**Description:** The caller has no pending refund available.
+
+**Common cause:** Calling `withdraw` without ever having been outbid, or calling it twice.
+
+**Resolution:** Call `get_pending(address)` to check for a refund balance before calling `withdraw`.
+
+---
+
+### `ReserveNotMet` (code 12)
+
+**Description:** Reserved for the reserve-price code path; the contract instead emits an `ended_reserve_not_met` event and refunds the highest bidder rather than returning this error from `end()`. Included for completeness with the error enum.
+
+**Common cause:** N/A — `end()` succeeds (refunding the bidder) when `highest_bid < reserve_price`.
+
+**Resolution:** N/A.
+
+---
+
+### `BidAlreadyPlaced` (code 13)
+
+**Description:** `cancel` was called after at least one bid has already been placed.
+
+**Common cause:** The seller attempting to cancel an auction that already has bidding activity.
+
+**Resolution:** `cancel` is only valid before the first bid; once bidding starts the auction must run to `end()`.
+
+---
+
+## Ballot Contract — `BallotError`
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `initialize` was called on a ballot that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the ballot was initialized.
+
+**Common cause:** Calling `register_voter`, `vote`, `tally`, or `tally_all` before `initialize`.
+
+**Resolution:** Call `initialize` with the admin, voting window, and choices list first.
+
+---
+
+### `Unauthorized` (code 3)
+
+**Description:** The caller is not the admin.
+
+**Common cause:** A non-admin address calling `register_voter`, `deregister_voter`, `tally`, or `tally_all`.
+
+**Resolution:** Ensure the transaction is signed by the address passed as `admin` to `initialize`.
+
+---
+
+### `NotRegistered` (code 4)
+
+**Description:** The voter is not on the registered-voter list.
+
+**Common cause:** Calling `vote` or `deregister_voter` for an address the admin never registered via `register_voter`.
+
+**Resolution:** Have the admin call `register_voter` for the address before it attempts to vote.
+
+---
+
+### `AlreadyVoted` (code 5)
+
+**Description:** The voter has already cast a vote.
+
+**Common cause:** Calling `vote` a second time for the same registered voter.
+
+**Resolution:** Each registered voter may vote exactly once; there is no re-vote mechanism.
+
+---
+
+### `InvalidChoice` (code 6)
+
+**Description:** The `choice` index passed to `vote` is out of range for the configured choices list.
+
+**Common cause:** Passing an index >= the number of choices set at `initialize`.
+
+**Resolution:** Call `get_choices()` to see the valid indices before voting.
+
+---
+
+### `VotingClosed` (code 7)
+
+**Description:** Voting is no longer active — either it was explicitly closed (by `tally`/`tally_all`) or the current ledger is past `voting_end`.
+
+**Common cause:** Calling `vote` after the voting window has closed or after tallying has already occurred.
+
+**Resolution:** Vote within the `[voting_start, voting_end]` window and before the admin calls `tally`/`tally_all`.
+
+---
+
+### `VotingAlreadyStarted` (code 8)
+
+**Description:** `deregister_voter` was called after at least one vote has already been cast.
+
+**Common cause:** The admin trying to correct a registration mistake after voting has begun.
+
+**Resolution:** `deregister_voter` is only allowed while `TotalVotes == 0`; corrections must happen before the first vote.
+
+---
+
+### `InvalidWindow` (code 9)
+
+**Description:** The voting window passed to `initialize` is invalid.
+
+**Common cause:** `voting_start >= voting_end`, or `voting_end` is not in the future relative to the current ledger.
+
+**Resolution:** Choose `voting_start < voting_end`, with `voting_end` greater than the current ledger sequence.
+
+---
+
+### `VotingNotStarted` (code 10)
+
+**Description:** `vote` was called before the current ledger reached `voting_start`.
+
+**Common cause:** Submitting a vote too early, before the configured voting window opens.
+
+**Resolution:** Wait until the current ledger sequence reaches `voting_start` before calling `vote`.
+
+---
+
+### `NoChoices` (code 11)
+
+**Description:** `initialize` was called with an empty `choices` list.
+
+**Common cause:** Passing an empty `Vec<String>` for `choices`.
+
+**Resolution:** Supply at least one named choice at `initialize`.
+
+---
+
+## Bonding Curve Contract — `BondingCurveError`
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `initialize` was called on a contract that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same deployed contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the contract was initialized.
+
+**Common cause:** Calling `buy` or `sell` before `initialize` has been called.
+
+**Resolution:** Call `initialize` with the admin and token address before any trading.
+
+---
+
+### `Unauthorized` (code 3)
+
+**Description:** The caller is not the admin. Reserved for future admin-only entry points; no current entry point returns this variant.
+
+**Common cause:** N/A in the current implementation.
+
+**Resolution:** N/A.
+
+---
+
+### `InvalidAmount` (code 4)
+
+**Description:** The trade amount is zero, negative, exceeds a caller-supplied slippage bound, or (for `sell`) exceeds the current supply.
+
+**Common cause:** Passing `amount <= 0` to `buy`/`sell`, a `buy` whose computed cost exceeds `max_cost`, or a `sell` whose computed proceeds fall below `min_proceeds`.
+
+**Resolution:** Pass a positive `amount`, and set `max_cost` / `min_proceeds` slippage bounds wide enough to accommodate the current curve price (read via `get_price()`).
+
+---
+
+### `InsufficientReserve` (code 5)
+
+**Description:** The contract does not hold enough reserve to pay out a `sell`'s proceeds.
+
+**Common cause:** Selling when the computed proceeds exceed the current reserve balance — should not occur under normal curve operation.
+
+**Resolution:** Check `get_reserve()` before selling; if this occurs it indicates a pricing/reserve invariant violation worth investigating.
+
+---
+
+### `Overflow` (code 6)
+
+**Description:** Arithmetic overflow occurred while computing the curve price, buy cost, or sell proceeds.
+
+**Common cause:** Trading an extremely large `amount` (e.g. near `i128::MAX`) that overflows the fixed-point price calculation.
+
+**Resolution:** Trade in smaller increments; this error is a safe failure mode rather than a panic.
+
+---
+
+## Crowdfund Contract — `CrowdfundError`
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `initialize` was called on a campaign that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the campaign was initialized.
+
+**Common cause:** Calling `pledge`, `withdraw`, `claim`, `refund`, or `get_info` before `initialize`.
+
+**Resolution:** Call `initialize` with the creator, token, goal, deadline, and tiers first.
+
+---
+
+### `DeadlinePassed` (code 3)
+
+**Description:** `pledge`, `withdraw`, or `extend_deadline` was called after the campaign deadline elapsed.
+
+**Common cause:** Attempting to pledge or withdraw funds after the deadline ledger has passed.
+
+**Resolution:** Pledges, withdrawals, and deadline extensions must happen before `get_info().deadline`.
+
+---
+
+### `DeadlineNotReached` (code 4)
+
+**Description:** `claim` or `refund` was called before the campaign deadline was reached.
+
+**Common cause:** The creator or a pledger attempting to settle the campaign early.
+
+**Resolution:** Wait until the current ledger exceeds the deadline before calling `claim` or `refund`.
+
+---
+
+### `GoalAlreadyMet` (code 5)
+
+**Description:** `refund` was called but the total pledged amount met or exceeded the goal.
+
+**Common cause:** A pledger calling `refund` on a successfully funded campaign.
+
+**Resolution:** When the goal is met, the creator calls `claim` instead; pledgers cannot refund a successful campaign.
+
+---
+
+### `GoalNotMet` (code 6)
+
+**Description:** `claim` was called but the total pledged amount is below the goal.
+
+**Common cause:** The creator attempting to claim funds from a campaign that failed to reach its goal.
+
+**Resolution:** When the goal is not met, pledgers call `refund` individually instead.
+
+---
+
+### `AlreadyClaimed` (code 7)
+
+**Description:** `claim` was called after the creator already claimed the funds once.
+
+**Common cause:** Calling `claim` a second time.
+
+**Resolution:** Funds can only be claimed once; check `get_info().claimed` first.
+
+---
+
+### `NothingToPledge` (code 8)
+
+**Description:** Reserved for a zero-pledge guard path. Included for completeness with the error enum; `pledge` currently reports a zero/negative amount via `InvalidAmount` instead.
+
+**Common cause:** N/A in the current implementation.
+
+**Resolution:** N/A.
+
+---
+
+### `NothingToWithdraw` (code 9)
+
+**Description:** The caller has no active pledge to withdraw or refund.
+
+**Common cause:** Calling `withdraw` or `refund` for an address that never pledged, or that already withdrew/refunded.
+
+**Resolution:** Call `get_pledge(address)` to confirm an active pledge exists first.
+
+---
+
+### `InvalidAmount` (code 10)
+
+**Description:** The pledge amount is zero or negative, or the optional `max_pledge_per_address` cap passed to `initialize` is non-positive.
+
+**Common cause:** Passing `amount <= 0` to `pledge`, or `Some(cap) <= 0` to `initialize`.
+
+**Resolution:** Pledge a positive amount; pass `None` to `initialize` for an uncapped campaign or a positive cap.
+
+---
+
+### `InvalidDeadline` (code 11)
+
+**Description:** The supplied deadline is invalid.
+
+**Common cause:** `initialize` called with `deadline <= current ledger`, or `extend_deadline` called with `new_deadline <= current deadline`.
+
+**Resolution:** Choose a deadline strictly in the future, and only extend to a strictly later ledger.
+
+---
+
+### `InvalidGoal` (code 12)
+
+**Description:** `initialize` was called with a non-positive `goal`.
+
+**Common cause:** Passing `goal <= 0`.
+
+**Resolution:** Set a positive funding goal.
+
+---
+
+### `NotAuthorized` (code 13)
+
+**Description:** The caller is not the campaign creator.
+
+**Common cause:** Someone other than the creator calling `claim` or `extend_deadline`.
+
+**Resolution:** Only the address passed as `creator` to `initialize` may call these entry points.
+
+---
+
+### `InvalidTier` (code 14)
+
+**Description:** A funding tier passed to `initialize` has a non-positive `threshold`.
+
+**Common cause:** Including a `FundingTier { threshold: 0, .. }` or negative threshold in the `tiers` list.
+
+**Resolution:** Every stretch-goal tier threshold must be a positive amount.
+
+---
+
+### `PledgeCapExceeded` (code 15)
+
+**Description:** A pledge would push the pledger's cumulative total above `max_pledge_per_address`.
+
+**Common cause:** A single address pledging more than the configured per-address cap, across one or more `pledge` calls.
+
+**Resolution:** Call `get_pledge(address)` to check the running total against `get_info().max_pledge_per_address` before pledging more.
+
+---
+
+### `DeadlineAlreadyExtended` (code 16)
+
+**Description:** `extend_deadline` was called after the deadline had already been extended once.
+
+**Common cause:** Calling `extend_deadline` a second time.
+
+**Resolution:** The deadline may only be extended once per campaign.
+
+---
+
+## DAO Contract — `DaoError`
+
+### `NotAuthorized` (code 1)
+
+**Description:** The caller is not permitted to perform this action.
+
+**Common cause:** A non-admin address calling `cancel_proposal`, or a non-proposer calling `proposer_cancel_proposal`.
+
+**Resolution:** Only the DAO admin may cancel arbitrary proposals; only the original proposer may self-cancel via `proposer_cancel_proposal`.
+
+---
+
+### `AlreadyInitialized` (code 2)
+
+**Description:** `initialize` was called on a DAO that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 3)
+
+**Description:** An operation was attempted before the DAO was initialized.
+
+**Common cause:** Calling `create_proposal`, `vote`, or `execute_proposal` before `initialize`.
+
+**Resolution:** Call `initialize` with the admin, governance token, voting period, and quorum settings first.
+
+---
+
+### `ProposalNotFound` (code 4)
+
+**Description:** The referenced `proposal_id` does not exist.
+
+**Common cause:** Passing a stale or out-of-range `proposal_id` to `vote`, `execute_proposal`, `cancel_proposal`, or `get_proposal`.
+
+**Resolution:** Use `proposal_count()` to confirm valid IDs, or read the ID returned by `create_proposal`.
+
+---
+
+### `InvalidState` (code 5)
+
+**Description:** The proposal is not in the `Active` state required for this operation.
+
+**Common cause:** Calling `vote`, `execute_proposal`, `cancel_proposal`, or `proposer_cancel_proposal` on a proposal that is already `Executed` or `Cancelled`.
+
+**Resolution:** Check `get_proposal(id).state` before acting on a proposal.
+
+---
+
+### `DeadlineNotReached` (code 6)
+
+**Description:** `execute_proposal` was called before the proposal's voting deadline passed.
+
+**Common cause:** Attempting to execute a proposal while voting is still open.
+
+**Resolution:** Wait until the current ledger exceeds `get_proposal(id).deadline` before executing.
+
+---
+
+### `AlreadyVoted` (code 7)
+
+**Description:** The voter has already voted on this proposal.
+
+**Common cause:** Calling `vote` a second time for the same `(voter, proposal_id)` pair.
+
+**Resolution:** Each address may cast one vote per proposal; there is no vote-changing mechanism.
+
+---
+
+### `QuorumNotMet` (code 8)
+
+**Description:** Total votes cast are below the required absolute `quorum`, or below the `quorum_bps` percentage of total token supply.
+
+**Common cause:** Executing a proposal that did not attract enough participation to satisfy either configured quorum threshold.
+
+**Resolution:** Encourage more voting before the deadline, or check the DAO's configured `quorum`/`quorum_bps` values.
+
+---
+
+### `ProposalRejected` (code 9)
+
+**Description:** `no_votes >= yes_votes` on an otherwise quorum-satisfying proposal.
+
+**Common cause:** Attempting to execute a proposal that did not receive a majority of `yes` votes.
+
+**Resolution:** A rejected proposal cannot be executed; a new proposal must be created if desired.
+
+---
+
+### `InsufficientVotingPower` (code 10)
+
+**Description:** The caller holds zero governance tokens.
+
+**Common cause:** Calling `create_proposal` or `vote` from an address with no balance in the configured governance token.
+
+**Resolution:** Acquire governance tokens before creating proposals or voting.
+
+---
+
+### `VotesAlreadyCast` (code 11)
+
+**Description:** `proposer_cancel_proposal` was called after at least one vote has already been recorded.
+
+**Common cause:** The proposer attempting to retract a proposal after voting has begun.
+
+**Resolution:** Self-cancellation is only available before any vote is cast; afterward, only the admin can cancel via `cancel_proposal`.
+
+---
+
+### `InvalidQuorumBps` (code 12)
+
+**Description:** `initialize` was called with `quorum_bps > 10_000`.
+
+**Common cause:** Passing a basis-points value outside the valid `0`–`10_000` range.
+
+**Resolution:** `quorum_bps` must be between `0` (disabled) and `10_000` (100%).
+
+---
+
+### `VotingClosed` (code 13)
+
+**Description:** `vote` was called after the proposal's voting deadline passed.
+
+**Common cause:** Submitting a vote too late.
+
+**Resolution:** Vote before `get_proposal(id).deadline` is reached.
+
+---
+
+## Lottery Contract — `LotteryError`
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `initialize` was called on a lottery that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the lottery was initialized.
+
+**Common cause:** Calling `buy_ticket`, `commit`, or `draw` before `initialize`.
+
+**Resolution:** Call `initialize` with the admin, token, ticket price, and winner configuration first.
+
+---
+
+### `Unauthorized` (code 3)
+
+**Description:** The caller is not the admin.
+
+**Common cause:** A non-admin address calling `commit` or `draw`.
+
+**Resolution:** Only the address passed as `admin` to `initialize` may commit or draw.
+
+---
+
+### `LotteryClosed` (code 4)
+
+**Description:** `buy_ticket` was called while the lottery is no longer in the `Open` state.
+
+**Common cause:** Buying a ticket after the admin has already called `commit`.
+
+**Resolution:** Purchase tickets only while `get_info().state == Open`.
+
+---
+
+### `DrawAlreadyDone` (code 5)
+
+**Description:** `commit`, `draw`, or `claim_refund` was called after the lottery already transitioned to `Drawn`.
+
+**Common cause:** Attempting a second `draw`, or claiming a refund after winners were already selected.
+
+**Resolution:** Once drawn, winners are final; refunds are only available before a successful `draw`.
+
+---
+
+### `DrawNotDone` (code 6)
+
+**Description:** `draw` was called before `commit`, or `get_winner`/`get_winners` was called before a draw occurred.
+
+**Common cause:** Calling `draw` while the lottery is still `Open`, or reading winners too early.
+
+**Resolution:** Call `commit` before `draw`, and only read winner results after `draw` succeeds.
+
+---
+
+### `InvalidTicketPrice` (code 7)
+
+**Description:** `initialize` was called with a non-positive `ticket_price`.
+
+**Common cause:** Passing `ticket_price <= 0`.
+
+**Resolution:** Set a positive ticket price.
+
+---
+
+### `CommitAlreadySubmitted` (code 8)
+
+**Description:** `commit` was called while the lottery is already in the `Committed` state.
+
+**Common cause:** Calling `commit` a second time before drawing.
+
+**Resolution:** `commit` may only be called once per lottery, transitioning `Open → Committed`.
+
+---
+
+### `RevealMismatch` (code 9)
+
+**Description:** The `secret`/`salt` pair passed to `draw` does not hash to the commitment stored by `commit`.
+
+**Common cause:** Revealing the wrong secret/salt pair, or a bug in how the commitment was originally computed.
+
+**Resolution:** Ensure `draw` is called with the exact `(secret, salt)` used to compute the hash passed to `commit`.
+
+---
+
+### `NoTickets` (code 10)
+
+**Description:** `commit` was called with no tickets sold.
+
+**Common cause:** Attempting to commit before any `buy_ticket` calls succeeded.
+
+**Resolution:** Wait for at least one ticket purchase before calling `commit`.
+
+---
+
+### `InvalidRevealDeadline` (code 11)
+
+**Description:** The `reveal_deadline` passed to `commit` is not in the future.
+
+**Common cause:** Passing a `reveal_deadline <= current ledger`.
+
+**Resolution:** Choose a `reveal_deadline` ledger sequence greater than the current one, leaving enough time to call `draw`.
+
+---
+
+### `RefundNotAvailable` (code 12)
+
+**Description:** `claim_refund` was called while the lottery is still `Open`, or before the reveal deadline has passed.
+
+**Common cause:** Requesting a refund too early — refunds are only for a `Committed` lottery whose admin missed the reveal deadline.
+
+**Resolution:** Wait until the current ledger exceeds `reveal_deadline` (and the admin has not called `draw`) before requesting a refund.
+
+---
+
+### `NothingToRefund` (code 13)
+
+**Description:** The caller holds no tickets to refund.
+
+**Common cause:** Calling `claim_refund` for an address that never bought a ticket, or that already refunded.
+
+**Resolution:** Call `get_ticket_count(address)` to confirm outstanding tickets before requesting a refund.
+
+---
+
+### `InvalidWinnerConfig` (code 14)
+
+**Description:** `winner_count` is zero, `prize_splits.len() != winner_count`, or the splits do not sum to 10 000 basis points.
+
+**Common cause:** Misconfigured `winner_count`/`prize_splits` arguments at `initialize`.
+
+**Resolution:** Ensure `prize_splits` has exactly `winner_count` entries summing to `10_000`.
+
+---
+
+### `InsufficientParticipants` (code 15)
+
+**Description:** Fewer distinct ticket-holding addresses exist than the configured `winner_count`.
+
+**Common cause:** Calling `draw` when too few unique participants bought tickets to select the configured number of winners.
+
+**Resolution:** Ensure enough distinct addresses hold tickets before drawing, or reduce `winner_count` at `initialize`.
+
+---
+
+### `InvalidTicketCap` (code 16)
+
+**Description:** `initialize` was called with `max_tickets_per_address = Some(0)`.
+
+**Common cause:** Passing a zero cap instead of `None` (uncapped) or a positive value.
+
+**Resolution:** Pass `None` for no cap, or a positive integer cap.
+
+---
+
+### `TicketCapExceeded` (code 17)
+
+**Description:** `buy_ticket` would push the buyer's ticket count above `max_tickets_per_address`.
+
+**Common cause:** A single address attempting to buy more tickets than the configured per-address cap.
+
+**Resolution:** Call `get_ticket_count(address)` before buying to check against the configured cap.
+
+---
+
+## Marketplace Contract — `MarketplaceError`
+
+> **Note:** `contracts/marketplace/src/lib.rs` currently contains corrupted/duplicated
+> code (two conflicting `get_active_listings` definitions, references to error
+> variants and types that don't exist anywhere in the crate, and no function that
+> creates an `Offer`). This section is cross-checked against the authoritative
+> `errors.rs` enum below; see `contract-api.md` for how this affects the
+> documented public API.
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `initialize` was called on a marketplace that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the marketplace was initialized.
+
+**Common cause:** Calling `list`, `buy`, or `cancel` before `initialize`.
+
+**Resolution:** Call `initialize` with the admin, payment token, and royalty configuration first.
+
+---
+
+### `NotAuthorized` (code 3)
+
+**Description:** The caller is not permitted to perform this action.
+
+**Common cause:** Someone other than the seller or admin calling `cancel`, or a non-seller accepting an offer.
+
+**Resolution:** Only the listing's seller (or the admin, for `cancel`) may perform seller-restricted actions.
+
+---
+
+### `InvalidPrice` (code 4)
+
+**Description:** A listing price is zero or negative.
+
+**Common cause:** Passing `price <= 0` to `list`.
+
+**Resolution:** List at a positive price.
+
+---
+
+### `ListingNotFound` (code 5)
+
+**Description:** The referenced `listing_id` does not exist.
+
+**Common cause:** Passing a stale or invalid `listing_id` to `buy`, `cancel`, or `get_listing`.
+
+**Resolution:** Use the ID returned by `list`, or enumerate listings via `get_active_listings`.
+
+---
+
+### `ListingInactive` (code 6)
+
+**Description:** The listing is no longer active (already bought or cancelled).
+
+**Common cause:** Calling `buy` or `cancel` on a listing that already sold or was cancelled.
+
+**Resolution:** Check `get_listing(id).active` before acting on it.
+
+---
+
+### `InvalidRoyalty` (code 7)
+
+**Description:** The royalty basis points exceed 10 000 (100%).
+
+**Common cause:** Passing `royalty_bps > 10_000` to `initialize`.
+
+**Resolution:** Keep `royalty_bps` within `0`–`10_000`.
+
+---
+
+### `InvalidExpiry` (code 8)
+
+**Description:** The provided listing expiry ledger sequence is not in the future.
+
+**Common cause:** Passing an `expires_at <= current ledger` when creating a listing with an expiry.
+
+**Resolution:** Choose an expiry ledger strictly greater than the current ledger sequence.
+
+---
+
+### `ListingExpired` (code 9)
+
+**Description:** The listing's expiry ledger sequence has already passed.
+
+**Common cause:** Calling `buy` on a listing whose optional `expires_at` has elapsed.
+
+**Resolution:** Check the listing's `expires_at` before buying; expired listings must be swept rather than bought.
+
+---
+
+### `ListingNotExpired` (code 10)
+
+**Description:** A sweep-style cleanup was called on a listing that has no expiry, or whose expiry has not yet passed.
+
+**Common cause:** Attempting to sweep an active, non-expired listing.
+
+**Resolution:** Only sweep listings whose `expires_at` is `Some` and in the past.
+
+---
+
+### `InvalidOfferAmount` (code 11)
+
+**Description:** An offer amount is zero, negative, or not below the listing price.
+
+**Common cause:** Proposing an offer that does not represent a genuine discount off the asking price.
+
+**Resolution:** Offer a positive amount strictly less than the listing's `price`.
+
+---
+
+### `OfferNotFound` (code 12)
+
+**Description:** No offer exists for the given `(listing_id, buyer)` pair.
+
+**Common cause:** Calling `cancel_offer` or accepting an offer that was never made, or was already cancelled/accepted.
+
+**Resolution:** Call `get_offer(listing_id, buyer)` to confirm an active offer exists first.
+
+---
+
+## Multisig Contract — `MultisigError`
+
+### `ProposalExpired` (code 11)
+
+**Description:** The proposal has expired and can no longer be signed or executed.
+
+**Common cause:** Signing or executing a transaction proposal after its expiry ledger has passed.
+
+**Resolution:** Propose a new transaction; expired proposals cannot be revived.
+
+---
+
+### `InvalidWeight` (code 12)
+
+**Description:** A signer weight of zero was supplied.
+
+**Common cause:** Adding or configuring a signer with weight `0` in a weighted-multisig setup.
+
+**Resolution:** Every signer must have a weight of at least `1`.
+
+> See `contract-api.md` for the full `MultisigContract` public API and the
+> remaining `MultisigError` codes 1–10.
+
+---
+
+## NFT Contract — `NftError`
+
+### `NotAuthorized` (code 1)
+
+**Description:** The caller is not permitted to perform this action.
+
+**Common cause:** A non-admin address calling `mint`, or a non-owner calling `transfer`/`approve`.
+
+**Resolution:** Only the collection admin may `mint`; only a token's current owner may `transfer` or `approve` it.
+
+---
+
+### `AlreadyInitialized` (code 2)
+
+**Description:** `initialize` was called on a collection that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 3)
+
+**Description:** An operation was attempted before the collection was initialized.
+
+**Common cause:** Calling `mint`, `transfer`, or `owner_of` before `initialize`.
+
+**Resolution:** Call `initialize` with the admin, name, symbol, and optional supply/royalty settings first.
+
+---
+
+### `TokenNotFound` (code 4)
+
+**Description:** The referenced `token_id` does not exist.
+
+**Common cause:** Passing a `token_id` that was never minted to `owner_of`, `token_uri`, `transfer`, or `approve`.
+
+**Resolution:** Use a `token_id` returned by a prior `mint` call.
+
+---
+
+### `TokenAlreadyMinted` (code 5)
+
+**Description:** Reserved for a duplicate-mint guard on explicit token IDs. Included for completeness with the error enum; the current `mint` always assigns the next sequential ID, so this cannot be triggered through the public API today.
+
+**Common cause:** N/A in the current implementation.
+
+**Resolution:** N/A.
+
+---
+
+### `NotOwner` (code 6)
+
+**Description:** The caller does not own the referenced token.
+
+**Common cause:** An address that is not `owner_of(token_id)` attempting to transfer or approve it.
+
+**Resolution:** Only the current owner (per `owner_of`) may transfer or approve a token.
+
+---
+
+### `NotApproved` (code 7)
+
+**Description:** Reserved for approved-spender transfer checks. Included for completeness with the error enum; the current `transfer` only checks direct ownership, not an approved spender.
+
+**Common cause:** N/A in the current implementation.
+
+**Resolution:** N/A.
+
+---
+
+### `SupplyCapReached` (code 8)
+
+**Description:** Minting would exceed the collection's configured `max_supply`.
+
+**Common cause:** Calling `mint` after `total_supply()` has reached the cap set at `initialize`.
+
+**Resolution:** Check `total_supply()` against the collection's `max_supply` before minting further.
+
+---
+
+### `InvalidTokenId` (code 9)
+
+**Description:** Reserved for token-ID range validation. Included for completeness with the error enum; current entry points derive `token_id` internally rather than accepting it as caller input.
+
+**Common cause:** N/A in the current implementation.
+
+**Resolution:** N/A.
+
+---
+
+### `InvalidRoyalty` (code 10)
+
+**Description:** A royalty basis-points value exceeds 10 000 (100%).
+
+**Common cause:** Passing `royalty_bps > 10_000` to `initialize` or a per-token override to `mint`.
+
+**Resolution:** Keep royalty BPS values within `0`–`10_000`.
+
+---
+
+### `RoyaltyRecipientMissing` (code 11)
+
+**Description:** A royalty BPS was provided without a corresponding recipient (or vice versa).
+
+**Common cause:** Passing `royalty_bps > 0` without `royalty_recipient` (collection-level at `initialize`, or per-token at `mint`).
+
+**Resolution:** Always supply both `royalty_bps` and `royalty_recipient` together when configuring a non-zero royalty.
+
+---
+
+## Oracle Contract — `OracleError`
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `initialize` was called on an oracle that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the oracle was initialized.
+
+**Common cause:** Calling `update_price`, `get_price`, or `set_publishers` before `initialize`.
+
+**Resolution:** Call `initialize` with the admin and staleness threshold first.
+
+---
+
+### `Unauthorized` (code 3)
+
+**Description:** The caller is not the configured admin, or (for `submit_price`) not an authorized publisher.
+
+**Common cause:** A non-admin calling `update_price`/`set_publishers`, or a publisher not in the configured set calling `submit_price`.
+
+**Resolution:** Only the admin may push prices directly or configure publishers; only addresses passed to `set_publishers` may `submit_price`.
+
+---
+
+### `StalePrice` (code 4)
+
+**Description:** The stored price is older than the configured staleness threshold.
+
+**Common cause:** Calling `get_price` (ledger-based threshold) or `get_price_checked` (caller-supplied `max_age` in seconds) when no fresh price update has occurred recently.
+
+**Resolution:** Ensure the admin (or a publisher) has pushed a recent price before consumers read it, or widen the staleness tolerance if appropriate.
+
+---
+
+### `InvalidStalenessThreshold` (code 5)
+
+**Description:** `initialize` was called with a `staleness_threshold` of zero.
+
+**Common cause:** Passing `0` for `staleness_threshold`.
+
+**Resolution:** Set a positive number of ledgers for the staleness threshold.
+
+---
+
+### `NoPublisherData` (code 6)
+
+**Description:** No authorized publisher has a fresh price submission for `get_median_price`.
+
+**Common cause:** All publisher submissions are older than the requested `max_staleness_seconds`, or no publisher has ever called `submit_price`.
+
+**Resolution:** Ensure at least one authorized publisher submits a recent price, or widen `max_staleness_seconds`.
+
+---
+
+### `InsufficientHistory` (code 7)
+
+**Description:** No recorded price observation falls within the requested TWAP `window`.
+
+**Common cause:** Calling `get_twap` with a `window` shorter than the time since the last `update_price`/`submit_price` call.
+
+**Resolution:** Widen the `window`, or ensure prices are updated more frequently relative to the desired TWAP window.
+
+---
+
+## Staking Contract — `StakingError`
+
+### `CompoundTokenMismatch` (code 8)
+
+**Description:** `compound` was called but the stake token and reward token differ.
+
+**Common cause:** Calling `compound` on a pool configured with different stake and reward tokens, where compounding rewards back into the stake is not meaningful.
+
+**Resolution:** Only call `compound` on pools initialized with `stake_token == reward_token`; otherwise call `claim_rewards` instead.
+
+---
+
+### `UnbondingNotComplete` (code 9)
+
+**Description:** `withdraw` was called before the unbonding period elapsed.
+
+**Common cause:** Attempting to withdraw unbonded tokens before the ledger recorded in the `UnbondRequest` (`available_at`) has been reached.
+
+**Resolution:** Wait until the current ledger reaches the `available_at` ledger returned by the `unbond_requested` event before calling `withdraw`.
+
+---
+
+### `NoUnbondRequest` (code 10)
+
+**Description:** `withdraw` was called with no pending unbond request.
+
+**Common cause:** Calling `withdraw` without first calling `unstake` to queue an unbond request (or after already withdrawing it).
+
+**Resolution:** Call `unstake` to queue an unbond request before calling `withdraw`.
+
+---
+
+### `UnbondRequestPending` (code 11)
+
+**Description:** `unstake` was called while a pending unbond request already exists for this staker.
+
+**Common cause:** Calling `unstake` a second time before withdrawing (or cancelling) the first unbond request.
+
+**Resolution:** Complete the pending `withdraw` before queuing another `unstake`.
+
+> See `contract-api.md` for the full `StakingContract` public API and error
+> codes 1–7 (`AlreadyInitialized`, `NotInitialized`, `Unauthorized`,
+> `InvalidAmount`, `NoStake`, `InsufficientStake`, `NoRewards`).
+
+---
+
+## Subscription Contract — `SubscriptionError`
+
+### `AlreadyInitialized` (code 1)
+
+**Description:** `initialize` was called on a contract that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same deployed contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 2)
+
+**Description:** An operation was attempted before the contract was initialized.
+
+**Common cause:** Calling `register_plan`, `subscribe`, or `charge` before `initialize`.
+
+**Resolution:** Call `initialize` with the provider and payment token first.
+
+---
+
+### `NotAuthorized` (code 3)
+
+**Description:** The caller is not the configured provider.
+
+**Common cause:** A non-provider address calling `register_plan`, `set_plan_active`, or `charge`.
+
+**Resolution:** Only the address passed as `provider` to `initialize` may call these entry points.
+
+---
+
+### `InvalidAmount` (code 4)
+
+**Description:** `register_plan` was called with a non-positive `amount`.
+
+**Common cause:** Passing `amount <= 0`.
+
+**Resolution:** Set a positive per-interval charge amount.
+
+---
+
+### `InvalidInterval` (code 5)
+
+**Description:** `register_plan` was called with `interval_ledgers == 0`.
+
+**Common cause:** Passing a zero billing interval.
+
+**Resolution:** Set a positive number of ledgers between charges.
+
+---
+
+### `AlreadySubscribed` (code 6)
+
+**Description:** The subscriber already has an active subscription.
+
+**Common cause:** Calling `subscribe` while a prior subscription for the same address is still active.
+
+**Resolution:** Call `cancel` on the existing subscription before subscribing to a new plan, or check `get_subscription(address)` first.
+
+---
+
+### `NotSubscribed` (code 7)
+
+**Description:** No subscription record exists for the given subscriber.
+
+**Common cause:** Calling `charge` or `cancel` for an address that never called `subscribe`.
+
+**Resolution:** Confirm a subscription exists via `get_subscription(address)` before charging or cancelling.
+
+---
+
+### `SubscriptionInactive` (code 8)
+
+**Description:** The subscription has already been cancelled.
+
+**Common cause:** Calling `charge` or `cancel` a second time after `cancel` already ran.
+
+**Resolution:** Check `get_subscription(address).active` before acting on it; a cancelled subscriber must call `subscribe` again to resume.
+
+---
+
+### `IntervalNotElapsed` (code 9)
+
+**Description:** `charge` was called before the trial period or billing interval had fully elapsed.
+
+**Common cause:** Charging a subscriber too soon after the last charge (or before the configured `trial_ledgers` completed).
+
+**Resolution:** Wait until `last_charged_ledger + interval_ledgers` (or `+ trial_ledgers` during the trial) is reached before charging again.
+
+---
+
+### `InsufficientAllowance` (code 10)
+
+**Description:** The subscriber has not granted this contract enough token allowance to cover the charge.
+
+**Common cause:** The subscriber never called `token.approve`, or the allowance has been exhausted or expired.
+
+**Resolution:** Have the subscriber call `approve(subscriber, subscription_contract, amount * periods, expiry_ledger)` on the payment token with sufficient allowance.
+
+---
+
+### `PlanAlreadyExists` (code 11)
+
+**Description:** `register_plan` was called with a `plan_id` that already exists.
+
+**Common cause:** Registering the same plan ID twice.
+
+**Resolution:** Use `set_plan_active` to update an existing plan instead of re-registering it.
+
+---
+
+### `PlanNotFound` (code 12)
+
+**Description:** The referenced `plan_id` does not exist.
+
+**Common cause:** Calling `subscribe` or `set_plan_active` with a `plan_id` that was never registered.
+
+**Resolution:** Call `get_plan(plan_id)` to confirm the plan exists, or register it first via `register_plan`.
+
+---
+
+### `PlanInactive` (code 13)
+
+**Description:** `subscribe` was called for a plan the provider has deactivated.
+
+**Common cause:** Attempting to subscribe to a plan after the provider called `set_plan_active(plan_id, false)`.
+
+**Resolution:** Only subscribe to plans where `get_plan(plan_id).active == true`.
+
+---
+
+## Swap Contract — `SwapError`
+
+> **Note:** `contracts/swap/src/lib.rs` currently contains corrupted/duplicated
+> code (e.g. `set_fee_bps` and `get_fee_bps` are each defined twice, and some
+> branches reference states/errors like `SwapState::Pending`/`Accepted` and
+> `SwapError::SwapNotPending`/`SwapExpired` that don't exist in `storage.rs` /
+> `errors.rs`). This section is cross-checked against the authoritative
+> `errors.rs` enum below; see `contract-api.md` for how this affects the
+> documented public API.
+
+### `NotAuthorized` (code 1)
+
+**Description:** The caller is not permitted to perform this action.
+
+**Common cause:** Someone other than party A calling `cancel_swap`, or someone other than the admin calling admin-only setters.
+
+**Resolution:** Only the swap's proposing party (or the admin, for configuration) may perform restricted actions.
+
+---
+
+### `SwapNotFound` (code 2)
+
+**Description:** The referenced `swap_id` does not exist.
+
+**Common cause:** Passing a stale or invalid `swap_id` to `accept_swap`, `cancel_swap`, or `get_swap`.
+
+**Resolution:** Use the ID returned by `propose_swap`.
+
+---
+
+### `InvalidState` (code 3)
+
+**Description:** The swap is not in the `Open` state required for this operation.
+
+**Common cause:** Calling `accept_swap` or `cancel_swap` on a swap that was already completed or cancelled.
+
+**Resolution:** Check `get_swap(id).state` before acting on it.
+
+---
+
+### `DeadlineExpired` (code 4)
+
+**Description:** The swap's `expires_at` ledger has already passed.
+
+**Common cause:** Calling `accept_swap` after the proposed swap's expiry.
+
+**Resolution:** Accept before `get_swap(id).expires_at`; an expired swap can no longer be accepted.
+
+---
+
+### `InvalidAmount` (code 5)
+
+**Description:** A swap amount is zero or negative.
+
+**Common cause:** Passing `amount_a <= 0` or `amount_b <= 0` to `propose_swap`.
+
+**Resolution:** Propose swaps with strictly positive amounts on both sides.
+
+---
+
+### `InvalidDeadline` (code 6)
+
+**Description:** The supplied `expires_at` is not in the future.
+
+**Common cause:** Passing `expires_at <= current ledger` to `propose_swap`.
+
+**Resolution:** Choose an `expires_at` ledger sequence greater than the current one.
+
+---
+
+### `AlreadyCompleted` (code 7)
+
+**Description:** An operation was attempted on a swap that has already been accepted/completed.
+
+**Common cause:** Calling `cancel_swap` on a swap that `accept_swap` already settled.
+
+**Resolution:** Check `get_swap(id).state` before cancelling.
+
+---
+
+### `AlreadyCancelled` (code 8)
+
+**Description:** An operation was attempted on a swap that has already been cancelled.
+
+**Common cause:** Calling `accept_swap` or `cancel_swap` a second time after cancellation.
+
+**Resolution:** Check `get_swap(id).state` before acting on it.
+
+---
+
+### `AlreadyInitialized` (code 9)
+
+**Description:** `initialize` was called on a contract that has already been set up.
+
+**Common cause:** Calling `initialize` more than once on the same deployed contract instance.
+
+**Resolution:** `initialize` should only be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 10)
+
+**Description:** An operation was attempted before the contract was initialized.
+
+**Common cause:** Calling `propose_swap`, `set_admin`, or other entry points before `initialize`.
+
+**Resolution:** Call `initialize` with the admin and fee configuration first.
+
+---
+
+### `InvalidFee` (code 11)
+
+**Description:** A fee basis-points value exceeds 10 000 (100%).
+
+**Common cause:** Passing `fee_bps > 10_000` to `initialize` or `set_fee_bps`.
+
+**Resolution:** Keep fee BPS values within `0`–`10_000`.
+
+---
+
+## Timelock Contract — `TimelockError`
+
+### `NotAuthorized` (code 1)
+
+**Description:** The caller is not the admin.
+
+**Common cause:** A non-admin address calling `cancel` or `reassign_beneficiary`.
+
+**Resolution:** Only the address passed as `admin` to `initialize` (or `initialize_with_tranches`) may call these entry points.
+
+---
+
+### `AlreadyInitialized` (code 2)
+
+**Description:** `initialize` (or `initialize_with_tranches`) was called on a timelock that has already been set up.
+
+**Common cause:** Calling either initializer more than once on the same contract instance.
+
+**Resolution:** Only one of `initialize` / `initialize_with_tranches` should be called once, immediately after deployment.
+
+---
+
+### `NotInitialized` (code 3)
+
+**Description:** An operation was attempted before the timelock was initialized.
+
+**Common cause:** Calling `release`, `cancel`, or `get_info` before `initialize`/`initialize_with_tranches`.
+
+**Resolution:** Call one of the initializer functions first.
+
+---
+
+### `NotYetReleasable` (code 4)
+
+**Description:** `release` was called before any tranche (or the single release ledger) became due.
+
+**Common cause:** Calling `release` before the current ledger reaches `release_ledger` (single-tranche) or any tranche's `release_ledger` (multi-tranche).
+
+**Resolution:** Check `is_releasable()` before calling `release`.
+
+---
+
+### `AlreadyReleased` (code 5)
+
+**Description:** `release` or `cancel` was called after the timelock already fully released.
+
+**Common cause:** Calling `release` again once all tranches have been released, or calling `cancel` post-release.
+
+**Resolution:** Check `get_info().state` before acting; a fully released timelock is terminal.
+
+---
+
+### `AlreadyCancelled` (code 6)
+
+**Description:** `release` or `cancel` was called after the timelock was already cancelled.
+
+**Common cause:** Calling `cancel` twice, or calling `release` after cancellation.
+
+**Resolution:** Check `get_info().state` before acting; a cancelled timelock is terminal.
+
+---
+
+### `InvalidAmount` (code 7)
+
+**Description:** The lock amount (or a tranche amount) is zero, negative, or the tranches list is empty.
+
+**Common cause:** Passing `amount <= 0` to `initialize`, an empty `tranches` vec, or any `tranche.amount <= 0` to `initialize_with_tranches`.
+
+**Resolution:** Ensure every locked amount is strictly positive and at least one tranche is provided.
+
+---
+
+### `InvalidReleaseLedger` (code 8)
+
+**Description:** A release ledger is not strictly in the future relative to the prior tranche (or the current ledger).
+
+**Common cause:** Passing `release_ledger <= current ledger` to `initialize`, or tranches whose `release_ledger` values are not strictly increasing / not in the future, to `initialize_with_tranches`.
+
+**Resolution:** Choose release ledgers strictly greater than the current ledger, and (for tranches) strictly increasing across the schedule.
+
+---
+
+## Vesting Contract — `VestingError`
+
+### `CliffAlreadyPassed` (code 8)
+
+**Description:** An admin release action was attempted after the vesting cliff has already passed.
+
+**Common cause:** Calling an admin-only pre-cliff release adjustment once the beneficiary's cliff has already been reached.
+
+**Resolution:** Admin release actions gated by this check are only valid before `CliffLedger`; afterward the beneficiary should use `claim` directly.
+
+---
+
+### `ScheduleAlreadyExists` (code 9)
+
+**Description:** A vesting schedule already exists for the specified beneficiary.
+
+**Common cause:** Attempting to create a second schedule for a beneficiary that already has one.
+
+**Resolution:** Check for an existing schedule (e.g. via `get_vested_amount`/`get_claimed_amount`) before creating a new one for the same beneficiary.
+
+---
+
+### `ScheduleNotFound` (code 10)
+
+**Description:** No vesting schedule was found for the specified beneficiary.
+
+**Common cause:** Querying or claiming against a beneficiary address that was never set up with a schedule.
+
+**Resolution:** Confirm the beneficiary address matches the one used when the schedule was created.
+
+> See `contract-api.md` for the full `VestingContract` public API and error
+> codes 1–7 (`AlreadyInitialized`, `NotInitialized`, `NotAuthorized`,
+> `InvalidAmount`, `InvalidSchedule`, `NothingToClaim`, `AlreadyRevoked`).

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -172,6 +172,214 @@ behind the `pausable` feature) pending investigation.
 
 ---
 
+### Airdrop Contract Events
+
+Events emitted by `contracts/airdrop`:
+
+| Event | Topic[0] | Data |
+|-------|----------|------|
+| `root_set` | `Symbol("root_set")` | `Bytes` (new merkle root) |
+| `claimed` | `Symbol("claimed")` | `(Address recipient, i128 amount)` |
+
+`claim_batch` emits one `claimed` event per successful entry rather than a single batch event.
+
+### Auction Contract Events
+
+Events emitted by `contracts/auction`:
+
+| Event | Topic[0] | Topic[1] | Data |
+|-------|----------|----------|------|
+| `started` | `Symbol("started")` | `Address` (seller) | `(i128 start_price, u32 deadline)` |
+| `bid_placed` | `Symbol("bid_placed")` | `Address` (bidder) | `i128` (amount) |
+| `ended` | `Symbol("ended")` | `Address` (winner) | `i128` (amount) |
+| `ended_no_bids` | `Symbol("ended_no_bids")` | — | `()` |
+| `ended_reserve_not_met` | `Symbol("ended_reserve_not_met")` | `Address` (highest bidder) | `(i128 highest_bid, i128 reserve_price)` |
+| `withdrawn` | `Symbol("withdrawn")` | `Address` (bidder) | `i128` (amount) |
+| `deadline_extended` | `Symbol("deadline_extended")` | — | `u32` (new deadline) |
+| `cancelled` | `Symbol("cancelled")` | `Address` (seller) | `()` |
+
+`deadline_extended` fires whenever a bid lands inside the anti-sniping `extension_window`; a monitoring job tracking auction end times should re-read `get_info().deadline` after each `bid_placed` rather than caching the value from `started`.
+
+### Ballot Contract Events
+
+Events emitted by `contracts/ballot`:
+
+| Event | Topic[0] | Data |
+|-------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (admin) |
+| `voter_registered` | `Symbol("voter_registered")` | `Address` (voter) |
+| `voter_deregistered` | `Symbol("voter_deregistered")` | `Address` (voter) |
+| `voted` | `Symbol("voted")` | `(Address voter, u32 choice)` |
+| `tally_result` | `Symbol("tally_result")` | `(i128 yes, i128 no)` — legacy two-choice tally |
+| `tally_all_result` | `Symbol("tally_all_result")` | `Vec<i128>` (per-choice counts, in `choices` order) |
+
+### Bonding Curve Contract Events
+
+Events emitted by `contracts/bonding-curve`:
+
+| Event | Topic[0] | Data |
+|-------|----------|------|
+| `initialized` | `Symbol("initialized")` | `(Address admin, Address token)` |
+| `bought` | `Symbol("bought")` | `(Address buyer, i128 tokens, i128 cost)` |
+| `sold` | `Symbol("sold")` | `(Address seller, i128 tokens, i128 proceeds)` |
+
+### Crowdfund Contract Events
+
+Events emitted by `contracts/crowdfund`:
+
+| Event | Topic[0] | Topic[1] | Data |
+|-------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (creator) | `(i128 goal, u32 deadline)` |
+| `pledged` | `Symbol("pledged")` | `Address` (pledger) | `(i128 amount, i128 new_total)` |
+| `withdrawn` | `Symbol("withdrawn")` | `Address` (pledger) | `i128` (amount) |
+| `claimed` | `Symbol("claimed")` | `Address` (creator) | `i128` (amount) |
+| `refunded` | `Symbol("refunded")` | `Address` (pledger) | `i128` (amount) |
+| `deadline_extended` | `Symbol("deadline_extended")` | `Address` (creator) | `u32` (new deadline) |
+
+### DAO Contract Events
+
+Events emitted by `contracts/dao`:
+
+| Event | Topic[0] | Topic[1] | Data |
+|-------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (admin), `Address` (token) | `i128` (quorum) |
+| `created` | `Symbol("created")` | `Address` (proposer) | `u32` (proposal_id) |
+| `voted` | `Symbol("voted")` | `Address` (voter) | `(u32 proposal_id, bool support, i128 weight)` |
+| `executed` | `Symbol("executed")` | — | `u32` (proposal_id) |
+| `cancelled` | `Symbol("cancelled")` | `Address` (admin) | `u32` (proposal_id) |
+| `prop_cancelled` | `Symbol("prop_cancelled")` | `Address` (proposer) | `u32` (proposal_id) |
+
+`created` is emitted by `create_proposal`, `executed` by `execute_proposal`, `cancelled` by admin `cancel_proposal`, and `prop_cancelled` by the proposer's own `proposer_cancel_proposal` — distinguish the last two when alerting on cancellations, since they indicate different actors.
+
+### Lottery Contract Events
+
+Events emitted by `contracts/lottery`:
+
+| Event | Topic[0] | Topic[1] | Data |
+|-------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (admin) | `i128` (ticket_price) |
+| `ticket_purchased` | `Symbol("ticket_purchased")` | `Address` (buyer) | `()` |
+| `committed` | `Symbol("committed")` | `Address` (admin) | `()` |
+| `winner_drawn` | `Symbol("winner_drawn")` | `Address` (winner) | `i128` (prize) |
+| `refund_claimed` | `Symbol("refund_claimed")` | `Address` (buyer) | `i128` (amount) |
+
+`winner_drawn` fires once per winner selected by `draw` (up to `winner_count` times in one transaction) — an indexer counting winners per drawing should aggregate by transaction/ledger, not assume exactly one event per draw.
+
+### Marketplace Contract Events
+
+Events emitted by `contracts/marketplace`:
+
+| Event | Topic[0] | Topic[1] | Data |
+|-------|----------|----------|------|
+| `listed` | `Symbol("listed")` | `u64` (listing_id) | `(Address seller, i128 price)` |
+| `sold` | `Symbol("sold")` | `u64` (listing_id) | `(Address buyer, i128 price)` |
+| `cancel` | `Symbol("cancel")` | `u64` (listing_id) | `Address` (seller) |
+| `swept` | `Symbol("swept")` | `u64` (listing_id) | `Address` (seller) |
+| `offered` | `Symbol("offered")` | `u64` (listing_id) | `(Address buyer, i128 amount)` |
+| `offracc` | `Symbol("offracc")` | `u64` (listing_id) | `(Address buyer, i128 amount)` |
+| `offrcncl` | `Symbol("offrcncl")` | `u64` (listing_id) | `Address` (buyer) |
+
+Topic symbols are truncated to fit `symbol_short!`'s 9-character limit: `cancel` = listing cancelled, `offered` = offer made, `offracc` = offer accepted, `offrcncl` = offer cancelled. As noted in `error-reference.md` and `contract-api.md`, `contracts/marketplace/src/lib.rs` currently has no working code path that emits `offered` or `offracc` (offer creation isn't implemented, and the offer-accept logic is bound to a broken duplicate function) — an indexer should not expect to see those two in practice until that's fixed.
+
+### Multisig Contract Events
+
+Events emitted by `contracts/multisig`:
+
+| Event | Topic[0] | Topic[1] | Topic[2] | Data |
+|-------|----------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `u32` (threshold) | — | `u32` (signer_count) |
+| `added` | `Symbol("added")` | `Address` (signer) | — | `u32` (new threshold) |
+| `removed` | `Symbol("removed")` | `Address` (signer) | — | `u32` (new threshold) |
+| `proposed` | `Symbol("proposed")` | `Address` (proposer) | — | `u64` (tx_id) |
+| `signed` | `Symbol("signed")` | `Address` (signer) | `u64` (tx_id) | `u32` (signature_count) |
+| `executed` | `Symbol("executed")` | `u64` (tx_id) | — | `()` |
+| `expired` | `Symbol("expired")` | `u64` (tx_id) | — | `()` |
+| `batch_executed` | `Symbol("batch_executed")` | — | — | `(Vec<u64> executed_ids, u32 skipped_count)` |
+
+`batch_executed` summarizes an `execute_batch` call; cross-reference `executed_ids` against individual `executed` events if per-transaction detail is needed for skipped entries.
+
+### NFT Contract Events
+
+Events emitted by `contracts/nft`:
+
+| Event | Topic[0] | Topic[1] | Topic[2] | Data |
+|-------|----------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (admin) | — | `(String name, String symbol)` |
+| `minted` | `Symbol("minted")` | `Address` (to) | — | `u32` (token_id) |
+| `transferred` | `Symbol("transferred")` | `Address` (from) | `Address` (to) | `u32` (token_id) |
+| `burned` | `Symbol("burned")` | `Address` (from) | — | `u32` (token_id) |
+| `approved` | `Symbol("approved")` | `Address` (owner) | `Address` (spender) | `u32` (token_id) |
+
+`burned` is defined in `events.rs` but there is currently no `burn` entry point in `lib.rs` that calls it — an indexer should not expect to observe this event until burning is implemented.
+
+### Oracle Contract Events
+
+Events emitted by `contracts/oracle`:
+
+| Event | Topic[0] | Topic[1] | Data |
+|-------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (admin) | `u32` (staleness_threshold) |
+| `price_updated` | `Symbol("price_updated")` | `Address` (admin) | `(i128 price, u32 ledger)` |
+| `price_submitted` | `Symbol("price_submitted")` | `Address` (publisher) | `(i128 price, u64 timestamp)` |
+
+`price_updated` comes from the single-admin `update_price` path; `price_submitted` comes from the multi-publisher `submit_price` path used by `get_median_price`/`get_twap`. A monitoring job computing price-change alerts should watch both.
+
+### Staking Contract Events
+
+Events emitted by `contracts/staking`:
+
+| Event | Topic[0] | Topic[1] | Topic[2] | Data |
+|-------|----------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (admin) | — | `(Address stake_token, Address reward_token)` |
+| `staked` | `Symbol("staked")` | `Address` (staker) | — | `(i128 amount, i128 new_total)` |
+| `unstaked` | `Symbol("unstaked")` | `Address` (staker) | — | `(i128 amount, i128 remaining)` |
+| `claimed_rewards` | `Symbol("claimed_rewards")` | `Address` (staker) | — | `i128` (amount) |
+| `added_rewards` | `Symbol("added_rewards")` | `Address` (admin) | — | `(i128 amount, i128 new_total)` |
+| `compounded` | `Symbol("compounded")` | `Address` (staker) | — | `(i128 reward, i128 new_stake)` |
+| `slashed` | `Symbol("slashed")` | `Address` (admin) | `Address` (staker) | `(i128 amount, Address destination)` |
+| `unbond_requested` | `Symbol("unbond_requested")` | `Address` (staker) | — | `(i128 amount, u32 available_at)` |
+| `withdrawn` | `Symbol("withdrawn")` | `Address` (staker) | — | `i128` (amount) |
+
+`slashed` is a high-severity signal worth alerting on every occurrence. `unbond_requested`'s `available_at` is the ledger sequence after which the corresponding `withdrawn` becomes callable — useful for building an unbonding-queue dashboard.
+
+### Swap Contract Events
+
+Events emitted by `contracts/swap`:
+
+| Event | Topic[0] | Topic[1] | Data |
+|-------|----------|----------|------|
+| `proposed` | `Symbol("proposed")` | `Address` (party_a) | `(u32 swap_id, Address token_a, i128 amount_a, Address token_b, i128 amount_b, u32 expires_at)` |
+| `accepted` | `Symbol("accepted")` | `Address` (party_b) | `u32` (swap_id) |
+| `cancelled` | `Symbol("cancelled")` | — | `u32` (swap_id) |
+
+As noted in `error-reference.md` and `contract-api.md`, `contracts/swap/src/lib.rs` currently calls `events::swap_cancelled` with a mismatched argument count relative to the `swap_cancelled(env, swap_id)` signature in `events.rs`; this table reflects the authoritative `events.rs` definition.
+
+### Timelock Contract Events
+
+Events emitted by `contracts/timelock`:
+
+| Event | Topic[0] | Topic[1] | Topic[2] | Data |
+|-------|----------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (admin) | `Address` (beneficiary) | `(u32 release_ledger, i128 amount)` |
+| `released` | `Symbol("released")` | `Address` (beneficiary) | — | `i128` (amount) |
+| `cancelled` | `Symbol("cancelled")` | `Address` (admin) | — | `i128` (amount) |
+| `beneficiary_reassigned` | `Symbol("beneficiary_reassigned")` | `Address` (admin) | `Address` (old beneficiary), `Address` (new beneficiary) | `()` |
+
+For a multi-tranche timelock (`initialize_with_tranches`), `initialized` reports the first tranche's ledger/amount and `released` may fire multiple times (once per tranche release) before the timelock's state finally transitions to `Released`.
+
+### Vesting Contract Events
+
+Events emitted by `contracts/vesting`:
+
+| Event | Topic[0] | Topic[1] | Data |
+|-------|----------|----------|------|
+| `initialized` | `Symbol("initialized")` | `Address` (beneficiary) | `(i128 amount, u32 cliff_ledger, u32 end_ledger)` |
+| `claimed` | `Symbol("claimed")` | `Address` (beneficiary) | `i128` (amount) |
+| `revoked` | `Symbol("revoked")` | `Address` (beneficiary) | `(Address admin, i128 returned)` |
+| `admin_released` | `Symbol("admin_released")` | `Address` (admin) | `i128` (amount) |
+
+---
+
 ## 4. Decoding Events
 
 Events are XDR-encoded on-chain. Use the Stellar CLI or SDK to decode them.

--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -129,6 +129,268 @@ This document details the storage keys, types, and TTL management policy for eac
 
 ---
 
+## Airdrop Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Admin address |
+| `Token` | Instance | `Address` | Extended on init | Payment token address |
+| `MerkleRoot` | Instance | `Bytes` | Extended on `set_root` | Merkle root of the distribution tree |
+| `ClaimDeadline` | Instance | `u32` | Extended on init | Ledger sequence after which claims are rejected |
+| `Claimed(Address)` | Persistent | `bool` | Extended on claim | Whether a given address has already claimed |
+
+Uses per-address persistent storage (`Claimed(Address)`) to prevent duplicate claims, alongside instance storage for the (rarely-changed) root and deadline.
+
+---
+
+## Auction Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Seller` | Instance | `Address` | Extended on init | Seller address |
+| `Token` | Instance | `Address` | Extended on init | Bid token address |
+| `StartPrice` | Instance | `i128` | Extended on init | Starting bid price |
+| `MinIncrement` | Instance | `i128` | Extended on init | Minimum bid increment |
+| `Deadline` | Instance | `u32` | Extended on bid (anti-sniping) | Auction end ledger; may be pushed back by a late bid |
+| `HighestBidder` | Instance | `Address` | Extended on bid | Current highest bidder |
+| `HighestBid` | Instance | `i128` | Extended on bid | Current highest bid amount |
+| `Settled` | Instance | `bool` | Extended on `end` | Whether the auction has been settled |
+| `ReservePrice` | Instance | `i128` | Extended on init | Optional reserve price |
+| `Pending(Address)` | Persistent | `i128` | Extended on bid | Refund owed to an outbid bidder |
+| `ExtensionWindow` | Instance | `u32` | Extended on init | Anti-sniping extension window in ledgers (0 = disabled) |
+| `Cancelled` | Instance | `bool` | Extended on `cancel` | Whether the seller cancelled before any bid |
+
+Per-address persistent storage (`Pending(Address)`) tracks outbid-bidder refunds independently of the single instance-storage auction state.
+
+---
+
+## Ballot Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Contract administrator |
+| `VotingActive` | Instance | `bool` | Extended on `tally`/`tally_all` | Whether voting is still open |
+| `RegisteredVoter(Address)` | Persistent | `bool` | Extended on register/vote | Whether an address is a registered voter |
+| `Voter(Address)` | Persistent | `bool` | Extended on vote | Whether an address has already voted |
+| `YesVotes` | Instance | `i128` | Extended on vote | Backward-compat yes counter (choice index 1) |
+| `NoVotes` | Instance | `i128` | Extended on vote | Backward-compat no counter (choice index 0) |
+| `VotingStart` | Instance | `u32` | Extended on init | First ledger at which voting opens |
+| `VotingEnd` | Instance | `u32` | Extended on init | Last ledger at which voting is open |
+| `TotalVotes` | Instance | `i128` | Extended on vote | Running total votes cast; gates `deregister_voter` |
+| `Choices` | Instance | `Vec<String>` | Extended on init | Ordered list of choice labels |
+| `ChoiceVotes(u32)` | Instance | `i128` | Extended on vote | Per-choice vote tally |
+
+Per-address persistent storage (`RegisteredVoter`, `Voter`) tracks voter eligibility and participation; all tallies live in instance storage since they're bounded by the fixed `choices` list.
+
+---
+
+## Bonding Curve Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Contract administrator |
+| `Token` | Instance | `Address` | Extended on init | Reserve token address |
+| `Reserve` | Instance | `i128` | Extended on buy/sell | Token reserve held by the contract |
+| `Supply` | Instance | `i128` | Extended on buy/sell | Current curve-token supply |
+| `Price` | Instance | `i128` | Extended on buy/sell | Current price per token (scaled by `PRICE_SCALE = 1_000_000`) |
+
+Instance-only storage — no per-address state — since the curve's price is a pure function of the shared `reserve`/`supply` pair.
+
+---
+
+## Crowdfund Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Creator` | Instance | `Address` | Extended on init | Campaign creator |
+| `Token` | Instance | `Address` | Extended on init | Pledge token address |
+| `Goal` | Instance | `i128` | Extended on init | Funding goal |
+| `Deadline` | Instance | `u32` | Extended on `extend_deadline` | Campaign deadline ledger |
+| `TotalPledged` | Instance | `i128` | Extended on pledge/withdraw | Running total pledged |
+| `Claimed` | Instance | `bool` | Extended on `claim` | Whether the creator has claimed the funds |
+| `Pledge(Address)` | Persistent | `i128` | Extended on pledge | Per-pledger cumulative pledge amount |
+| `Tiers` | Instance | `Vec<FundingTier>` | Extended on init | Optional stretch-goal reward tiers |
+| `MaxPledgePerAddress` | Instance | `i128` | Extended on init | Optional per-address pledge cap |
+| `DeadlineExtended` | Instance | `bool` | Extended on `extend_deadline` | Whether the one-time deadline extension has been used |
+
+Per-address persistent storage (`Pledge(Address)`) tracks individual contributions, gated against `MaxPledgePerAddress` when configured.
+
+---
+
+## Lottery Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Contract administrator |
+| `Token` | Instance | `Address` | Extended on init | Ticket payment token |
+| `TicketPrice` | Instance | `i128` | Extended on init | Price per ticket |
+| `Participants` | Instance | `Vec<Address>` | Extended on ticket purchase/refund | List of ticket-holding addresses (one entry per ticket) |
+| `State` | Instance | `LotteryState` | Extended on state change | `Open` \| `Committed` \| `Drawn` |
+| `Commit` | Instance | `Commit` | Extended on `commit` | Stored `hash(secret \|\| salt)` commitment |
+| `Winner` | Instance | `Address` | Extended on `draw` | First (or only) winner address |
+| `Winners` | Instance | `Vec<Address>` | Extended on `draw` | All winner addresses |
+| `RevealDeadline` | Instance | `u32` | Extended on `commit` | Ledger by which `draw` must be called |
+| `WinnerCount` | Instance | `u32` | Extended on init | Number of distinct winners to select |
+| `PrizeSplits` | Instance | `Vec<u32>` | Extended on init | Per-winner prize share, in basis points (sums to 10 000) |
+| `MaxTicketsPerAddress` | Instance | `u32` | Extended on init | Optional per-address ticket cap |
+| `TicketCount(Address)` | Persistent | `u32` | Extended on ticket purchase | Per-address ticket count, gated against the cap |
+
+Uses per-address persistent storage (`TicketCount`) for the ticket cap, while the participant list itself (used for weighted draw and refunds) lives in instance storage.
+
+---
+
+## Marketplace Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Admin address |
+| `PaymentToken` | Instance | `Address` | Extended on init | Token used to pay for listings |
+| `RoyaltyBps` | Instance | `u32` | Extended on init | Royalty in basis points (e.g. `250` = 2.5%) |
+| `RoyaltyRecipient` | Instance | `Address` | Extended on init | Royalty recipient address |
+| `NextListingId` | Instance | `u64` | Extended on `list` | Auto-incrementing listing ID counter |
+| `Listing(u64)` | Persistent | `Listing` | Extended on list/buy/cancel | Per-listing seller, price, and active state |
+| `Offer(u64, Address)` | Persistent | `i128` | Extended on offer activity | Escrowed offer amount for a `(listing_id, buyer)` pair |
+
+Per-listing (`Listing(u64)`) and per-`(listing, buyer)` (`Offer`) persistent keys let each listing/offer expire independently of the shared instance config. See `contract-api.md` and `error-reference.md` for a note on `contracts/marketplace/src/lib.rs` currently containing corrupted/duplicated code — this storage layout reflects the authoritative `storage.rs` definitions.
+
+---
+
+## NFT Contract
+
+### Instance-Storage Keys (`DataKey`)
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Collection administrator |
+| `Name` | Instance | `String` | Extended on init | Collection name |
+| `Symbol` | Instance | `String` | Extended on init | Collection symbol |
+| `TotalSupply` | Instance | `u32` | Extended on mint | Number of tokens minted so far |
+| `MaxSupply` | Instance | `u32` | Extended on init | Optional supply cap |
+| `Initialized` | Instance | `bool` | Extended on init | Whether the contract has been initialized |
+| `RoyaltyBps` | Instance | `u32` | Extended on init | Collection-level default royalty in basis points |
+| `RoyaltyRecipient` | Instance | `Address` | Extended on init | Collection-level default royalty recipient |
+
+### Persistent-Storage Keys (`TokenKey`)
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Owner(u32)` | Persistent | `Address` | Extended on mint/transfer | Current owner of a token ID |
+| `Approval(u32)` | Persistent | `Address` | Extended on approve | Approved spender for a token ID |
+| `Uri(u32)` | Persistent | `String` | Extended on mint | Metadata URI for a token ID |
+| `TokenRoyaltyBps(u32)` | Persistent | `u32` | Extended on mint | Optional per-token royalty override (basis points) |
+| `TokenRoyaltyRecipient(u32)` | Persistent | `Address` | Extended on mint | Optional per-token royalty recipient override |
+
+Despite the doc comment on `TokenKey` describing it as persistent-tier, per-token owner/URI/royalty data is stored under `env.storage().instance()` in the current `lib.rs` rather than `env.storage().persistent()` — see `error-reference.md`'s NFT section for related `lib.rs`/`errors.rs` naming drift (e.g. `Unauthorized` vs. `NotAuthorized`, `MaxSupplyReached` vs. `SupplyCapReached`) that a future fix should reconcile alongside this.
+
+---
+
+## Oracle Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Admin authorized to push prices |
+| `Price` | Instance | `i128` | Extended on `update_price` | Most recently published price |
+| `UpdatedAt` | Instance | `u32` | Extended on `update_price` | Ledger sequence of the last price update |
+| `StalenessThreshold` | Instance | `u32` | Extended on init | Max age (in ledgers) before `get_price` rejects the price |
+| `UpdatedAtTimestamp` | Instance | `u64` | Extended on `update_price` | Unix timestamp of the last price update |
+| `Publishers` | Instance | `Vec<Address>` | Extended on `set_publishers` | Admin-configured set of authorized publishers |
+| `Submission(Address)` | Persistent | `PublisherSubmission` | Extended on `submit_price` | Latest submission from a given publisher |
+| `History` | Instance | `Vec<PriceObservation>` | Extended on price update | Ring buffer of the last `MAX_HISTORY` (30) observations, used for `get_twap` |
+
+Per-publisher persistent storage (`Submission(Address)`) supports the multi-publisher median-price feature independently of the single admin-pushed `Price`.
+
+---
+
+## Subscription Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Provider` | Instance | `Address` | Extended on init | Service provider address |
+| `Token` | Instance | `Address` | Extended on init | Payment token address |
+| `Subscription(Address)` | Persistent | `SubscriptionInfo` | Extended on subscribe/charge/cancel | Per-subscriber plan, trial, and billing state |
+| `Plan(Symbol)` | Persistent | `Plan` | Extended on register/update | Named plan configuration (amount, interval, active) |
+
+Per-subscriber (`Subscription(Address)`) and per-plan (`Plan(Symbol)`) persistent keys let individual subscriptions and plans expire independently of the shared `Provider`/`Token` instance config.
+
+---
+
+## Swap Contract
+
+### Instance-Storage Keys (`DataKey`)
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `SwapCount` | Instance | `u32` | Extended on `propose_swap` | Auto-incrementing swap ID counter |
+| `Initialized` | Instance | `bool` | Extended on init | Whether the contract has been initialized |
+| `Admin` | Instance | `Address` | Extended on init | Contract administrator |
+| `Treasury` | Instance | `Address` | Extended on `set_treasury` | Fee-collection treasury address |
+| `FeeBps` | Instance | `u32` | Extended on init/`set_fee_bps` | Swap fee in basis points |
+
+### Persistent-Storage Keys (`SwapKey`)
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Swap(u32)` | Persistent | `SwapInfo` | Extended on propose/accept/cancel | Per-swap parties, tokens, amounts, expiry, and state |
+
+Per-swap persistent storage (`Swap(u32)`) lets each proposed swap expire independently of the shared instance config. See `error-reference.md`'s Swap section for a note on `contracts/swap/src/lib.rs` currently containing corrupted/duplicated code; this storage layout reflects the authoritative `storage.rs` definitions.
+
+---
+
+## Timelock Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Contract administrator |
+| `Token` | Instance | `Address` | Extended on init | Locked token address |
+| `Beneficiary` | Instance | `Address` | Extended on init/`reassign_beneficiary` | Recipient of released tokens |
+| `ReleaseLedger` | Instance | `u32` | Extended on init | Deprecated: single-tranche release ledger (backward compat) |
+| `Amount` | Instance | `i128` | Extended on init | Deprecated: single-tranche amount (backward compat) |
+| `State` | Instance | `TimelockState` | Extended on release/cancel | `Active` \| `Released` \| `Cancelled` |
+| `Tranches` | Instance | `Vec<ReleaseTranche>` | Extended on `initialize_with_tranches` | Multi-tranche release schedule |
+| `ReleasedTranches` | Instance | `Vec<bool>` | Extended on `release` | Per-tranche release flags, indexed by tranche position |
+
+Instance-only storage — a single timelock instance has one admin/beneficiary/schedule, so there's no per-address fan-out the way there is in per-user contracts like Token or Staking.
+
+---
+
+## Wrapped-Token Contract
+
+### Storage Keys
+
+| Key | Tier | Type | TTL Policy | Description |
+|-----|------|------|------------|-------------|
+| `Admin` | Instance | `Address` | Extended on init | Contract administrator |
+| `WrappedToken` | Instance | `Address` | Extended on init | Wrapped (minted) token contract address |
+| `UnderlyingToken` | Instance | `Address` | Extended on init | Underlying (reserve) token contract address |
+| `TotalWrapped` | Instance | `i128` | Extended on wrap/unwrap | Contract-tracked total wrapped supply |
+| `Paused` | Instance | `bool` | Extended on pause/unpause | Whether the contract is paused (`pausable` feature only) |
+| `MaxWrapPerAddress` | Instance | `i128` | Extended on init | Optional cap on cumulative wrap per address |
+| `WrappedByAddress(Address)` | Persistent | `i128` | Extended on wrap | Cumulative amount wrapped so far by an address (only tracked when a cap is set) |
+
+**Storage-key stability:** the `DataKey` enum's variant order is covered by an exhaustive discriminant test (`discriminant_tests::data_key_discriminants_are_stable`) — new keys must be appended at the end, never inserted or reordered, since Soroban's `#[contracttype]` encoding uses the variant name/position as the on-chain storage discriminant.
+
+---
+
 ## TTL Extension Strategy
 
 ### Instance vs. Persistent


### PR DESCRIPTION

## Summary

  Four of the repo's reference docs only documented a handful of the 19 contracts, despite the same information already existing per-contract in each contract's own
  errors.rs/storage.rs/lib.rs/events.rs. This PR brings all four docs to full 19-contract coverage, cross-checked against the actual source in each contract directory.

  - docs/error-reference.md — added a section per remaining contract (airdrop, auction, ballot, bonding-curve, crowdfund, dao, lottery, marketplace, multisig, nft, oracle, staking,
  subscription, swap, timelock, vesting).
  - docs/storage-layout.md — added a section per remaining contract (airdrop, auction, ballot, bonding-curve, crowdfund, lottery, marketplace, nft, oracle, subscription, swap, timelock,
  wrapped-token).
  - docs/contract-api.md — added a section per remaining contract (airdrop, auction, ballot, bonding-curve, crowdfund, dao, lottery, marketplace, nft, oracle, subscription, swap, timelock,
  wrapped-token).
  - docs/monitoring.md (§3 Event Schema) — added a subsection per remaining contract (airdrop, auction, ballot, bonding-curve, crowdfund, dao, lottery, marketplace, multisig, nft, oracle,
  staking, swap, timelock, vesting).

  ### Pre-existing issues surfaced (documented, not fixed here)

  - contracts/marketplace/src/lib.rs currently contains corrupted/duplicated code (conflicting duplicate get_active_listings definitions, references to error variants/types not present in the
  crate, no function that creates an Offer).
  - contracts/swap/src/lib.rs similarly has duplicate set_fee_bps/get_fee_bps definitions and references states/errors that don't exist in storage.rs/errors.rs.
  Both sections document the authoritative errors.rs/storage.rs/events.rs for those contracts, flagging the drift inline for a separate fix.

  Closes #957
  Closes #958
  Closes #959
  Closes #960
