### PR TITLE
fix: correct upgrade-guide, incident-response, and ADR-0003 docs

### DIFF
--- a/docs/adr/0003-admin-model.md
+++ b/docs/adr/0003-admin-model.md
@@ -1,6 +1,6 @@
 # ADR-0003: Admin Model
 
-- **Status**: Accepted
+- **Status**: Accepted (amended 2026-08-29)
 - **Date**: 2024-04-24
 
 ## Context
@@ -33,6 +33,16 @@ The admin address is set once during `initialize` and can be a regular account o
 
 Privileged operations (mint, burn, set_admin) call `admin.require_auth()`, delegating all authentication to the Soroban host.
 
+**Two-step admin transfer (added post-initial ADR):** To prevent permanent admin lockout caused by a typo'd address, the token contract implements a propose / accept protocol in addition to the deprecated single-step `set_admin`:
+
+```rust
+pub fn propose_admin(env: Env, new_admin: Address) -> Result<(), TokenError> { ... }
+pub fn accept_admin(env: Env) -> Result<(), TokenError> { ... }
+pub fn cancel_admin_proposal(env: Env) -> Result<(), TokenError> { ... }
+```
+
+`propose_admin` stores the candidate in `DataKey::PendingAdmin`. The candidate must call `accept_admin` to complete the transfer; until then the current admin retains control and can call `cancel_admin_proposal` to abort. `set_admin` (single-step, no confirmation) is deprecated and retained only for backward compatibility.
+
 ### Escrow contract — role-based parties, no global admin
 
 The escrow has no "admin" in the traditional sense. Instead, three distinct roles are established at initialisation:
@@ -53,5 +63,9 @@ To avoid duplicating admin-read logic, the `soroban-common` crate exposes `get_a
 
 - The token admin is a single address; operators who need multi-party control should deploy a multisig contract as the admin address.
 - The escrow arbiter provides dispute resolution without granting blanket admin power.
-- Admin transfer for the token contract must be implemented explicitly (set_admin function) — there is no implicit ownership transfer.
-- Removing the admin from the token contract (setting it to a burn address) effectively makes the token immutable.
+- Admin transfer for the token contract uses a **two-step propose / accept flow** to guard against permanent lockout from a typo'd address:
+  - `propose_admin(new_admin)` — current admin nominates a successor and stores the pending address.
+  - `accept_admin()` — the nominated address must actively accept, confirming it controls the key.
+  - `cancel_admin_proposal()` — current admin can retract a pending proposal before it is accepted.
+  - The older `set_admin(new_admin)` function (single-step, send-and-done) is **deprecated**; it remains for backward compatibility but should not be used in new integrations. A typo'd address passed to `set_admin` would permanently lock the admin role with no recovery path — the two-step flow was introduced specifically to eliminate this footgun.
+- Removing the admin from the token contract (setting it to a burn address via `set_admin`) effectively makes the token immutable.

--- a/docs/incident-response.md
+++ b/docs/incident-response.md
@@ -19,11 +19,18 @@ stellar contract invoke \
 Verify the paused state:
 
 ```bash
+# Escrow contract — use get_state (returns the full escrow state including paused flag):
 stellar contract invoke \
   --id <CONTRACT_ID> \
   --source-account <ADMIN_KEY> \
   --network <testnet|mainnet> \
   -- get_state
+
+# Token contract — there is currently no dedicated read-only is_paused query.
+# Use stellar contract info to inspect on-chain state, or check your off-chain
+# monitoring (see scripts/monitor-token.sh) for the paused flag.
+# A universal is_paused / get_state function across all contracts is a known gap
+# (tracked separately) — the exact verification command differs per contract.
 ```
 
 > If the contract does not support pausing, proceed immediately to upgrading to a patched WASM (§3).

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -53,12 +53,13 @@ WASM_HASH="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 **Important:** Only call this if your contract includes timelock pause functionality (escrow with `pausable` feature).
 
-Propose the upgrade to activate after timelock delay:
+Propose the upgrade to activate after the timelock delay:
+
+> **Important:** The timelock delay is a **fixed contract constant** (`UPGRADE_DELAY_LEDGERS = 17_280`), not a parameter you supply at call time. `propose_upgrade` only accepts the WASM hash; the delay is always 17,280 ledgers (≈ 24 hours at 5 s/ledger: 17,280 × 5 s = 86,400 s) regardless of any shell variable you set locally.
 
 ```bash
 CONTRACT_ID="CXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 ADMIN_KEY="admin-key"
-TIMELOCK_DELAY_LEDGERS=300  # ~1.5 hours on mainnet (every 5 seconds)
 
 stellar contract invoke \
   --id $CONTRACT_ID \
@@ -67,12 +68,12 @@ stellar contract invoke \
   -- propose_upgrade --wasm_hash $WASM_HASH
 ```
 
-**Response:** Proposal created. Current ledger: `12345`. Execution available at: `12645`.
+**Response:** Proposal created. Current ledger: `12345`. Execution available at: `29625` (12345 + 17280).
 
 Record the target ledger for step 3.
 
 ```bash
-TARGET_LEDGER=12645
+TARGET_LEDGER=29625  # example: 12345 + 17280
 ```
 
 ## Step 3: Wait for Timelock (Optional Key Rotation)
@@ -88,14 +89,16 @@ stellar keys generate new-admin-key
 # Securely back up the secret key
 ```
 
-2. **Export current admin from contract:**
+2. **Export current admin from contract** (token contract only):
+
+> **Note:** This step applies to the **token** contract, which exposes a single `admin` function. The **escrow** contract uses role-based parties (buyer / seller / arbiter) with no single admin address — skip this step for escrow.
 
 ```bash
 CURRENT_ADMIN=$(stellar contract invoke \
   --id $CONTRACT_ID \
   --network testnet \
   --source $ADMIN_KEY \
-  -- get_admin)
+  -- admin)
 ```
 
 3. **Update admin in new code** (if contract includes admin management):
@@ -146,7 +149,7 @@ stellar contract invoke \
   --id $CONTRACT_ID \
   --network testnet \
   --source $ADMIN_KEY \
-  -- get_version
+  -- version
 
 # Should return new version string
 ```
@@ -170,15 +173,10 @@ If the upgrade fails:
 
 ### 1. Immediate Actions (Before Timelock Expires)
 
-Cancel the proposal (if supported):
-
-```bash
-stellar contract invoke \
-  --id $CONTRACT_ID \
-  --network testnet \
-  --source $ADMIN_KEY \
-  -- cancel_upgrade  # If this function exists
-```
+> **Note:** There is currently **no `cancel_upgrade` function** in any contract in this repository. Once `propose_upgrade` is called, the pending proposal cannot be retracted — it will simply become executable after 17,280 ledgers. If you proposed an upgrade by mistake:
+> - Do **not** execute it when the timelock expires.
+> - If you need to prevent execution entirely (e.g., the contract should not be upgraded at all), pausing the contract first and then re-deploying a patched version via a second proposal is the safest path.
+> - As a future improvement, a `cancel_upgrade` function could be added to allow the admin to retract a pending proposal before it becomes executable.
 
 ### 2. Restore Previous WASM
 
@@ -203,18 +201,27 @@ stellar contract invoke \
 
 ### 3. Key Rotation for Revoked Keys
 
-If keys were compromised:
+If keys were compromised, use the two-step admin transfer (token contract):
 
 ```bash
-# 1. Rotate to emergency key (pre-positioned)
+# 1. Propose the emergency key as the new admin (from current, still-accessible key)
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  --source $ADMIN_KEY \
+  -- propose_admin --new_admin $EMERGENCY_KEY
+
+# 2. Accept from the new emergency key
 stellar contract invoke \
   --id $CONTRACT_ID \
   --network testnet \
   --source $EMERGENCY_KEY \
-  -- rotate_admin --new_admin $EMERGENCY_KEY
+  -- accept_admin
 
-# 2. Disable all other keys in your key management system
+# 3. Disable all other keys in your key management system
 ```
+
+> **Note:** The `rotate_admin` function does not exist. The token contract uses a two-step `propose_admin` / `accept_admin` flow to prevent admin lockout from typo'd addresses. The escrow contract has no single admin to rotate — its roles (buyer / seller / arbiter) are fixed at initialization; key compromise on escrow requires deploying a new contract instance.
 
 ## Testing Upgrades (Local)
 
@@ -249,7 +256,7 @@ stellar contract invoke \
 stellar contract invoke \
   --id $CONTRACT_ID \
   --network local \
-  -- get_version
+  -- version
 ```
 
 ## Safety Checklist


### PR DESCRIPTION
Closes #1019
Closes #1020
Closes #1021
Closes #1022

**#1022 — upgrade-guide.md Step 2: misleading TIMELOCK_DELAY_LEDGERS variable and wrong duration math**
- Remove the shell variable TIMELOCK_DELAY_LEDGERS=300 from Step 2; it was never passed to propose_upgrade and implied the delay was caller-configurable.
- Add an explicit note that UPGRADE_DELAY_LEDGERS = 17_280 is a fixed contract constant, not a per-call parameter.
- Fix the example arithmetic: 300 × 5 s = 1,500 s ≈ 25 min, not '~1.5 hours'. Update the example TARGET_LEDGER to reflect the real 17,280-ledger offset.

**#1021 — upgrade-guide.md: four non-existent function names**
- Replace get_version → version (the real function on both token and escrow).
- Replace get_admin → admin (the real token function); add a note that escrow has no single admin and this step does not apply to it.
- Replace rotate_admin with the real propose_admin / accept_admin two-step flow for the token contract; document that escrow has no rotatable admin.
- Remove the cancel_upgrade invocation and document clearly that no such function exists: once propose_upgrade is called the proposal cannot be retracted before the timelock elapses.

**#1019 — incident-response.md: get_state only exists on escrow**
- Annotate the 'Verify the paused state' block: get_state is escrow-only.
- Document that the token contract has no dedicated is_paused query and note the gap (also tracked by the monitor-token.sh issue).

**#1020 — ADR-0003: doesn't mention propose_admin / accept_admin flow**
- Add the two-step propose / accept / cancel_admin_proposal design to the Decision section with code signatures and rationale.
- Update the Consequences section: replace the stale 'set_admin' statement with a description of the two-step flow, set_admin's deprecated status, and the footgun (permanent lockout) it was introduced to prevent.
- Mark the ADR status as 'Accepted (amended 2026-08-29)'.

