### PR TITLE
fix(ci): add workflow_dispatch trigger and replace nonexistent create…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, develop]
   schedule:
     - cron: '0 0 * * 0' # Runs every Sunday at midnight; drives the `nightly` job only.
+  workflow_dispatch:
 
 jobs:
   fmt:
@@ -660,13 +661,17 @@ jobs:
         run: cargo test --workspace --all-targets
       - name: Report failure
         if: ${{ failure() }}
-        uses: actions/create-issue@v2
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          title: "Nightly build failed"
-          body: "The nightly build failed. Please investigate."
-          labels: "bug"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Nightly build failed',
+              body: `The nightly build failed. Please investigate: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              labels: ['bug'],
+            });
 
   soroban-sdk-next:
     name: Soroban SDK Next Version Compatibility


### PR DESCRIPTION
Body:
▎ Both #1005 and #1006 turned out to be mostly already fixed on main (schedule trigger is correctly at the workflow level; nightly's actions are already SHA-pinned). Two gaps remained:
▎
▎ - workflow_dispatch: was missing from the top-level on: block, so there was no way to manually trigger the nightly job from the Actions tab (per #1005's acceptance criteria).
▎ - The failure-reporting step used actions/create-issue@v2, which isn't a real published action and would fail as soon as nightly actually ran. Replaced it with actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1 (SHA verified against the upstream v7.0.1 tag) calling github.rest.issues.create directly.
▎
▎ Closes #1005
▎ Closes #1006