### PR TITLE
docs: fix escrow example scripts and contract-api drift (#986 #987 #988)

### DIFF
--- a/docs/contract-api.md
+++ b/docs/contract-api.md
@@ -40,17 +40,30 @@ Complete public API documentation for all Soroban starter kit contracts.
 
 | Function | Parameters | Returns | Errors |
 |----------|-----------|---------|--------|
-| `initialize` | `env: Env, buyer: Address, seller: Address, arbiter: Address, token_contract: Address, amount: i128, deadline_ledger: u32` | `Result<(), EscrowError>` | `AlreadyInitialized`, `InvalidAmount`, `InvalidParties` |
-| `initialize_with_arbiters` | `env: Env, buyer: Address, seller: Address, arbiters: Vec<Address>, token_contract: Address, amount: i128, deadline_ledger: u32, required_signatures: u32` | `Result<(), EscrowError>` | Same + validation |
+| `initialize` | `env: Env, admin: Address, buyer: Address, seller: Address, arbiter: Address, token_contract: Address, amount: i128, deadline_ledger: u32, dispute_timeout_ledgers: u32, metadata_hash: Option<BytesN<32>>` | `Result<(), EscrowError>` | `AlreadyInitialized`, `InvalidAmount`, `InvalidParties` |
+| `initialize_with_arbiters` | `env: Env, admin: Address, buyer: Address, seller: Address, arbiters: Vec<Address>, token_contract: Address, amount: i128, deadline_ledger: u32, required_signatures: u32, dispute_timeout_ledgers: u32, metadata_hash: Option<BytesN<32>>` | `Result<(), EscrowError>` | Same + validation |
+| `initialize_with_milestones` | `env: Env, admin: Address, buyer: Address, seller: Address, arbiter: Address, token_contract: Address, milestones: Vec<Milestone>, deadline_ledger: u32, dispute_timeout_ledgers: u32, metadata_hash: Option<BytesN<32>>` | `Result<(), EscrowError>` | Same + validation |
+| `update_amount` | `env: Env, new_amount: i128` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState`, `InvalidAmount` |
 | `fund` | `env: Env` | `Result<(), EscrowError>` | `InvalidState`, `InsufficientFunds` |
 | `mark_delivered` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
 | `approve_delivery` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
 | `release_partial` | `env: Env, amount: i128` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState`, `InvalidAmount` |
+| `release_milestone` | `env: Env, caller: Address, milestone_index: u32` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` — `caller` must be the buyer or arbiter |
 | `request_refund` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `request_partial_refund` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
 | `raise_dispute` | `env: Env, caller: Address` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
-| `resolve_dispute` | `env: Env, release_to_seller: bool` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `resolve_dispute` | `env: Env, caller: Address, release_to_seller: bool` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `claim_dispute_timeout` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
 | `cancel` | `env: Env` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
 | `extend_deadline` | `env: Env, new_deadline: u32` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidState` |
+| `bump` | `env: Env` | `Result<(), EscrowError>` | `NotInitialized` — refreshes storage TTL |
+| `set_fee_config` | `env: Env, fee_bps: u32, treasury: Address` | `Result<(), EscrowError>` | `NotAuthorized`, `InvalidAmount` — must be called by the buyer |
+| `pause` †| `env: Env` | `Result<(), EscrowError>` | `NotAuthorized` |
+| `unpause` †| `env: Env` | `Result<(), EscrowError>` | `NotAuthorized` |
+| `propose_upgrade` †| `env: Env, wasm_hash: BytesN<32>` | `Result<(), EscrowError>` | `NotAuthorized` |
+| `execute_upgrade` †| `env: Env` | `Result<(), EscrowError>` | `NotAuthorized` |
+
+† Only compiled when the contract's `pausable` Cargo feature is enabled.
 
 ### Query Functions
 
@@ -60,6 +73,10 @@ Complete public API documentation for all Soroban starter kit contracts.
 | `get_state` | `env: Env` | `Option<EscrowState>` | None |
 | `is_deadline_passed` | `env: Env` | `bool` | None |
 | `get_remaining_ledgers` | `env: Env` | `i64` | None |
+| `get_fee_config` | `env: Env` | `(u32, Option<Address>)` | None — `(fee_bps, treasury)`, or `(0, None)` if unconfigured |
+| `get_milestones` | `env: Env` | `Vec<Milestone>` | None — empty for a non-milestone escrow |
+| `contract_version` | `env: Env` | `u32` | None |
+| `version` †| `env: Env` | `String` | None — build/git-hash version string |
 
 **Errors:**
 - `NotAuthorized` (1) — Caller not permitted
@@ -80,24 +97,34 @@ Complete public API documentation for all Soroban starter kit contracts.
 
 | Function | Parameters | Returns | Errors |
 |----------|-----------|---------|--------|
-| `initialize` | `env: Env, admin: Address, stake_token: Address, reward_token: Address` | `Result<(), StakingError>` | `AlreadyInitialized` |
+| `initialize` | `env: Env, admin: Address, stake_token: Address, reward_token: Address, unbonding_period: u32, slash_destination: Address` | `Result<(), StakingError>` | `AlreadyInitialized` |
 | `stake` | `env: Env, staker: Address, amount: i128` | `Result<(), StakingError>` | `NotInitialized`, `InvalidAmount` |
-| `unstake` | `env: Env, staker: Address, amount: i128` | `Result<(), StakingError>` | `NotInitialized`, `InvalidAmount`, `InsufficientStake`, `NoStake` |
+| `unstake` | `env: Env, staker: Address, amount: i128` | `Result<(), StakingError>` | `NotInitialized`, `InvalidAmount`, `InsufficientStake`, `NoStake`, `UnbondRequestPending` |
+| `withdraw` | `env: Env, staker: Address` | `Result<i128, StakingError>` | `NotInitialized`, `NoUnbondRequest`, `UnbondingNotComplete` |
+| `claim_rewards` | `env: Env, staker: Address` | `Result<i128, StakingError>` | `NotInitialized`, `NoRewards` |
 | `add_rewards` | `env: Env, amount: i128` | `Result<(), StakingError>` | `Unauthorized`, `NotInitialized`, `InvalidAmount` |
-| `claim_rewards` | `env: Env, staker: Address` | `Result<(), StakingError>` | `NotInitialized`, `NoRewards` |
-| `total_staked` | `env: Env` | `i128` | None |
-| `total_rewards` | `env: Env` | `i128` | None |
-| `user_stake` | `env: Env, staker: Address` | `i128` | None |
-| `user_rewards` | `env: Env, staker: Address` | `i128` | None |
+| `slash` | `env: Env, staker: Address, amount: i128` | `Result<i128, StakingError>` | `Unauthorized`, `NotInitialized`, `InvalidAmount`, `NoStake` |
+| `set_compounding` | `env: Env, staker: Address, enabled: bool` | `Result<(), StakingError>` | `NotInitialized` |
+| `compound` | `env: Env, staker: Address` | `Result<i128, StakingError>` | `NotInitialized`, `NoRewards`, `CompoundTokenMismatch` |
+| `get_stake` | `env: Env, staker: Address` | `i128` | None |
+| `get_rewards` | `env: Env, staker: Address` | `i128` | None |
+| `get_total_staked` | `env: Env` | `i128` | None |
+| `get_total_rewards` | `env: Env` | `i128` | None |
+| `get_unbond_request` | `env: Env, staker: Address` | `Option<UnbondRequest>` | None |
+| `contract_version` | `env: Env` | `u32` | None |
 
 **Errors:**
 - `AlreadyInitialized` (1) — initialize called twice
 - `NotInitialized` (2) — Operation before initialize
 - `Unauthorized` (3) — Caller not admin
 - `InvalidAmount` (4) — Amount zero or negative
-- `NoStake` (5) — No stake to unstake/claim
+- `NoStake` (5) — No stake to unstake/claim/slash
 - `InsufficientStake` (6) — Unstake amount exceeds stake
 - `NoRewards` (7) — No rewards available
+- `CompoundTokenMismatch` (8) — Stake token and reward token differ
+- `UnbondingNotComplete` (9) — `withdraw` called before the unbonding period elapsed
+- `NoUnbondRequest` (10) — `withdraw` called with no pending unbond request
+- `UnbondRequestPending` (11) — `unstake` called while an unbond request is already pending
 
 ---
 

--- a/examples/shell/run.sh
+++ b/examples/shell/run.sh
@@ -16,26 +16,30 @@ NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:-Standalone Network ; February 2017}"
 
 MINT_AMOUNT=1000000
 ESCROW_AMOUNT=500000
-DEADLINE=$(( $(date +%s) + 3600 ))
+DISPUTE_TIMEOUT_LEDGERS=100
 
 echo "=== Generating keypairs ==="
 stellar keys generate admin   --network "$NETWORK" --overwrite
 stellar keys generate buyer   --network "$NETWORK" --overwrite
 stellar keys generate seller  --network "$NETWORK" --overwrite
+stellar keys generate arbiter --network "$NETWORK" --overwrite
 
 ADMIN_KEY=$(stellar keys address admin)
 BUYER_KEY=$(stellar keys address buyer)
 SELLER_KEY=$(stellar keys address seller)
+ARBITER_KEY=$(stellar keys address arbiter)
 
-echo "Admin:  $ADMIN_KEY"
-echo "Buyer:  $BUYER_KEY"
-echo "Seller: $SELLER_KEY"
+echo "Admin:   $ADMIN_KEY"
+echo "Buyer:   $BUYER_KEY"
+echo "Seller:  $SELLER_KEY"
+echo "Arbiter: $ARBITER_KEY"
 
 echo ""
 echo "=== Funding accounts via friendbot ==="
-curl -sf "http://localhost:8000/friendbot?addr=$ADMIN_KEY"  > /dev/null
-curl -sf "http://localhost:8000/friendbot?addr=$BUYER_KEY"  > /dev/null
-curl -sf "http://localhost:8000/friendbot?addr=$SELLER_KEY" > /dev/null
+curl -sf "http://localhost:8000/friendbot?addr=$ADMIN_KEY"   > /dev/null
+curl -sf "http://localhost:8000/friendbot?addr=$BUYER_KEY"   > /dev/null
+curl -sf "http://localhost:8000/friendbot?addr=$SELLER_KEY"  > /dev/null
+curl -sf "http://localhost:8000/friendbot?addr=$ARBITER_KEY" > /dev/null
 echo "Funded all accounts"
 
 echo ""
@@ -63,7 +67,7 @@ stellar contract invoke --id "$TOKEN_ID" --source admin --network "$NETWORK" \
   --admin "$ADMIN_KEY" \
   --name "DemoToken" \
   --symbol "DEMO" \
-  --decimal 7
+  --decimals 7
 
 echo ""
 echo "=== Minting tokens to buyer ==="
@@ -74,14 +78,29 @@ stellar contract invoke --id "$TOKEN_ID" --source admin --network "$NETWORK" \
 echo "Minted $MINT_AMOUNT DEMO to buyer"
 
 echo ""
+echo "=== Computing escrow deadline ==="
+# The contract measures deadlines in ledger sequence numbers, not Unix time.
+# A local standalone network closes a ledger roughly every 5s, so ~720
+# ledgers is roughly one hour out.
+LATEST_LEDGER=$(curl -sf -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getLatestLedger","params":{}}' \
+  | grep -o '"sequence":[0-9]*' | head -1 | cut -d: -f2)
+DEADLINE_LEDGER=$(( LATEST_LEDGER + 720 ))
+echo "Latest ledger: $LATEST_LEDGER, deadline ledger: $DEADLINE_LEDGER"
+
+echo ""
 echo "=== Creating escrow ==="
 stellar contract invoke --id "$ESCROW_ID" --source buyer --network "$NETWORK" \
-  -- create \
-  --buyer  "$BUYER_KEY" \
-  --seller "$SELLER_KEY" \
-  --token  "$TOKEN_ID" \
+  -- initialize \
+  --admin   "$ADMIN_KEY" \
+  --buyer   "$BUYER_KEY" \
+  --seller  "$SELLER_KEY" \
+  --arbiter "$ARBITER_KEY" \
+  --token_contract "$TOKEN_ID" \
   --amount "$ESCROW_AMOUNT" \
-  --deadline "$DEADLINE"
+  --deadline_ledger "$DEADLINE_LEDGER" \
+  --dispute_timeout_ledgers "$DISPUTE_TIMEOUT_LEDGERS"
 echo "Escrow created"
 
 echo ""
@@ -93,13 +112,13 @@ echo "Escrow funded"
 echo ""
 echo "=== Marking delivery ==="
 stellar contract invoke --id "$ESCROW_ID" --source seller --network "$NETWORK" \
-  -- mark_delivery
+  -- mark_delivered
 echo "Delivery marked"
 
 echo ""
-echo "=== Releasing funds to seller ==="
+echo "=== Approving delivery (releasing funds to seller) ==="
 stellar contract invoke --id "$ESCROW_ID" --source buyer --network "$NETWORK" \
-  -- release
+  -- approve_delivery
 echo "Funds released"
 
 echo ""

--- a/examples/typescript/index.js
+++ b/examples/typescript/index.js
@@ -63,20 +63,28 @@ async function main() {
   const admin = Keypair.random();
   const buyer = Keypair.random();
   const seller = Keypair.random();
+  const arbiter = Keypair.random();
 
   console.log('Admin:', admin.publicKey());
   console.log('Buyer:', buyer.publicKey());
   console.log('Seller:', seller.publicKey());
+  console.log('Arbiter:', arbiter.publicKey());
 
   // Fund accounts via friendbot (local node)
-  for (const kp of [admin, buyer, seller]) {
+  for (const kp of [admin, buyer, seller, arbiter]) {
     await fetch(`http://localhost:8000/friendbot?addr=${kp.publicKey()}`);
     console.log(`Funded ${kp.publicKey().slice(0, 8)}...`);
   }
 
   const MINT_AMOUNT = 1_000_000n;
   const ESCROW_AMOUNT = 500_000n;
-  const DEADLINE = BigInt(Math.floor(Date.now() / 1000) + 3600);
+
+  // The contract measures deadlines in ledger sequence numbers, not Unix
+  // time. A local standalone network closes a ledger roughly every 5s, so
+  // ~720 ledgers is roughly one hour out.
+  const latestLedger = await server.getLatestLedger();
+  const DEADLINE_LEDGER = latestLedger.sequence + 720;
+  const DISPUTE_TIMEOUT_LEDGERS = 100;
 
   console.log('\n--- Minting tokens to buyer ---');
   await invokeContract(admin, TOKEN_CONTRACT_ID, 'mint', [
@@ -86,12 +94,16 @@ async function main() {
   console.log(`Minted ${MINT_AMOUNT} tokens to buyer`);
 
   console.log('\n--- Creating escrow ---');
-  await invokeContract(buyer, ESCROW_CONTRACT_ID, 'create', [
+  await invokeContract(buyer, ESCROW_CONTRACT_ID, 'initialize', [
+    new Address(admin.publicKey()).toScVal(),
     new Address(buyer.publicKey()).toScVal(),
     new Address(seller.publicKey()).toScVal(),
+    new Address(arbiter.publicKey()).toScVal(),
     new Address(TOKEN_CONTRACT_ID).toScVal(),
     nativeToScVal(ESCROW_AMOUNT, { type: 'i128' }),
-    nativeToScVal(DEADLINE, { type: 'u64' }),
+    nativeToScVal(DEADLINE_LEDGER, { type: 'u32' }),
+    nativeToScVal(DISPUTE_TIMEOUT_LEDGERS, { type: 'u32' }),
+    xdr.ScVal.scvVoid(), // metadata_hash: None
   ]);
   console.log('Escrow created');
 
@@ -100,11 +112,11 @@ async function main() {
   console.log('Escrow funded');
 
   console.log('\n--- Marking delivery ---');
-  await invokeContract(seller, ESCROW_CONTRACT_ID, 'mark_delivery', []);
+  await invokeContract(seller, ESCROW_CONTRACT_ID, 'mark_delivered', []);
   console.log('Delivery marked');
 
-  console.log('\n--- Releasing funds to seller ---');
-  await invokeContract(buyer, ESCROW_CONTRACT_ID, 'release', []);
+  console.log('\n--- Approving delivery (releasing funds to seller) ---');
+  await invokeContract(buyer, ESCROW_CONTRACT_ID, 'approve_delivery', []);
   console.log('Funds released to seller');
 
   console.log('\nFull escrow lifecycle complete.');


### PR DESCRIPTION
- examples: replace non-existent create/mark_delivery/release calls with the real initialize/mark_delivered/approve_delivery methods, pass all required initialize args, compute deadlines as ledger sequence offsets instead of Unix timestamps, and fix --decimal to --decimals.
- docs/contract-api.md: correct Escrow initialize/resolve_dispute parameters and document all real entry points (including the pausable-feature-gated ones); correct Staking initialize params, fix get_-prefixed query names, and document withdraw/slash/compounding functions and their errors.

docs/upgrade-compatibility-matrix.md (#985) already matches contracts/*/src/storage.rs on main (verified nft, ballot, wrapped-token, and subscription rows) — no changes needed.



## Summary

Describe the changes in this PR — what problem does it solve and how?

## Related Issue(s)

Closes #985 

<!-- Add more lines if this PR addresses multiple issues:
Closes #986 
closes #987

Closes #988 
-->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / chore
- [ ] Other

## Test Plan

Describe how you tested these changes. Check all that apply:

- [ ] Built contracts locally (`cargo build --target wasm32-unknown-unknown`)
- [ ] Ran unit tests (`cargo test`)
- [ ] Ran integration / smoke tests (`./scripts/smoke-test.sh`)
- [ ] Ran linter and formatter (`./scripts/clippy-all.sh` / `cargo fmt`)
- [ ] Tested in devcontainer / Codespace
- [ ] No automated tests applicable — reason: <!-- explain -->

## Checklist

- [ ] My branch is up to date with `main`
- [ ] I have reviewed my own diff
- [ ] I have added or updated documentation where needed
- [ ] My changes do not introduce new compiler warnings or clippy lints
- [ ] Any new scripts are executable (`chmod +x`) and have a usage comment
