### PR TITLE
Fix phantom feature names, wrong arg order, and duplicate section num…

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -259,7 +259,7 @@ WASM Hash: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ---
 
-## 3b. Post-Deploy Initialization
+## 5. Post-Deploy Initialization
 
 After deploying contracts, run the initialization script to call each contract's `initialize` function:
 
@@ -285,7 +285,7 @@ The script is idempotent: contracts that return an "already initialized" error a
 
 ---
 
-## 5. Mainnet Deployment
+## 6. Mainnet Deployment
 
 > ⚠️ Mainnet deployments are irreversible. Complete testnet validation first.
 
@@ -306,7 +306,7 @@ stellar contract deploy --wasm <path>.wasm \
 
 ---
 
-## 6. Frontend Deployment
+## 7. Frontend Deployment
 
 ### Build
 
@@ -337,7 +337,7 @@ npm run build
 
 ---
 
-## 7. CI/CD Pipeline
+## 8. CI/CD Pipeline
 
 The GitHub Actions workflow at `.github/workflows/ci.yml` runs on every push:
 
@@ -384,7 +384,7 @@ NDJSON stream, you can pipe it straight into a log aggregator or filter it with
 
 ---
 
-## 8. Automated Guide Generation
+## 9. Automated Guide Generation
 
 Run the docs check script to validate documentation coverage and regenerate the docs report:
 
@@ -402,7 +402,7 @@ node scripts/generate-guides.mjs
 
 ---
 
-## 9. Validation Checklist
+## 10. Validation Checklist
 
 ### Pre-deployment
 
@@ -415,7 +415,7 @@ node scripts/generate-guides.mjs
 
 ### Post-deployment
 
-- [ ] **Contract health verified** — run `./scripts/check-contract-ids.sh` (see §13)
+- [ ] **Contract health verified** — run `./scripts/check-contract-ids.sh` (see §15)
 - [ ] Contract responds to `simulate` calls
 - [ ] Frontend connects to the correct RPC endpoint
 - [ ] Admin functions are restricted to the correct address
@@ -424,7 +424,7 @@ node scripts/generate-guides.mjs
 
 ---
 
-## 10. Security Considerations
+## 11. Security Considerations
 
 - Store `STELLAR_SECRET_KEY` only in CI secrets, never in `.env` committed to git
 - Use separate deployer accounts per environment (local / testnet / mainnet)
@@ -439,7 +439,7 @@ node scripts/generate-guides.mjs
 
 ---
 
-## 11. Performance Optimization
+## 12. Performance Optimization
 
 - Build contracts with `--release` flag (default in `deploy.sh`)
 - Minimize contract storage reads — cache values in `Env::storage().instance()`
@@ -526,7 +526,7 @@ To track WASM sizes across PRs, add a step to your CI workflow:
 
 ---
 
-## 12. Contract Upgrades (Timelock)
+## 13. Contract Upgrades (Timelock)
 
 Both the Token and Escrow contracts enforce a **two-step upgrade process** when
 built with the `upgradeable` / `pausable` feature flags. A minimum delay of
@@ -579,7 +579,7 @@ upgrade as complete.
 
 ---
 
-## 13. Troubleshooting
+## 14. Troubleshooting
 
 ### Identity and Funding Issues
 
@@ -605,7 +605,7 @@ upgrade as complete.
 
 ---
 
-## 13. Post-Deployment Contract Verification
+## 15. Post-Deployment Contract Verification
 
 After deploying, confirm that every contract in `.contract-ids` is alive:
 
@@ -634,7 +634,7 @@ suitable for use in CI/CD pipelines.
 
 ---
 
-## 14. Escrow Status Monitoring
+## 16. Escrow Status Monitoring
 
 After deploying an escrow contract, use `scripts/monitor-escrow.sh` to check its current state at any time:
 
@@ -676,18 +676,7 @@ The script also prints a warning when the deadline has passed and funds are stil
 
 ---
 
-## Resources
-
-- [Stellar CLI Reference](https://developers.stellar.org/docs/tools/stellar-cli)
-- [Soroban Deployment Docs](https://soroban.stellar.org/docs/getting-started/deploy-to-testnet)
-- [Stellar Friendbot (testnet funding)](https://friendbot.stellar.org)
-- [Stellar Laboratory](https://laboratory.stellar.org/)
-- [cargo-audit](https://crates.io/crates/cargo-audit)
-- [Contract Monitoring Guide](./monitoring.md) — event indexing, anomaly detection, Prometheus alerts, and a sample Grafana dashboard for deployed contracts
-
----
-
-## 14. Monitoring Token Contract Status
+## 17. Monitoring Token Contract Status
 
 Use `scripts/monitor-token.sh` to quickly inspect a deployed token contract:
 
@@ -728,7 +717,7 @@ export TOKEN_CONTRACT_ID=<CONTRACT_ID>
 
 ---
 
-## 15. Cargo Feature Defaults
+## 18. Cargo Feature Defaults
 
 `scripts/deploy.sh` and `scripts/deploy-all.sh` run a bare `stellar contract
 build` with no `--features` flag, so a contract's compiled-in capabilities are
@@ -752,3 +741,14 @@ release WASM. It parses each WASM's export section directly (no `wasm-tools`
 dependency) and fails CI if an expected feature-gated function — e.g.
 `pause`, `execute_upgrade`, `max_supply` — is missing, so a default silently
 regressing to off is caught before it reaches a deploy.
+
+---
+
+## Resources
+
+- [Stellar CLI Reference](https://developers.stellar.org/docs/tools/stellar-cli)
+- [Soroban Deployment Docs](https://soroban.stellar.org/docs/getting-started/deploy-to-testnet)
+- [Stellar Friendbot (testnet funding)](https://friendbot.stellar.org)
+- [Stellar Laboratory](https://laboratory.stellar.org/)
+- [cargo-audit](https://crates.io/crates/cargo-audit)
+- [Contract Monitoring Guide](./monitoring.md) — event indexing, anomaly detection, Prometheus alerts, and a sample Grafana dashboard for deployed contracts

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -90,15 +90,19 @@ cd contracts/escrow && stellar contract deploy --network testnet
 
 ### How do I enable feature flags for a contract?
 
-Feature flags are configured in each contract's `Cargo.toml`. For example, the token contract has optional features:
+Feature flags are configured in each contract's `Cargo.toml`. For the token contract, `pausable`, `upgradeable`, `capped-supply`, `freeze`, and `transfer-hook` are all **enabled by default** — a plain build already includes them:
 
 ```bash
-# Build with a specific feature
-cargo build -p token --features fee-token
-
-# Build with multiple features
-cargo build -p token --features fee-token,cap-supply
+cargo build -p token
 ```
+
+To build with only a subset, opt out of the defaults explicitly:
+
+```bash
+cargo build -p token --no-default-features --features pausable,capped-supply
+```
+
+See [Deployment Guide, "Cargo Feature Defaults"](deployment-guide.md#18-cargo-feature-defaults) — `scripts/deploy.sh` and `scripts/deploy-all.sh` run a bare `stellar contract build` with no `--features` flag, so a standard deploy ships with every default feature turned on.
 
 ### What feature flags are available?
 
@@ -113,9 +117,10 @@ Each contract's source code and `Cargo.toml` defines available features. Integra
 ### How do I customize the token contract?
 
 1. **Change name/symbol**: Edit `initialize()` call with desired values
-2. **Set supply cap**: Enable and use the `cap-supply` feature in `Cargo.toml`
-3. **Add fee logic**: Enable and configure the `fee-token` feature
-4. **Mint/burn controls**: The contract is admin-controlled; only the admin can mint or burn
+2. **Set supply cap**: The `capped-supply` feature is on by default; pass a `max_supply` to `initialize()` to enforce it
+3. **Mint/burn controls**: The contract is admin-controlled; only the admin can mint or burn
+
+There is no fee-on-transfer feature in this contract — the token has no fee logic today. If you need one, implement it yourself (e.g. via the `transfer-hook` feature's `on_transfer` callback).
 
 See [Token Features](adr/0007-token-interface-compliance.md) for compliance details.
 
@@ -129,9 +134,10 @@ const call = new ContractInvoke({
   method: 'initialize',
   args: [
     new Address(admin),
-    new U32(18),           // decimals
-    nativeToScVal('MyToken', 'string'),
-    nativeToScVal('MTK', 'string'),
+    nativeToScVal('MyToken', 'string'),  // name
+    nativeToScVal('MTK', 'string'),      // symbol
+    new U32(18),                         // decimals
+    nativeToScVal(null, 'void'),         // max_supply: None (or an i128 to cap supply)
   ],
 });
 ```
@@ -168,18 +174,19 @@ Contracts on Testnet consume fees from the account that deployed them. Top up yo
 
 ### How do I extend contract storage TTL?
 
-Call the TTL bump function (varies by contract):
+TTL extension varies by contract:
 
-```rust
-// For token contract
-token::Client::new(&env, &token_contract_id).bump();
-```
+- **Token contract**: there is no standalone `bump()` entry point. Every state-mutating call (`mint`, `transfer`, `approve`, etc.) automatically extends the relevant instance/persistent TTL internally via `extend_ttl_instance`/`extend_ttl_persistent`. To keep a token contract alive, periodically invoke any such state-mutating function — a read-only call like `balance_of` does not extend TTL.
+- **Escrow contract**: exposes a public, permissionless `bump()` you can call directly:
+  ```rust
+  escrow::Client::new(&env, &escrow_contract_id).bump();
+  ```
 
 All contracts define `LEDGER_LIFETIME_THRESHOLD` and `LEDGER_BUMP_AMOUNT` constants for TTL strategy.
 
 ### Why does my contract state expire?
 
-Soroban requires periodic TTL (time-to-live) extension. If no one calls a state-mutating function for ~7 days, the contract's persistent storage expires. Call a bump function to extend it.
+Soroban requires periodic TTL (time-to-live) extension. If no one calls a state-mutating function for ~7 days, the contract's persistent storage expires. For contracts without a standalone bump entry point (like `token`), invoke any state-mutating function to refresh the TTL; for contracts that expose one (like `escrow`), call its `bump()`.
 
 ## Errors
 


### PR DESCRIPTION
…bers in docs

- faq.md: replace non-existent fee-token/cap-supply features with real ones (pausable, capped-supply, etc.), note they're on by default via deploy.sh's bare build, and remove the fee-token reference entirely since no fee logic exists in the token contract ( closes #973)
- faq.md: fix initialize() example arg order to (admin, name, symbol, decimals, max_supply) and include max_supply ( closes #976)
- faq.md: fix TTL example — token has no bump(), TTL extends automatically on state-mutating calls; escrow does have bump() ( closes #975)
- deployment-guide.md: renumber all sections sequentially, resolving duplicate ## 13 and ## 14 headings and misplaced 3b section ( closes #974)

Closes #973, #974, #975, #976

## Summary

Describe the changes in this PR — what problem does it solve and how?

## Related Issue(s)

Closes #

<!-- Add more lines if this PR addresses multiple issues:
Closes #
Closes #
-->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Other

## Test Plan

Describe how you tested these changes. Check all that apply:

- [ ] Built contracts locally (`cargo build --target wasm32-unknown-unknown`)
- [ ] Ran unit tests (`cargo test`)
- [ ] Ran integration / smoke tests (`./scripts/smoke-test.sh`)
- [ ] Ran linter and formatter (`./scripts/clippy-all.sh` / `cargo fmt`)
- [ ] Tested in devcontainer / Codespace
- [ ] No automated tests applicable — reason: <!-- explain -->

## Checklist

- [ ] My branch is up to date with `main`
- [ ] I have reviewed my own diff
- [ ] I have added or updated documentation where needed
- [ ] My changes do not introduce new compiler warnings or clippy lints
- [ ] Any new scripts are executable (`chmod +x`) and have a usage comment
