### PR TITLE
docs: fix threat model, ADR-0004, ADR-0005 per issues #1015 #1016 #10…

### DIFF
--- a/docs/adr/0004-escrow-state-machine.md
+++ b/docs/adr/0004-escrow-state-machine.md
@@ -14,12 +14,23 @@ An escrow contract must enforce a strict lifecycle so that funds can never be do
 ```
 Created ──fund()──► Funded ──mark_delivered()──► Delivered
    │                  │                              │
-cancel()        request_refund()             approve_delivery()
-   │            (after deadline)             resolve_dispute()
-   ▼                  │                              │
-Cancelled         Refunded ◄──resolve_dispute()──────┤
-                                                      │
-                                               Completed
+cancel()        raise_dispute()             raise_dispute()
+   │                  │                              │
+   ▼                  └──────────────┬───────────────┘
+Cancelled                            ▼
+                                Disputed
+                                   │
+                 resolve_dispute() (arbiter / multisig-arbiter, ADR-0008)
+                 claim_dispute_timeout() (buyer, if timeout configured)
+                      │                        │
+                      ▼                        ▼
+                  Completed               Refunded
+               (release to seller)     (return to buyer)
+
+Also reachable without entering Disputed:
+
+  Funded/Delivered ──request_refund() (after deadline)──► Refunded
+  Delivered ──approve_delivery()──► Completed
 ```
 
 | State | Meaning |
@@ -27,6 +38,7 @@ Cancelled         Refunded ◄──resolve_dispute()──────┤
 | `Created` | Escrow initialised; no funds held yet |
 | `Funded` | Buyer has transferred tokens to the contract |
 | `Delivered` | Seller has marked goods/services as delivered |
+| `Disputed` | Either party has raised a dispute via `raise_dispute()`; contract awaits arbiter resolution |
 | `Completed` | Funds released to seller — terminal |
 | `Refunded` | Funds returned to buyer — terminal |
 | `Cancelled` | Buyer cancelled before funding — terminal |
@@ -60,13 +72,19 @@ The `deadline_ledger` is a Soroban ledger sequence number set at initialisation.
 
 `release_partial(amount)` allows the buyer to release a portion of funds to the seller while the escrow remains in `Funded` or `Delivered` state. The stored `Amount` is decremented; the state does not change. This enables milestone-based payments without requiring a new escrow deployment.
 
-### Arbiter
+### Dispute flow
 
-The arbiter can call `resolve_dispute` in `Funded` or `Delivered` states to either complete or refund the escrow. The arbiter has no power in `Created`, `Completed`, `Refunded`, or `Cancelled` states.
+Dispute resolution is a **two-step** transition, not a direct edge from `Funded`/`Delivered` to a terminal state:
+
+1. **Enter `Disputed`**: Either party (buyer or seller) calls `raise_dispute()` from `Funded` or `Delivered`. This records the dispute timestamp and transitions to `Disputed`.
+2. **Exit `Disputed`**: The arbiter (or a quorum of multisig arbiters, see ADR-0008) calls `resolve_dispute(release_to_seller: bool)`. If `true`, the state transitions through `Delivered` to `Completed`; if `false`, it transitions through `Funded` to `Refunded`. Alternatively, if a `DisputeTimeoutLedgers` was configured and the timeout has elapsed, the buyer may call `claim_dispute_timeout()` to auto-resolve in their favour.
+
+The arbiter has no power in `Created`, `Completed`, `Refunded`, or `Cancelled` states — only in `Disputed`. Both the single-arbiter path and the multisig-arbiter path (ADR-0008) share this same `Disputed` state as their common entry point.
 
 ## Consequences
 
 - Terminal states (`Completed`, `Refunded`, `Cancelled`) are irreversible; a new contract instance must be deployed for a new escrow.
+- The `Disputed` intermediate state ensures that arbiter resolution is always explicit and traceable on-chain — there is no way for an arbiter to resolve a dispute that was never raised.
 - The CEI pattern makes the contract safe against re-entrant token callbacks.
 - The explicit state enum makes the lifecycle easy to audit and test exhaustively.
 - Partial releases reduce the need for multiple escrow deployments in milestone scenarios.

--- a/docs/adr/0005-feature-flags.md
+++ b/docs/adr/0005-feature-flags.md
@@ -1,6 +1,6 @@
 # ADR-0005: Feature Flag Design
 
-- **Status**: Accepted
+- **Status**: Superseded — runtime `FeatureKey` system was never implemented; compile-time Cargo features are the actual mechanism in use (see Audit note below)
 - **Date**: 2026-06-01
 
 ## Context
@@ -15,6 +15,8 @@ Soroban contracts are immutable once deployed. Upgrading logic requires either a
 Without a deliberate flag strategy, developers either hard-code behaviour (inflexible) or scatter ad-hoc boolean checks across the codebase (unmaintainable).
 
 ## Decision
+
+> ⚠️ **Status note**: The runtime `FeatureKey` / `set_flag` / `require_feature` system described below was designed but never implemented in any contract. The mechanism actually in use across the codebase is **Cargo compile-time features** (`#[cfg(feature = "...")]` blocks declared in each contract's `Cargo.toml`). The two mechanisms are fundamentally different: compile-time features are baked in at build time and are not admin-toggleable post-deployment, and they carry none of the storage / TTL / cleanup considerations discussed here. See the Audit note at the end of this document for full details. If the runtime-toggle system is still desired, it should be implemented in `contracts/common` (matching the pattern of other cross-contract helpers there) and this ADR's status updated to `Accepted` at that point.
 
 ### Flag storage
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,12 @@ Each ADR follows this structure:
 - **Context** — the problem and forces at play
 - **Decision** — what was decided
 - **Consequences** — trade-offs and follow-on implications
+
+## ⚠️ File placement rule
+
+**Only ADR files belong in this directory.** ADR files must:
+
+1. Follow the `NNNN-kebab-title.md` naming convention (e.g. `0011-my-decision.md`).
+2. Contain the `Status` / `Date` / `Context` / `Decision` / `Consequences` structure above.
+
+General reference documentation (dev environment, error codes, event catalogues, deployment guides, etc.) belongs in the parent `docs/` directory, not here. In the past, non-ADR files were accidentally left in this folder after a docs reorganisation and drifted out of sync with the canonical copies in `docs/`. If you are unsure where a document belongs, put it in `docs/` and link to it from here if relevant.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -44,7 +44,7 @@ This document catalogues, per contract, who is trusted, what each trusted role c
 
 | Role | Can do | Cannot do | Compromise blast radius |
 |------|--------|-----------|--------------------------|
-| Admin | `initialize`, `cancel_proposal` (any proposal, any time) | Vote on others' behalf, force a proposal to pass | Governance availability: attacker can veto any proposal indefinitely. The DAO holds no treasury funds itself, so this is a censorship/liveness risk, not a direct fund-theft risk |
+| Admin | `initialize`, `cancel_proposal` (only while the proposal is `Active`, i.e. within its voting window) | Vote on others' behalf, force a proposal to pass; cancel or reverse an already-`Executed` or already-`Cancelled` proposal | Governance availability: attacker can veto any proposal that is still being voted on, but cannot retroactively cancel or reverse a proposal that has already executed. This bounds the blast radius to the active voting window — a censorship/liveness risk, not a direct fund-theft risk |
 | Proposer/Voter | `create_proposal`, `vote` (weight = live token balance) | Vote more than once per proposal | Vote-weight manipulation is possible via flash-loan-style balance changes (see [Known Issues](known-issues.md#dao)), not role-key compromise |
 
 ## Escrow


### PR DESCRIPTION
…17 #1018

Closes #1018: threat-model.md DAO row overstated cancel_proposal blast radius as 'any proposal, any time'. The code gates cancel_proposal on ProposalState::Active, so a compromised admin can only veto proposals still in their voting window — not retroactively cancel or reverse an already-Executed proposal. Updated 'Can do', 'Cannot do', and 'Compromise blast radius' columns accordingly.

Closes #1016: ADR-0004 state diagram and state table omitted the Disputed state entirely. The actual EscrowState enum has seven variants (Created, Funded, Delivered, Disputed, Completed, Refunded, Cancelled). Rewrote the diagram to show the two-step dispute flow:
  Funded/Delivered → raise_dispute() → Disputed → resolve_dispute() →
  Completed or Refunded.
Also updated the 'Arbiter' section to 'Dispute flow' section, added a Consequences bullet, and cross-referenced the multisig-arbiter path from ADR-0008 (both paths share the same Disputed entry point).

Closes #1015: ADR-0005 was marked Status: Accepted but the FeatureKey/set_flag/require_feature runtime-toggle system it describes has never been implemented in any contract. Every contract uses Cargo compile-time features instead. Updated the Status line to 'Superseded' and added a prominent warning box at the top of the Decision section explaining the gap and pointing to the path forward (implement in contracts/common, or keep as unimplemented design doc). The existing Audit note already documented this discrepancy; the Status and Decision heading now match it.

Closes #1017: docs/adr/ already contains only the real ADRs (0001-0010) and README.md — the five orphaned files (dev-environment.md, devcontainer.md, directory-tree.md, error-reference.md, event-catalogue.md) are not present and no repo paths reference them, so no file deletions are needed. Added a File placement rule section to docs/adr/README.md to prevent non-ADR files from landing there again.

