### PR TITLE
docs: expand monitoring alerts and contract security guidance

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -764,3 +764,71 @@ Prometheus datasource and the metrics described in §10. Replace the
 - [Stellar Expert Explorer](https://stellar.expert)
 - [soroban-sdk event docs](https://docs.rs/soroban-sdk/latest/soroban_sdk/struct.Events.html)
 - [XDR types reference](https://developers.stellar.org/docs/learn/fundamentals/transactions/list-of-operations)
+
+
+## 8. Failed-Transaction Alert Rules
+
+The examples below assume an indexer exports monotonically increasing counters named `soroban_transactions_total` and `soroban_transaction_failures_total`, each labeled with `contract_id` and `contract_name`. Adjust the window and thresholds to the normal traffic profile of each deployment; use `for` to avoid paging on a single transient failure.
+
+```yaml
+groups:
+  - name: soroban-transaction-health
+    rules:
+      - alert: SorobanContractFailureRateHigh
+        expr: |
+          (
+            sum by (contract_id, contract_name) (
+              increase(soroban_transaction_failures_total[10m])
+            )
+            /
+            clamp_min(
+              sum by (contract_id, contract_name) (
+                increase(soroban_transactions_total[10m])
+              ), 1
+            )
+          ) > 0.10
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Elevated failed-transaction rate for {{ $labels.contract_name }}"
+          description: "More than 10% of transactions failed for 15 minutes. Check recent deployments, authorization errors, and dependency health."
+
+      - alert: SorobanContractFailureRateCritical
+        expr: |
+          (
+            sum by (contract_id, contract_name) (
+              increase(soroban_transaction_failures_total[5m])
+            )
+            /
+            clamp_min(
+              sum by (contract_id, contract_name) (
+                increase(soroban_transactions_total[5m])
+              ), 1
+            )
+          ) > 0.25
+          and
+          sum by (contract_id, contract_name) (
+            increase(soroban_transactions_total[5m])
+          ) >= 20
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical failed-transaction rate for {{ $labels.contract_name }}"
+          description: "At least 20 transactions were observed and more than 25% failed in each five-minute window. Investigate immediately and consider pausing the affected contract."
+
+      - alert: SorobanContractFailureBurst
+        expr: |
+          sum by (contract_id, contract_name) (
+            increase(soroban_transaction_failures_total[5m])
+          ) >= 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Failed-transaction burst for {{ $labels.contract_name }}"
+          description: "At least 10 failed transactions occurred in five minutes. This catches incidents even when total traffic is too low for a percentage threshold."
+```
+
+The 10% warning threshold is intended to identify degradation before it becomes a widespread outage. The 25% critical threshold requires at least 20 attempts so that a low-volume contract does not page on a single failure. The burst rule is complementary: it detects a sustained absolute spike and is useful for contracts with uneven traffic. Route alerts by `contract_id`, include the deployment environment in the metric labels, and link each alert to the relevant runbook and transaction/event dashboard.

--- a/docs/security.md
+++ b/docs/security.md
@@ -233,3 +233,121 @@ For detailed per-contract breakdown, see the individual contract documentation i
 ---
 
 For the front-running risk assessment, see [front-running-risk-assessment.md](front-running-risk-assessment.md).
+
+## Newer Contract Security Considerations
+
+The following sections cover the newer contracts in the template. The role boundaries and compromise outcomes are summarized in the [Threat Model](threat-model.md); deployment teams should review both documents before funding or configuring an instance.
+
+### Airdrop
+
+**Trust assumptions.** The administrator is trusted to publish the intended Merkle root and to protect the root-management key. Recipients are trusted only to submit proofs for their own allocations.
+
+**Known limitations.** Replacing the root can change every unclaimed allocation, and a recipient cannot recover a claim made against an earlier root. Merkle proofs establish inclusion, not the correctness of the allocation file supplied by the administrator.
+
+**Safe deployment.** Verify the root and allocation manifest independently, announce root changes, fund the contract only after verification, and monitor `root_set` and `claimed` events. See [Threat Model — Airdrop](threat-model.md#airdrop).
+
+### Auction
+
+**Trust assumptions.** The seller controls the lot and auction parameters; bidders trust the contract to escrow and return bid funds according to its state machine. Settlement is permissionless.
+
+**Known limitations.** The seller can cancel only before a bid, and anti-sniping deadline extensions affect the expected close time. The contract does not independently attest to the quality or authenticity of the lot.
+
+**Safe deployment.** Confirm seller and asset metadata off-chain, set a realistic reserve and deadline, and monitor bids, deadline extensions, withdrawals, and terminal events. See [Threat Model — Auction](threat-model.md#auction).
+
+### Ballot
+
+**Trust assumptions.** The administrator is trusted to register the intended voters and to call tally at an appropriate time. Voters are trusted to protect their own signing keys.
+
+**Known limitations.** Registration is permissioned, so a compromised administrator can add sybil voters or force a tally. The contract records votes but does not establish that the proposal itself was communicated honestly off-chain.
+
+**Safe deployment.** Audit the voter registry before opening voting, publish the choice set and voting window, and treat admin-key compromise as a governance incident. See [Threat Model — Ballot](threat-model.md#ballot).
+
+### Bonding Curve
+
+**Trust assumptions.** Traders trust the configured token and curve parameters; after initialization, the contract has no standing administrator withdrawal path.
+
+**Known limitations.** Price impact, slippage, reserve depth, and integer rounding are inherent to the curve. A direct token or reserve transfer can create accounting conditions that are not equivalent to a trade.
+
+**Safe deployment.** Validate token identity and curve parameters before initialization, require caller-supplied cost/proceeds bounds, and monitor reserve and buy/sell events. See [Threat Model — Bonding Curve](threat-model.md#bonding-curve).
+
+### Crowdfund
+
+**Trust assumptions.** The creator is trusted to deliver the campaign and controls the deadline-extension and successful-claim paths. Pledgers trust the contract to isolate each pledge.
+
+**Known limitations.** Once the goal is met, `claim` transfers the pool to the creator; the contract cannot enforce off-chain promises. A creator key compromise can redirect the raised funds after the success condition.
+
+**Safe deployment.** Verify the creator and campaign metadata, publish the goal and deadline, monitor deadline extensions and goal progress, and keep a recovery process for creator-key compromise. See [Threat Model — Crowdfund](threat-model.md#crowdfund).
+
+### DAO
+
+**Trust assumptions.** The administrator controls proposal cancellation, while voting power is derived from the configured token balance. Participants trust the token and proposal semantics.
+
+**Known limitations.** Live-balance voting can be sensitive to temporary balance changes, and admin cancellation is a governance censorship vector. The contract does not itself execute treasury calls.
+
+**Safe deployment.** Use a governed admin, document quorum and proposal rules, snapshot or otherwise account for balance-manipulation risk in the surrounding process, and monitor creation, voting, cancellation, and execution events. See [Threat Model — DAO](threat-model.md#dao).
+
+### Lottery
+
+**Trust assumptions.** Participants trust the administrator to commit a fair secret and reveal it, and trust the configured token and ticket price. The contract’s commit-reveal mechanism is not an external randomness beacon.
+
+**Known limitations.** An administrator can grind candidate secrets before committing and may withhold a reveal, leaving the refund path as the availability fallback. Winner selection is therefore not trustless.
+
+**Safe deployment.** Use an operationally independent reveal process, publish the commit before ticket sales, define a reveal deadline and refund procedure, and monitor `committed`, `winner_drawn`, and `refund_claimed`. See [Threat Model — Lottery](threat-model.md#lottery).
+
+### Marketplace
+
+**Trust assumptions.** Sellers control their listings and buyers control their purchase decisions; the administrator is trusted only for initialization of payment and royalty configuration.
+
+**Known limitations.** The contract does not verify off-chain ownership, authenticity, or delivery of listed assets. Offer-related event paths may be unavailable until the implementation supports them fully.
+
+**Safe deployment.** Validate asset identifiers and royalty settings before initialization, use exact-price and expiry checks in clients, and monitor listing, sale, cancellation, sweep, and offer events. See [Threat Model — Marketplace](threat-model.md#marketplace).
+
+### NFT
+
+**Trust assumptions.** The administrator is trusted to mint the intended collection and supply, while owners and approved spenders are trusted only for their authorized tokens.
+
+**Known limitations.** Admin minting can dilute or counterfeit the collection up to the configured cap; metadata and provenance are external to the contract. There is no assumption that an on-chain token implies legal ownership of an off-chain work.
+
+**Safe deployment.** Set and verify the maximum supply before minting, protect the admin key, publish immutable metadata references where possible, and monitor mint, transfer, burn, and approval events. See [Threat Model — NFT](threat-model.md#nft).
+
+### Oracle
+
+**Trust assumptions.** Consumers trust the administrator or configured publishers to report accurate prices and trust the staleness parameters to bound data age.
+
+**Known limitations.** A single-source update can be manipulated until replaced or rejected as stale; a publisher quorum reduces but does not eliminate collusion and data-quality risk. The oracle cannot validate a downstream consumer’s use of a price.
+
+**Safe deployment.** Configure independent publishers where supported, enforce freshness and deviation checks in consumers, protect publisher-management authority, and alert on updates, stale data, and publisher-set changes. See [Threat Model — Oracle](threat-model.md#oracle).
+
+### Subscription
+
+**Trust assumptions.** The provider is trusted to charge only for the agreed service, while the subscriber is trusted to grant an appropriate token allowance. The token contract and allowance semantics are critical dependencies.
+
+**Known limitations.** An elapsed interval permits a provider charge up to the remaining allowance; cancellation may not reverse a charge that has already become due. The contract cannot enforce service quality.
+
+**Safe deployment.** Use least-privilege allowances, display interval and maximum exposure clearly, monitor charge failures and cancellations, and revoke allowances when service ends. See [Threat Model — Subscription](threat-model.md#subscription).
+
+### Swap
+
+**Trust assumptions.** Parties trust the configured token contracts and each other to provide the assets described by the proposal; the contract enforces atomic acceptance and timeout cancellation.
+
+**Known limitations.** Token behavior and asset value are external dependencies. Party A’s deposit is locked until acceptance or timeout, and a party can become unavailable without violating the contract.
+
+**Safe deployment.** Verify both token addresses and amounts before signing, communicate the deadline to both parties, and monitor proposals, acceptances, and timeout cancellations. See [Threat Model — Swap](threat-model.md#swap).
+
+### Timelock
+
+**Trust assumptions.** The administrator is trusted to initialize the intended beneficiary, asset, amount, and release ledger. Anyone may trigger release once the time condition is met.
+
+**Known limitations.** Before release, the administrator can cancel and reclaim the full locked amount. The contract does not guarantee the beneficiary’s off-chain identity or prevent an administrator key compromise.
+
+**Safe deployment.** Verify the beneficiary and release ledger from an independent source, treat initialization as irreversible policy, monitor cancellation and release events, and use a hardened or multisig admin. See [Threat Model — Timelock](threat-model.md#timelock).
+
+### Wrapped Token
+
+**Trust assumptions.** Users trust the external underlying token and its mint/burn authority, which must be correctly restricted to the wrapper. The wrapper administrator is trusted during initialization.
+
+**Known limitations.** The wrapper cannot repair a malicious or non-standard underlying token. Direct transfers can make reserves exceed tracked wrapped supply, while a reserve shortfall is a critical solvency signal.
+
+**Safe deployment.** Verify the underlying token and authority configuration before initialization, enforce the reserve invariant described above, monitor `wrapped`/`unwrapped` events, and pause wrapping on any shortfall. See [Threat Model — Wrapped Token](threat-model.md#wrapped-token).
+
+The [Threat Model](threat-model.md) provides the corresponding role-by-role compromise analysis for every section above.


### PR DESCRIPTION
Summary
This pull request strengthens the operational and security documentation for the expanded Soroban contract set.

Changes
Adds three Prometheus alert-rule examples for elevated failed-transaction rates, including percentage-based warning and critical thresholds plus an absolute failure-burst rule.
Documents the rationale for each threshold and the expected operator response.
Adds per-contract security considerations for the newer contract set, covering trust assumptions, known limitations, safe deployment notes, and links to the corresponding threat-model sections.
Preserves the existing monitoring and security guidance while making the newer contracts easier to deploy and operate safely.
Validation
git diff --check passes.
Rust workspace tests could not be run because the sandbox does not have cargo installed.
Closes https://github.com/Fidelis900/soroban-starter-kit/issues/872
Closes https://github.com/Fidelis900/soroban-starter-kit/issues/874