### PR TITLE
docs: document missing storage keys and contract events

### DIFF
--- a/docs/event-catalogue.md
+++ b/docs/event-catalogue.md
@@ -29,9 +29,15 @@ env.events().publish((topic_1, topic_2, ...), data);
 | Approved | `approve` | `(Symbol, Address, Address)` → event name, owner, spender | `i128` → allowance amount | `approve()` called |
 | Revoked | `revoke` | `(Symbol, Address, Address)` → event name, owner, spender | `()` | `approve()` called with amount 0 |
 | Transferred | `transfer` | `(Symbol, Address, Address)` → event name, from, to | `i128` → amount transferred | `transfer()` or `transfer_from()` called |
+| Account Frozen | `account_frozen` | `(Symbol, Address)` → event name, account | `()` | `freeze_account()` called |
+| Account Unfrozen | `account_unfrozen` | `(Symbol, Address)` → event name, account | `()` | `unfreeze_account()` called |
 | Paused | `paused` | `(Symbol, Address)` → event name, admin | `()` | `pause()` called (pausable feature) |
 | Unpaused | `unpaused` | `(Symbol, Address)` → event name, admin | `()` | `unpause()` called (pausable feature) |
 | Upgraded | `upgraded` | `(Symbol, Address)` → event name, admin | `BytesN<32>` → new WASM hash | `execute_upgrade()` called (upgradeable feature) |
+| Transfer Hook Set | `hook_set` | `(Symbol, Address)` → event name, admin | `Option<Address>` → hook address (`None` to clear) | `set_transfer_hook()` called |
+| Snapshot Taken | `snapshot` | `(Symbol, Address, u32)` → event name, account, ledger | `i128` → recorded balance | `snapshot()` called (governance balance snapshots) |
+| Permit Signer Set | `permit_signer_set` | `(Symbol, Address)` → event name, owner | `()` | `set_permit_signer()` called |
+| Permit Used | `permit_used` | `(Symbol, Address, Address)` → event name, owner, spender | `(i128, u32)` → amount, nonce | `approve_with_signature()` succeeds |
 
 ---
 
@@ -46,6 +52,13 @@ env.events().publish((topic_1, topic_2, ...), data);
 | Funds Released | `released` | `(Symbol, Address)` → event name, seller | `i128` → amount released | `release()` called |
 | Partial Release | `released_partial` | `(Symbol, Address)` → event name, seller | `i128` → partial amount | `partial_release()` called |
 | Funds Refunded | `refunded` | `(Symbol, Address)` → event name, buyer | `i128` → amount refunded | `refund()` called (deadline passed) |
+| Amount Updated | `amount_updated` | `(Symbol, Address)` → event name, buyer | `i128` → new amount | `update_amount()` called |
+| Escrow Cancelled | `escrow_cancelled` | `(Symbol, Address)` → event name, buyer | `()` | `cancel()` called |
+| Deadline Extended | `deadline_extended` | `(Symbol, Address)` → event name, buyer | `u32` → new deadline ledger | `extend_deadline()` called |
+| Dispute Raised | `dispute_raised` | `(Symbol, Address)` → event name, caller | `()` | `raise_dispute()` called |
+| Dispute Timeout Claimed | `dispute_timeout` | `(Symbol, Address)` → event name, buyer | `i128` → amount claimed | `claim_dispute_timeout()` called |
+| Milestone Released | `milestone_released` | `(Symbol, Address, u32)` → event name, seller, milestone index | `(i128, i128)` → amount, fee | `release_milestone()` called |
+| Fee Config Set | `fee_config_set` | `(Symbol, Address)` → event name, admin | `(u32, Address)` → fee bps, treasury | `set_fee_config()` called |
 | Paused | `paused` | `(Symbol, Address)` → event name, admin | `()` | `pause()` called |
 | Unpaused | `unpaused` | `(Symbol, Address)` → event name, admin | `()` | `unpause()` called |
 | Upgraded | `upgraded` | `(Symbol, Address)` → event name, admin | `BytesN<32>` → new WASM hash | `execute_upgrade()` called |
@@ -71,6 +84,10 @@ env.events().publish((topic_1, topic_2, ...), data);
 | Unstaked | `unstaked` | `(Symbol, Address)` → event name, staker | `(i128, i128)` → amount unstaked, remaining stake | `unstake()` called |
 | Rewards Claimed | `claimed_rewards` | `(Symbol, Address)` → event name, staker | `i128` → reward amount claimed | `claim_rewards()` called |
 | Rewards Added | `added_rewards` | `(Symbol, Address)` → event name, admin | `(i128, i128)` → reward amount, new total | `add_rewards()` called |
+| Compounded | `compounded` | `(Symbol, Address)` → event name, staker | `(i128, i128)` → reward compounded, new stake | `compound()` called (auto-compounding) |
+| Slashed | `slashed` | `(Symbol, Address, Address)` → event name, admin, staker | `(i128, Address)` → amount slashed, destination | `slash()` called by admin |
+| Unbond Requested | `unbond_requested` | `(Symbol, Address)` → event name, staker | `(i128, u32)` → amount queued, available-at ledger | `unstake()` called when `unbonding_period > 0` |
+| Withdrawn | `withdrawn` | `(Symbol, Address)` → event name, staker | `i128` → amount withdrawn | `withdraw()` called after unbonding period |
 
 ---
 
@@ -84,6 +101,8 @@ env.events().publish((topic_1, topic_2, ...), data);
 | Transaction Proposed | `proposed` | `(Symbol, Address)` → event name, proposer | `u64` → transaction ID | `propose()` called |
 | Transaction Signed | `signed` | `(Symbol, Address, u64)` → event name, signer, tx ID | `u32` → signature count | `sign()` called |
 | Transaction Executed | `executed` | `(Symbol, u64)` → event name, tx ID | `()` | `execute()` called (threshold met) |
+| Proposal Expired | `expired` | `(Symbol, u64)` → event name, tx ID | `()` | `cleanup_expired()` called |
+| Batch Executed | `batch_executed` | `(Symbol,)` → event name | `(Vec<u64>, u32)` → executed IDs, skipped count | `execute_batch()` called |
 
 ---
 
@@ -96,6 +115,7 @@ env.events().publish((topic_1, topic_2, ...), data);
 | Voted | `voted` | `(Symbol, Address)` → event name, voter | `(u32, bool, i128)` → proposal ID, support, voting weight | `vote()` called |
 | Proposal Executed | `executed` | `(Symbol,)` → event name | `u32` → proposal ID | `execute()` called (quorum + majority met) |
 | Proposal Cancelled | `cancelled` | `(Symbol, Address)` → event name, admin | `u32` → proposal ID | `cancel_proposal()` called (admin) |
+| Proposer Cancelled | `prop_cancelled` | `(Symbol, Address)` → event name, proposer | `u32` → proposal ID | `proposer_cancel_proposal()` called (proposer self-cancellation) |
 
 ---
 
@@ -106,6 +126,7 @@ env.events().publish((topic_1, topic_2, ...), data);
 | Initialized | `initialized` | `(Symbol, Address, Address)` → event name, admin, beneficiary | `(u32, i128)` → release ledger, amount | `initialize()` called |
 | Released | `released` | `(Symbol, Address)` → event name, beneficiary | `i128` → amount released | `release()` called |
 | Cancelled | `cancelled` | `(Symbol, Address)` → event name, admin | `i128` → amount returned to admin | `cancel()` called |
+| Beneficiary Reassigned | `beneficiary_reassigned` | `(Symbol, Address, Address, Address)` → event name, admin, old beneficiary, new beneficiary | `()` | `reassign_beneficiary()` called |
 
 ---
 
@@ -238,6 +259,7 @@ env.events().publish((topic_1, topic_2, ...), data);
 | Initialized | `initialized` | `(Symbol, Address, Address)` → event name, admin, beneficiary | `(u32, i128)` → release ledger, amount | `initialize()` called |
 | Released | `released` | `(Symbol, Address)` → event name, beneficiary | `i128` → amount released | `release()` called after release ledger |
 | Cancelled | `cancelled` | `(Symbol, Address)` → event name, admin | `i128` → amount returned to admin | `cancel()` called by admin before release ledger |
+| Beneficiary Reassigned | `beneficiary_reassigned` | `(Symbol, Address, Address, Address)` → event name, admin, old beneficiary, new beneficiary | `()` | `reassign_beneficiary()` called |
 
 ---
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -80,14 +80,19 @@ All token events are emitted by `contracts/token` and follow this structure:
 | `mint` | `Symbol("mint")` | `Address` (recipient) | — | `i128` (amount) |
 | `burn` | `Symbol("burn")` | `Address` (account) | — | `i128` (amount) |
 | `transfer` | `Symbol("transfer")` | `Address` (from) | `Address` (to) | `i128` (amount) |
+| `account_frozen` | `Symbol("account_frozen")` | `Address` (account) | — | `()` |
+| `account_unfrozen` | `Symbol("account_unfrozen")` | `Address` (account) | — | `()` |
 | `approve` | `Symbol("approve")` | `Address` (owner) | `Address` (spender) | `i128` (amount) |
 | `revoke` | `Symbol("revoke")` | `Address` (owner) | `Address` (spender) | `()` |
 | `admin_changed` | `Symbol("admin_changed")` | `Address` (old admin) | — | `Address` (new admin) |
 | `admin_proposed` | `Symbol("admin_proposed")` | `Address` (current admin) | — | `Address` (pending admin) |
 | `admin_accepted` | `Symbol("admin_accepted")` | `Address` (new admin) | — | `()` |
+| `admin_proposal_cancelled` | `Symbol("admin_proposal_cancelled")` | `Address` (admin) | — | `()` |
 | `paused` | `Symbol("paused")` | `Address` (admin) | — | `()` |
 | `unpaused` | `Symbol("unpaused")` | `Address` (admin) | — | `()` |
 | `upgraded` | `Symbol("upgraded")` | `Address` (admin) | — | `BytesN<32>` (wasm hash) |
+| `hook_set` | `Symbol("hook_set")` | `Address` (admin) | — | `Option<Address>` (hook; `None` to clear) |
+| `snapshot` | `Symbol("snapshot")` | `Address` (account) | `u32` (ledger) | `i128` (balance) |
 | `permit_signer_set` | `Symbol("permit_signer_set")` | `Address` (owner) | — | `()` |
 | `permit_used` | `Symbol("permit_used")` | `Address` (owner) | `Address` (spender) | `(i128 amount, u32 nonce)` |
 
@@ -97,6 +102,14 @@ changes via `approve`/`revoke` needs no special-casing for signature-granted
 allowances. Watch `permit_signer_set` for unexpected signer rotations — a
 rotation invalidates all outstanding, unsubmitted permits signed with the
 previous key.
+
+`account_frozen` / `account_unfrozen` are the compliance freeze signals — index
+both if you need to know which accounts currently cannot transfer. `hook_set`
+fires from `set_transfer_hook` (data is `None` when the hook is cleared).
+`snapshot` is the governance balance snapshot from `snapshot()` (issue #717);
+topic[2] is the ledger the snapshot is recorded against. `admin_proposal_cancelled`
+fires when the current admin aborts a pending two-step admin transfer via
+`cancel_admin_proposal`.
 
 ### Escrow Contract Events
 
@@ -125,9 +138,17 @@ Events emitted by `contracts/subscription`:
 | Event | Topic[0] | Topic[1] | Topic[2] | Data |
 |-------|----------|----------|----------|------|
 | `initialized` | `Symbol("initialized")` | `Address` (provider) | — | `Address` (token) |
-| `subscribed` | `Symbol("subscribed")` | `Address` (subscriber) | — | `(i128 amount, u32 interval_ledgers)` |
+| `plan_registered` | `Symbol("plan_registered")` | `Symbol` (plan_id) | — | `(i128 amount, u32 interval_ledgers)` |
+| `plan_updated` | `Symbol("plan_updated")` | `Symbol` (plan_id) | — | `bool` (active) |
+| `subscribed` | `Symbol("subscribed")` | `Address` (subscriber) | — | `(Symbol plan_id, i128 amount, u32 interval_ledgers)` |
 | `charged` | `Symbol("charged")` | `Address` (subscriber) | `Address` (provider) | `i128` (amount) |
 | `cancelled` | `Symbol("cancelled")` | `Address` (subscriber) | — | `()` |
+| `trial_completed` | `Symbol("trial_completed")` | `Address` (subscriber) | — | `()` |
+
+`plan_registered` fires from `register_plan`; `plan_updated` from `set_plan_active`.
+`subscribed` data includes `plan_id` so an indexer can join a subscription to its plan
+without a separate lookup. `trial_completed` is emitted from `charge()` when a
+subscriber's trial period ends (no separate `complete_trial` entry point).
 
 ### Wrapped-Token Contract Events
 

--- a/docs/storage-layout.md
+++ b/docs/storage-layout.md
@@ -100,6 +100,7 @@ This document details the storage keys, types, and TTL management policy for eac
 | Key | Tier | Type | TTL Policy | Description |
 |-----|------|------|------------|-------------|
 | `Signers` | Instance | `Vec<Address>` | Extended on signer change | List of authorized signers |
+| `Weights` | Instance | `Map<Address, u32>` | Extended on init / signer change | Per-signer vote weight for weighted voting; signers not listed default to 1 |
 | `Threshold` | Instance | `u32` | Extended on threshold change | Required number of signatures (N-of-M) |
 | `NextTransactionId` | Instance | `u64` | Extended on proposal | Auto-incrementing transaction ID counter |
 | `Transaction(u64)` | Persistent | `Transaction` | Extended on propose/sign/execute | Proposed transaction details and signatures |


### PR DESCRIPTION
closes #998
closes #994
closes #993
closes #995

**PR description:**

## Summary

Closes documentation gaps that would cause indexers and operators to miss real on-chain activity. All topic/data shapes were read from each contract’s `events.rs` (and `DataKey` for storage).

### #998 — `docs/storage-layout.md` Multisig `Weights` key
The Multisig storage table listed Signers, Threshold, NextTransactionId, Transaction, Paused, and Version, but not **Weights** (closed issue #825, weighted voting). Same gap as the multisig row in `upgrade-compatibility-matrix.md` (#980).

Added:

| Key | Tier | Type | Description |
|-----|------|------|-------------|
| `Weights` | Instance | `Map<Address, u32>` | Per-signer vote weight; unlisted signers default to 1 |

TTL: extended on init / signer change, matching `initialize` / `add_signer` / `remove_signer`.

### #995 — `docs/event-catalogue.md` missing events
**Required 7 events** (topics/data from `events.rs`):

| Contract | Event | Symbol | Topics | Data | When |
|----------|-------|--------|--------|------|------|
| Staking | Compounded | `compounded` | `(Symbol, Address)` staker | `(i128, i128)` reward, new stake | `compound()` |
| Staking | Slashed | `slashed` | `(Symbol, Address, Address)` admin, staker | `(i128, Address)` amount, destination | `slash()` |
| Staking | Unbond Requested | `unbond_requested` | `(Symbol, Address)` staker | `(i128, u32)` amount, available-at | `unstake()` when `unbonding_period > 0` |
| Staking | Withdrawn | `withdrawn` | `(Symbol, Address)` staker | `i128` amount | `withdraw()` after unbonding |
| Multisig | Proposal Expired | `expired` | `(Symbol, u64)` tx ID | `()` | `cleanup_expired()` |
| Multisig | Batch Executed | `batch_executed` | `(Symbol,)` | `(Vec<u64>, u32)` executed IDs, skipped count | `execute_batch()` (#826) |
| DAO | Proposer Cancelled | `prop_cancelled` | `(Symbol, Address)` proposer | `u32` proposal ID | `proposer_cancel_proposal()` (#830) |

**Full pass of token, escrow, and timelock** (same missing-event gap):

- **Token:** `account_frozen`, `account_unfrozen`, `hook_set` (`set_transfer_hook`; data `Option<Address>`), `snapshot` (`snapshot()`; topics include ledger), `permit_signer_set`, `permit_used`
- **Escrow:** `amount_updated`, `escrow_cancelled`, `deadline_extended`, `dispute_raised`, `dispute_timeout`, `milestone_released`, `fee_config_set`
- **Timelock:** `beneficiary_reassigned` (both Timelock tables in the catalogue)

### #994 — `docs/monitoring.md` Token events table
Table had 14 events; `contracts/token/src/events.rs` also publishes these 5:

| Event (published symbol) | Topic[1] | Topic[2] | Data |
|--------------------------|----------|----------|------|
| `admin_proposal_cancelled` | admin | — | `()` |
| `account_frozen` | account | — | `()` |
| `account_unfrozen` | account | — | `()` |
| `hook_set` | admin | — | `Option<Address>` (`None` clears the hook) |
| `snapshot` | account | ledger (`u32`) | `i128` balance |

Symbols match what is published (`hook_set` / `snapshot`, not the Rust function names). Freeze events are called out as the compliance signals to index.

### #993 — `docs/monitoring.md` Subscription events table
Added rows for events already in `contracts/subscription/src/events.rs`:

| Event | Topic[1] | Data |
|-------|----------|------|
| `plan_registered` | `Symbol` plan_id | `(i128 amount, u32 interval_ledgers)` |
| `plan_updated` | `Symbol` plan_id | `bool` active (`set_plan_active`) |
| `trial_completed` | subscriber | `()` (emitted from `charge()` when the trial ends) |

Corrected `subscribed` data from `(i128 amount, u32 interval_ledgers)` to **`(Symbol plan_id, i128 amount, u32 interval_ledgers)`**.

## Test plan
- [ ] Diff `docs/storage-layout.md` Multisig table against `contracts/multisig/src/storage.rs` `DataKey::Weights`
- [ ] Diff Staking / Multisig / DAO catalogue rows against each `events.rs`
- [ ] Diff Token / Escrow / Timelock catalogue rows against each `events.rs` (no remaining unpublished events)
- [ ] Diff monitoring Token table against `contracts/token/src/events.rs` (19 events)
- [ ] Diff monitoring Subscription table against `contracts/subscription/src/events.rs`, including `subscribed`’s `plan_id`