### PR TITLE
Standardize error-derive and event-emission patterns across newer contracts

### DIFF
--- a/contracts/airdrop/src/errors.rs
+++ b/contracts/airdrop/src/errors.rs
@@ -1,28 +1,33 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum AirdropError {
-    /// `initialize` called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// Operation attempted before the contract was initialized.
     NotInitialized = 2,
-    /// Caller is not the admin.
     Unauthorized = 3,
-    /// Merkle root has not been set yet.
     RootNotSet = 4,
-    /// The provided merkle proof is invalid.
     InvalidProof = 5,
-    /// This address has already claimed their airdrop.
     AlreadyClaimed = 6,
-    /// Claim amount is zero.
     InvalidAmount = 7,
-    /// The claim deadline has passed; no further claims are accepted.
     ClaimWindowClosed = 8,
 }
+
+impl_display_error!(
+    AirdropError,
+    AlreadyInitialized => "already initialized",
+    NotInitialized     => "not initialized",
+    Unauthorized       => "not authorized",
+    RootNotSet         => "merkle root not set",
+    InvalidProof       => "invalid merkle proof",
+    AlreadyClaimed     => "already claimed",
+    InvalidAmount      => "invalid amount",
+    ClaimWindowClosed  => "claim window closed",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/airdrop/src/events.rs
+++ b/contracts/airdrop/src/events.rs
@@ -1,11 +1,11 @@
-use soroban_sdk::{Address, Bytes, Env, symbol_short};
+use soroban_sdk::{Address, Bytes, Env, Symbol};
 
 pub fn root_set(env: &Env, root: &Bytes) {
     env.events()
-        .publish((symbol_short!("root_set"),), root.clone());
+        .publish((Symbol::new(env, "root_set"),), root.clone());
 }
 
 pub fn claimed(env: &Env, recipient: &Address, amount: i128) {
     env.events()
-        .publish((symbol_short!("claimed"),), (recipient.clone(), amount));
+        .publish((Symbol::new(env, "claimed"),), (recipient.clone(), amount));
 }

--- a/contracts/ballot/src/errors.rs
+++ b/contracts/ballot/src/errors.rs
@@ -1,31 +1,36 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BallotError {
-    /// `initialize` was called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// An operation was attempted before the contract was initialized.
     NotInitialized = 2,
-    /// Caller is not the admin.
     Unauthorized = 3,
-    /// Voter is not registered.
     NotRegistered = 4,
-    /// Voter has already voted.
     AlreadyVoted = 5,
-    /// Invalid vote choice index (out of range).
     InvalidChoice = 6,
-    /// Voting has not started, is closed, or has not reached its start ledger yet.
     VotingClosed = 7,
-    /// `deregister_voter` was called after at least one vote has been cast.
     VotingAlreadyStarted = 8,
-    /// Voting window is invalid: start_ledger >= end_ledger or window is in the past.
     InvalidWindow = 9,
-    /// Current ledger is before voting_start.
     VotingNotStarted = 10,
-    /// `initialize` was called with an empty choices list.
     NoChoices = 11,
 }
+
+impl_display_error!(
+    BallotError,
+    AlreadyInitialized   => "already initialized",
+    NotInitialized       => "not initialized",
+    Unauthorized         => "not authorized",
+    NotRegistered        => "voter not registered",
+    AlreadyVoted         => "voter has already voted",
+    InvalidChoice        => "invalid vote choice",
+    VotingClosed         => "voting is closed",
+    VotingAlreadyStarted => "voting already started",
+    InvalidWindow        => "invalid voting window",
+    VotingNotStarted     => "voting not started",
+    NoChoices            => "no choices provided",
+);

--- a/contracts/ballot/src/events.rs
+++ b/contracts/ballot/src/events.rs
@@ -1,34 +1,33 @@
 use soroban_sdk::{Address, Env, Symbol, Vec};
 
 pub fn initialized(env: &Env, admin: &Address) {
-    let topics = (Symbol::new(env, "initialized"),);
-    env.events().publish(topics, admin.clone());
+    env.events().publish((Symbol::new(env, "initialized"),), admin.clone());
 }
 
 pub fn voter_registered(env: &Env, voter: &Address) {
-    let topics = (Symbol::new(env, "voter_registered"),);
-    env.events().publish(topics, voter.clone());
+    env.events()
+        .publish((Symbol::new(env, "voter_registered"),), voter.clone());
 }
 
 pub fn voter_deregistered(env: &Env, voter: &Address) {
-    let topics = (Symbol::new(env, "voter_deregistered"),);
-    env.events().publish(topics, voter.clone());
+    env.events()
+        .publish((Symbol::new(env, "voter_deregistered"),), voter.clone());
 }
 
 pub fn voted(env: &Env, voter: &Address, choice: u32) {
-    let topics = (Symbol::new(env, "voted"),);
-    env.events().publish(topics, (voter.clone(), choice));
+    env.events()
+        .publish((Symbol::new(env, "voted"),), (voter.clone(), choice));
 }
 
 /// Emitted by `tally` (binary ballot, backward compat).
 pub fn tally_result(env: &Env, yes: i128, no: i128) {
-    let topics = (Symbol::new(env, "tally_result"),);
-    env.events().publish(topics, (yes, no));
+    env.events()
+        .publish((Symbol::new(env, "tally_result"),), (yes, no));
 }
 
 /// Emitted by `tally_all` (multi-choice ballot, #788).
 /// `counts` contains per-choice vote tallies in declaration order.
 pub fn tally_all_result(env: &Env, counts: &Vec<i128>) {
-    let topics = (Symbol::new(env, "tally_all_result"),);
-    env.events().publish(topics, counts.clone());
+    env.events()
+        .publish((Symbol::new(env, "tally_all_result"),), counts.clone());
 }

--- a/contracts/bonding-curve/src/errors.rs
+++ b/contracts/bonding-curve/src/errors.rs
@@ -1,24 +1,29 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BondingCurveError {
-    /// `initialize` was called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// An operation was attempted before the contract was initialized.
     NotInitialized = 2,
-    /// Caller is not the admin.
     Unauthorized = 3,
-    /// Amount is zero or negative.
     InvalidAmount = 4,
-    /// Insufficient reserve to sell.
     InsufficientReserve = 5,
-    /// Arithmetic overflow.
     Overflow = 6,
 }
+
+impl_display_error!(
+    BondingCurveError,
+    AlreadyInitialized   => "already initialized",
+    NotInitialized       => "not initialized",
+    Unauthorized         => "not authorized",
+    InvalidAmount        => "invalid amount",
+    InsufficientReserve  => "insufficient reserve",
+    Overflow             => "arithmetic overflow",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/bonding-curve/src/events.rs
+++ b/contracts/bonding-curve/src/events.rs
@@ -1,16 +1,16 @@
 use soroban_sdk::{Address, Env, Symbol};
 
 pub fn initialized(env: &Env, admin: &Address, token: &Address) {
-    let topics = (Symbol::new(env, "initialized"),);
-    env.events().publish(topics, (admin.clone(), token.clone()));
+    env.events()
+        .publish((Symbol::new(env, "initialized"),), (admin.clone(), token.clone()));
 }
 
 pub fn bought(env: &Env, buyer: &Address, tokens: i128, cost: i128) {
-    let topics = (Symbol::new(env, "bought"),);
-    env.events().publish(topics, (buyer.clone(), tokens, cost));
+    env.events()
+        .publish((Symbol::new(env, "bought"),), (buyer.clone(), tokens, cost));
 }
 
 pub fn sold(env: &Env, seller: &Address, tokens: i128, proceeds: i128) {
-    let topics = (Symbol::new(env, "sold"),);
-    env.events().publish(topics, (seller.clone(), tokens, proceeds));
+    env.events()
+        .publish((Symbol::new(env, "sold"),), (seller.clone(), tokens, proceeds));
 }

--- a/contracts/lottery/src/errors.rs
+++ b/contracts/lottery/src/errors.rs
@@ -1,6 +1,7 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
@@ -24,6 +25,27 @@ pub enum LotteryError {
     InvalidTicketCap = 16,
     TicketCapExceeded = 17,
 }
+
+impl_display_error!(
+    LotteryError,
+    AlreadyInitialized      => "already initialized",
+    NotInitialized          => "not initialized",
+    Unauthorized            => "not authorized",
+    LotteryClosed           => "lottery closed",
+    DrawAlreadyDone         => "draw already done",
+    DrawNotDone             => "draw not done",
+    InvalidTicketPrice      => "invalid ticket price",
+    CommitAlreadySubmitted  => "commit already submitted",
+    RevealMismatch          => "reveal mismatch",
+    NoTickets               => "no tickets",
+    InvalidRevealDeadline   => "invalid reveal deadline",
+    RefundNotAvailable      => "refund not available",
+    NothingToRefund         => "nothing to refund",
+    InvalidWinnerConfig     => "invalid winner config",
+    InsufficientParticipants => "insufficient participants",
+    InvalidTicketCap        => "invalid ticket cap",
+    TicketCapExceeded       => "ticket cap exceeded",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/marketplace/src/errors.rs
+++ b/contracts/marketplace/src/errors.rs
@@ -1,36 +1,41 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MarketplaceError {
-    /// `initialize` called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// Operation attempted before the contract was initialized.
     NotInitialized = 2,
-    /// Caller is not authorized for this operation.
     NotAuthorized = 3,
-    /// Price is zero or negative.
     InvalidPrice = 4,
-    /// Listing ID does not exist.
     ListingNotFound = 5,
-    /// Listing is no longer active (already bought or cancelled).
     ListingInactive = 6,
-    /// Royalty basis points exceed 10 000 (100 %).
     InvalidRoyalty = 7,
-    /// The provided expiry ledger sequence is not in the future.
     InvalidExpiry = 8,
-    /// The listing's expiry ledger sequence has already passed.
     ListingExpired = 9,
-    /// `sweep_expired` called on a listing that has no expiry, or whose expiry hasn't passed.
     ListingNotExpired = 10,
-    /// Offer amount is zero, negative, or not below the listing price.
     InvalidOfferAmount = 11,
-    /// No offer exists for this (listing, buyer) pair.
     OfferNotFound = 12,
 }
+
+impl_display_error!(
+    MarketplaceError,
+    AlreadyInitialized  => "already initialized",
+    NotInitialized      => "not initialized",
+    NotAuthorized       => "not authorized",
+    InvalidPrice        => "invalid price",
+    ListingNotFound     => "listing not found",
+    ListingInactive     => "listing inactive",
+    InvalidRoyalty      => "invalid royalty",
+    InvalidExpiry       => "invalid expiry",
+    ListingExpired      => "listing expired",
+    ListingNotExpired   => "listing not expired",
+    InvalidOfferAmount  => "invalid offer amount",
+    OfferNotFound       => "offer not found",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/marketplace/src/events.rs
+++ b/contracts/marketplace/src/events.rs
@@ -1,42 +1,42 @@
-use soroban_sdk::{Address, Env, symbol_short};
+use soroban_sdk::{Address, Env, Symbol};
 
 pub fn listed(env: &Env, listing_id: u64, seller: &Address, price: i128) {
     env.events().publish(
-        (symbol_short!("listed"), listing_id),
+        (Symbol::new(env, "listed"), listing_id),
         (seller.clone(), price),
     );
 }
 
 pub fn sold(env: &Env, listing_id: u64, buyer: &Address, price: i128) {
     env.events()
-        .publish((symbol_short!("sold"), listing_id), (buyer.clone(), price));
+        .publish((Symbol::new(env, "sold"), listing_id), (buyer.clone(), price));
 }
 
 pub fn cancelled(env: &Env, listing_id: u64, seller: &Address) {
     env.events()
-        .publish((symbol_short!("cancel"), listing_id), seller.clone());
+        .publish((Symbol::new(env, "cancelled"), listing_id), seller.clone());
 }
 
 pub fn swept(env: &Env, listing_id: u64, seller: &Address) {
     env.events()
-        .publish((symbol_short!("swept"), listing_id), seller.clone());
+        .publish((Symbol::new(env, "swept"), listing_id), seller.clone());
 }
 
 pub fn offer_made(env: &Env, listing_id: u64, buyer: &Address, amount: i128) {
     env.events().publish(
-        (symbol_short!("offered"), listing_id),
+        (Symbol::new(env, "offered"), listing_id),
         (buyer.clone(), amount),
     );
 }
 
 pub fn offer_accepted(env: &Env, listing_id: u64, buyer: &Address, amount: i128) {
     env.events().publish(
-        (symbol_short!("offracc"), listing_id),
+        (Symbol::new(env, "offer_accepted"), listing_id),
         (buyer.clone(), amount),
     );
 }
 
 pub fn offer_cancelled(env: &Env, listing_id: u64, buyer: &Address) {
     env.events()
-        .publish((symbol_short!("offrcncl"), listing_id), buyer.clone());
+        .publish((Symbol::new(env, "offer_cancelled"), listing_id), buyer.clone());
 }

--- a/contracts/oracle/src/errors.rs
+++ b/contracts/oracle/src/errors.rs
@@ -2,27 +2,31 @@
 // missing_docs for this module. The variants themselves are still documented.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
-/// Errors returned by the oracle contract entry points.
 #[contracterror]
 #[derive(Clone, Copy, Debug)]
 pub enum OracleError {
-    /// `initialize` was called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// An entry point was called before `initialize`.
     NotInitialized = 2,
-    /// The caller is not the configured admin.
     Unauthorized = 3,
-    /// The stored price is older than the staleness threshold.
     StalePrice = 4,
-    /// The provided staleness threshold is zero.
     InvalidStalenessThreshold = 5,
-    /// No authorized publisher has submitted a price yet.
     NoPublisherData = 6,
-    /// No price observations fall within the requested TWAP window.
     InsufficientHistory = 7,
 }
+
+impl_display_error!(
+    OracleError,
+    AlreadyInitialized          => "already initialized",
+    NotInitialized              => "not initialized",
+    Unauthorized                => "not authorized",
+    StalePrice                  => "stale price",
+    InvalidStalenessThreshold   => "invalid staleness threshold",
+    NoPublisherData             => "no publisher data",
+    InsufficientHistory         => "insufficient history",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/staking/src/errors.rs
+++ b/contracts/staking/src/errors.rs
@@ -1,34 +1,39 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum StakingError {
-    /// `initialize` was called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// An operation was attempted before the contract was initialized.
     NotInitialized = 2,
-    /// Caller is not the admin.
     Unauthorized = 3,
-    /// Amount is zero or negative.
     InvalidAmount = 4,
-    /// Staker has no stake to unstake or claim from.
     NoStake = 5,
-    /// Requested unstake amount exceeds the staker's current stake.
     InsufficientStake = 6,
-    /// No rewards are available to claim.
     NoRewards = 7,
-    /// Stake and reward token must be the same to compound.
     CompoundTokenMismatch = 8,
-    /// `withdraw` called before the unbonding period has elapsed.
     UnbondingNotComplete = 9,
-    /// `withdraw` called with no pending unbond request.
     NoUnbondRequest = 10,
-    /// `unstake` called while a pending UnbondRequest already exists for this staker.
     UnbondRequestPending = 11,
 }
+
+impl_display_error!(
+    StakingError,
+    AlreadyInitialized     => "already initialized",
+    NotInitialized         => "not initialized",
+    Unauthorized           => "not authorized",
+    InvalidAmount          => "invalid amount",
+    NoStake                => "no stake",
+    InsufficientStake      => "insufficient stake",
+    NoRewards              => "no rewards",
+    CompoundTokenMismatch  => "compound token mismatch",
+    UnbondingNotComplete   => "unbonding not complete",
+    NoUnbondRequest        => "no unbond request",
+    UnbondRequestPending   => "unbond request pending",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/subscription/src/errors.rs
+++ b/contracts/subscription/src/errors.rs
@@ -1,38 +1,43 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum SubscriptionError {
-    /// `initialize` was called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// An operation was attempted before the contract was initialized.
     NotInitialized = 2,
-    /// Caller is not authorized (e.g. non-provider calling `charge`).
     NotAuthorized = 3,
-    /// Amount is zero or negative.
     InvalidAmount = 4,
-    /// Interval is zero.
     InvalidInterval = 5,
-    /// Subscriber already has an active subscription.
     AlreadySubscribed = 6,
-    /// No subscription found for this subscriber.
     NotSubscribed = 7,
-    /// Subscription has been cancelled.
     SubscriptionInactive = 8,
-    /// The charge interval has not elapsed since the last payment.
     IntervalNotElapsed = 9,
-    /// Subscriber has not granted sufficient token allowance to this contract.
     InsufficientAllowance = 10,
-    /// Plan with this ID already exists.
     PlanAlreadyExists = 11,
-    /// Plan does not exist.
     PlanNotFound = 12,
-    /// Plan is not active and cannot be subscribed to.
     PlanInactive = 13,
 }
+
+impl_display_error!(
+    SubscriptionError,
+    AlreadyInitialized     => "already initialized",
+    NotInitialized         => "not initialized",
+    NotAuthorized          => "not authorized",
+    InvalidAmount          => "invalid amount",
+    InvalidInterval        => "invalid interval",
+    AlreadySubscribed      => "already subscribed",
+    NotSubscribed          => "not subscribed",
+    SubscriptionInactive   => "subscription inactive",
+    IntervalNotElapsed     => "interval not elapsed",
+    InsufficientAllowance  => "insufficient allowance",
+    PlanAlreadyExists      => "plan already exists",
+    PlanNotFound           => "plan not found",
+    PlanInactive           => "plan inactive",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/vesting/src/errors.rs
+++ b/contracts/vesting/src/errors.rs
@@ -1,32 +1,37 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum VestingError {
-    /// `initialize` was called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// An operation was attempted before the contract was initialized.
     NotInitialized = 2,
-    /// Caller is not authorized to perform this action.
     NotAuthorized = 3,
-    /// Amount is zero or negative.
     InvalidAmount = 4,
-    /// `cliff_ledger` >= `end_ledger`, or `end_ledger` <= current ledger.
     InvalidSchedule = 5,
-    /// No tokens are currently vested and unclaimed.
     NothingToClaim = 6,
-    /// The vesting schedule has already been revoked.
     AlreadyRevoked = 7,
-    /// admin_release was called after the cliff has already passed.
     CliffAlreadyPassed = 8,
-    /// A schedule already exists for the specified beneficiary.
     ScheduleAlreadyExists = 9,
-    /// No schedule was found for the specified beneficiary.
     ScheduleNotFound = 10,
 }
+
+impl_display_error!(
+    VestingError,
+    AlreadyInitialized    => "already initialized",
+    NotInitialized        => "not initialized",
+    NotAuthorized         => "not authorized",
+    InvalidAmount         => "invalid amount",
+    InvalidSchedule       => "invalid schedule",
+    NothingToClaim        => "nothing to claim",
+    AlreadyRevoked        => "already revoked",
+    CliffAlreadyPassed    => "cliff already passed",
+    ScheduleAlreadyExists => "schedule already exists",
+    ScheduleNotFound      => "schedule not found",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/wrapped-token/src/errors.rs
+++ b/contracts/wrapped-token/src/errors.rs
@@ -1,26 +1,31 @@
 // `#[contracterror]` generates undocumented public associated items.
 #![allow(missing_docs)]
 
+use soroban_common::impl_display_error;
 use soroban_sdk::contracterror;
 
 #[contracterror]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum WrappedTokenError {
-    /// `initialize` was called on an already-initialized contract.
     AlreadyInitialized = 1,
-    /// An operation was attempted before the contract was initialized.
     NotInitialized = 2,
-    /// Caller is not the admin.
     Unauthorized = 3,
-    /// Amount is zero or negative.
     InvalidAmount = 4,
-    /// Insufficient wrapped token balance to burn.
     InsufficientBalance = 5,
-    /// Insufficient XLM in reserve to unwrap.
     InsufficientReserve = 6,
-    /// Wrapping this amount would exceed the per-address cap set at `initialize`.
     MaxWrapExceeded = 7,
 }
+
+impl_display_error!(
+    WrappedTokenError,
+    AlreadyInitialized  => "already initialized",
+    NotInitialized      => "not initialized",
+    Unauthorized        => "not authorized",
+    InvalidAmount       => "invalid amount",
+    InsufficientBalance => "insufficient balance",
+    InsufficientReserve => "insufficient reserve",
+    MaxWrapExceeded     => "max wrap exceeded",
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/wrapped-token/src/events.rs
+++ b/contracts/wrapped-token/src/events.rs
@@ -1,18 +1,18 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{Address, Env, Symbol};
 
 pub fn initialized(env: &Env, admin: &Address, token: &Address) {
-    let topics = (Symbol::new(env, "initialized"),);
-    env.events().publish(topics, (admin.clone(), token.clone()));
+    env.events()
+        .publish((Symbol::new(env, "initialized"),), (admin.clone(), token.clone()));
 }
 
 pub fn wrapped(env: &Env, user: &Address, amount: i128, total: i128) {
-    let topics = (Symbol::new(env, "wrapped"),);
-    env.events().publish(topics, (user.clone(), amount, total));
+    env.events()
+        .publish((Symbol::new(env, "wrapped"),), (user.clone(), amount, total));
 }
 
 pub fn unwrapped(env: &Env, user: &Address, amount: i128, total: i128) {
-    let topics = (Symbol::new(env, "unwrapped"),);
-    env.events().publish(topics, (user.clone(), amount, total));
+    env.events()
+        .publish((Symbol::new(env, "unwrapped"),), (user.clone(), amount, total));
 }
 
 /// Emitted when the contract is paused. Only used when the `pausable` feature is enabled.
@@ -28,5 +28,3 @@ pub fn unpaused(env: &Env, admin: &Address) {
     env.events()
         .publish((Symbol::new(env, "unpaused"), admin.clone()), ());
 }
-
-use soroban_sdk::Symbol;


### PR DESCRIPTION
## Summary

Extends the Display/error-derive standardization (from #706 and #764) and event-emission conventions to all 13 newer contracts, bringing them in line with the original 7.

## Changes

### Issue #882 — Error-derive standardization
Added impl_display_error! macro from soroban_common to 10 contracts that were missing it:
- irdrop, allot, lottery, onding-curve, marketplace, oracle, staking, subscription, esting, wrapped-token

Each error enum now has a consistent Display implementation via the shared macro, matching the pattern established in uction, crowdfund, dao, escrow, swap, 	imelock, 	oken, 
ft, and multisig.

### Issue #883 — Event-emission consolidation
Normalized event-emission style across newer contracts:
- **airdrop, marketplace**: Replaced symbol_short!() with Symbol::new() for consistency
- **ballot, bonding-curve, wrapped-token**: Inlined topic tuples (removed intermediate let topics bindings)
- **wrapped-token**: Fixed misplaced Symbol import (was at end of file)
- **marketplace**: Used full readable event names instead of abbreviated forms (cancel → cancelled, offracc → offer_accepted, offrcncl → offer_cancelled)

## Files Changed
- contracts/airdrop/src/errors.rs — Added impl_display_error!
- contracts/airdrop/src/events.rs — Normalized to Symbol::new()
- contracts/ballot/src/errors.rs — Added impl_display_error!
- contracts/ballot/src/events.rs — Inlined topic tuples
- contracts/bonding-curve/src/errors.rs — Added impl_display_error!
- contracts/bonding-curve/src/events.rs — Inlined topic tuples
- contracts/lottery/src/errors.rs — Added impl_display_error!
- contracts/marketplace/src/errors.rs — Added impl_display_error!
- contracts/marketplace/src/events.rs — Normalized to Symbol::new(), full names
- contracts/oracle/src/errors.rs — Added impl_display_error!
- contracts/staking/src/errors.rs — Added impl_display_error!
- contracts/subscription/src/errors.rs — Added impl_display_error!
- contracts/vesting/src/errors.rs — Added impl_display_error!
- contracts/wrapped-token/src/errors.rs — Added impl_display_error!
- contracts/wrapped-token/src/events.rs — Inlined topics, fixed import

Closes #882
Closes #883